### PR TITLE
docs(db): remove redundant rustdoc link targets

### DIFF
--- a/crates/reinhardt-db/src/orm/many_to_many_accessor.rs
+++ b/crates/reinhardt-db/src/orm/many_to_many_accessor.rs
@@ -559,7 +559,7 @@ where
 
 	/// Replace all relationships with a new set.
 	///
-	/// The caller controls atomicity. Pass an [`AtomicTransaction`](super::AtomicTransaction)
+	/// The caller controls atomicity. Pass an [`AtomicTransaction`]
 	/// when clearing and adding must be committed or rolled back together.
 	///
 	/// # Parameters

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -236,7 +236,7 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 	/// Encodes a primary key into its canonical database representation.
 	///
 	/// Macro-generated models route this through the primary-key field's
-	/// [`DatabaseField`](super::DatabaseField) implementation. Manual model
+	/// [`DatabaseField`] implementation. Manual model
 	/// implementations retain the legacy numeric, UUID, or string fallback and
 	/// can override this method for custom primary-key codecs.
 	fn primary_key_database_value(pk: &Self::PrimaryKey) -> Result<DatabaseValue, FieldCodecError> {

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -3011,7 +3011,7 @@ where
 	///
 	/// The returned typestate builder prevents combining `NOWAIT` and
 	/// `SKIP LOCKED`. Locking queries must be evaluated with a caller-owned
-	/// [`TransactionExecutor`](super::connection::TransactionExecutor). CTE-backed
+	/// [`TransactionExecutor`]. CTE-backed
 	/// querysets, derived `FROM` sources, LATERAL joins, raw aggregate projections
 	/// from [`Self::values`], and aggregate annotations are rejected before query
 	/// execution to preserve lock scope.

--- a/crates/reinhardt-db/src/orm/transaction.rs
+++ b/crates/reinhardt-db/src/orm/transaction.rs
@@ -1,8 +1,8 @@
 //! # Transaction SQL and ORM Atomicity
 //!
-//! [`DatabaseConnection`](super::connection::DatabaseConnection) provides the ORM
+//! [`DatabaseConnection`] provides the ORM
 //! transaction capability through
-//! [`DatabaseConnection::atomic`](super::connection::DatabaseConnection::atomic). Its callback
+//! [`DatabaseConnection::atomic`]. Its callback
 //! receives an [`AtomicTransaction`], the only executor that may run ORM work
 //! until the callback returns. A successful outer callback commits; an error
 //! rolls back, and a rollback failure takes precedence over the callback error.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- Docs.rs Build Check failure on Release PR #6112 (`redundant explicit link target`)
- Nightly rustdoc `-D warnings` rejects `[`DatabaseField`](super::DatabaseField)` in `crates/reinhardt-db/src/orm/model.rs`
- Drop equivalent parent-module rustdoc targets that resolve to the same items (`AtomicTransaction`, `DatabaseConnection`, `TransactionExecutor`)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Release PR #6112 (`chore: release` for `0.4.0-alpha.8`) failed CI on `cargo doc --workspace --all-features --no-deps` with `RUSTDOCFLAGS="--cfg docsrs -D warnings"`. Nightly rustdoc reported:

```text
error: redundant explicit link target
 --> crates/reinhardt-db/src/orm/model.rs:239:24
```

The link label already resolves through the parent `orm` module re-export, so the explicit `(super::DatabaseField)` target is redundant (RD-8). Per the Release PR policy, this fix targets `develop/0.4.0` so release-plz can regenerate #6112 instead of editing the generated release branch.

Related to: #6112

## How Was This Tested?

- Pending local `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo doc -p reinhardt-db --all-features --no-deps`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR #6112 Docs.rs Build Check failure (`redundant explicit link target` in `reinhardt-db`)

## Labels to Apply

### Type Label (select one)
- [x] `documentation` - Documentation update

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder

---

**Additional Context:**

Do not push this fix onto `develop-release-plz-*`. After this lands on `develop/0.4.0`, release-plz should regenerate Release PR #6112.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02371-d7b6-7455-b489-a02450301b2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02371-d7b6-7455-b489-a02450301b2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

