### PR TITLE
style(serializers): drop blank line after FieldError rustdoc

### DIFF
--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -107,7 +107,6 @@ fn coerce_json_integer(value: &Value) -> Option<i64> {
 /// assert_eq!(error.original(), &FieldError::TooLong(5));
 /// assert!(error.is(&FieldError::TooLong(5)));
 /// ```
-
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldError {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the blank line between the `FieldError` rustdoc example and the enum so Clippy's `empty_line_after_doc_comments` lint stays clean.

This PR addresses:

- Clippy `-D warnings` failure left on `main` after merging #6098

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Merging #6098 combined JSON field-extraction helpers with the `FieldError` rustdoc example. The resolved file kept a blank line after the doctest fence, which Clippy denies under `-D warnings`.

Related to: #6098

## How Was This Tested?

- `cargo test --package reinhardt-core --all-features --test serializers_integration` (122 passed)
- `cargo test --package reinhardt-rest --all-features --test serializers_integration` (100 passed)
- `cargo test --doc --package reinhardt-core --all-features` (693 passed, 6 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy --package reinhardt-core --package reinhardt-rest --all-features -- -D warnings`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #6098

## Labels to Apply

### Type Label (select one)

- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)

- [x] `api` - REST API, serializers, views
- [x] `forms` - Form handling, validation, rendering
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `admin` - Admin interface, admin panels
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [x] `medium` - Normal priority

**Additional Context:**

- Whitespace-only change: the `FieldError` rustdoc remains attached to the enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0236b-c216-745a-8196-01e18f6605c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0236b-c216-745a-8196-01e18f6605c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

