### PR TITLE
test(macros): isolate server_only Info compile-fail from serde bounds

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/README.md
+++ b/crates/reinhardt-core/macros/tests/ui/README.md
@@ -66,6 +66,12 @@ This ensures the macro produces a helpful error message pointing to the exact pr
 2. For `fail/` tests, run `cargo test` to generate the `.stderr` file automatically
 3. Review and commit both files
 
+`#[model]` compile-fail fixtures must still derive `Serialize`/`Deserialize`
+(as production models do). The derive emits `serialize_model_database_value`,
+which requires those traits. Omitting them adds incidental `E0277` noise that
+hides the error the snapshot is meant to lock, as happened with
+`model/fail/server_only_info.rs`.
+
 ## Reference
 
 - [trybuild documentation](https://docs.rs/trybuild/)

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs
@@ -1,10 +1,12 @@
 use reinhardt_macros::model;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 include!("../support.rs");
 
+// Database serialization still requires serde; derive it so this snapshot
+// only asserts that `server_only` omits SecretInfo.
 #[model(table_name = "secrets", server_only)]
-#[derive(Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Secret {
 	#[field(primary_key = true)]
 	id: i64,

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.stderr
@@ -1,5 +1,5 @@
 error[E0422]: cannot find struct, variant or union type `SecretInfo` in this scope
-  --> tests/ui/model/fail/server_only_info.rs:17:10
+  --> tests/ui/model/fail/server_only_info.rs:19:10
    |
-17 |     let _ = SecretInfo { id: 1 };
+19 |     let _ = SecretInfo { id: 1 };
    |             ^^^^^^^^^^ not found in this scope


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- Release PR #6113 failed `UI Tests / UI Tests (3/5)` because `test_model_macro_parity_fail` expected only the missing `SecretInfo` error from `#[model(server_only)]`
- The Model derive now serializes rows through `serialize_model_database_value`, which requires `serde::Serialize`
- Align the `server_only` compile-fail fixture with the other model UI tests (`Debug`, `Clone`, `Serialize`, `Deserialize`) so trybuild only asserts that `SecretInfo` is absent
- Document the fixture rule in `crates/reinhardt-core/macros/tests/ui/README.md`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #6113 (`chore: release`) failed because `crates/reinhardt-core/macros/tests/ui/model/fail/server_only_info.rs` did not derive serde. The generated `serialize_database_value` path then emitted `E0277` (`Secret: serde::Serialize` is not satisfied) in addition to the intended `E0422` (`SecretInfo` not found), so trybuild rejected the snapshot.

`server_only` still skips `{Model}Info` generation. Database serialization remains required, so the fail fixture must derive serde like production models and the model UI pass tests.

Related to: #6113

## How Was This Tested?

- [x] `cargo test -p reinhardt-macros --test ui test_model_macro_parity_fail -- --exact` passed locally
- [x] `cargo fmt -p reinhardt-macros -- --check` passed for the updated fixture
- [ ] `cargo make clippy-check` (not applicable: trybuild fixture and markdown only)

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Release PR: #6113
- The `Serialize` derive itself already landed on `main` via #6097 / #6098; this PR isolates the snapshot from incidental trait-bound noise and documents the fixture rule so release-plz can pick up a focused test lock.

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Scope Label (select all that apply)
- [x] `orm` - ORM layer, models, query builder

---

**Additional Context:**

Per `instructions/RELEASE_PROCESS.md`, this targets `main` rather than the `release-plz-*` branch. After merge, release-plz regenerates Release PR #6113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02371-6754-7ce4-96e4-d1e4c6484068?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02371-6754-7ce4-96e4-d1e4c6484068&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

