### PR TITLE
fix: resolve merged review findings from pr 6140

### DIFF
--- a/crates/reinhardt-core/src/serializers/fields.rs
+++ b/crates/reinhardt-core/src/serializers/fields.rs
@@ -216,7 +216,7 @@ impl FieldErrorMessages {
 		}
 	}
 
-	fn apply<T>(&self, result: Result<T, FieldError>) -> Result<T, FieldError> {
+	pub(crate) fn apply<T>(&self, result: Result<T, FieldError>) -> Result<T, FieldError> {
 		result.map_err(|error| match &self.formatter {
 			Some(formatter) => match formatter(&error) {
 				Some(message) => FieldError::WithMessage {

--- a/crates/reinhardt-core/src/serializers/validator.rs
+++ b/crates/reinhardt-core/src/serializers/validator.rs
@@ -182,6 +182,11 @@ pub trait FieldValidator {
 	fn is_required(&self) -> bool {
 		false
 	}
+
+	/// Message used when a required JSON key is missing.
+	fn required_error_message(&self) -> String {
+		FieldError::Required.to_string()
+	}
 }
 
 macro_rules! impl_typed_field_validator {
@@ -197,6 +202,13 @@ macro_rules! impl_typed_field_validator {
 				fn is_required(&self) -> bool {
 					self.required
 				}
+
+				fn required_error_message(&self) -> String {
+					self.error_messages
+						.apply::<()>(Err(FieldError::Required))
+						.expect_err("required errors cannot validate")
+						.to_string()
+				}
 			}
 		)+
 	};
@@ -206,13 +218,24 @@ impl_typed_field_validator!(
 	CharField,
 	IntegerField,
 	FloatField,
-	BooleanField,
 	EmailField,
 	URLField,
 	ChoiceField,
 	DateField,
 	DateTimeField,
 );
+
+impl FieldValidator for BooleanField {
+	fn validate(&self, value: &Value) -> ValidationResult {
+		self.to_internal_value(Some(value))
+			.map(|_| ())
+			.map_err(|error| ValidationError::object_error(error.to_string()))
+	}
+
+	fn is_required(&self) -> bool {
+		self.required
+	}
+}
 
 /// Trait for object-level validators
 ///
@@ -332,7 +355,7 @@ pub fn validate_fields(
 			None if validator.is_required() => {
 				errors.push(ValidationError::field_error(
 					field_name,
-					FieldError::Required.to_string(),
+					validator.required_error_message(),
 				));
 			}
 			None => {}
@@ -544,5 +567,23 @@ mod tests {
 		// Missing custom validators are not required (pass through)
 		let result = validate_fields(&data, &validators);
 		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn missing_required_builtin_field_uses_custom_error_message() {
+		let mut validators: HashMap<String, Box<dyn FieldValidator>> = HashMap::new();
+		validators.insert(
+			"username".to_owned(),
+			Box::new(CharField::new().error_messages(|error| {
+				error
+					.is(&FieldError::Required)
+					.then(|| "username is required".to_owned())
+			})),
+		);
+
+		let error = validate_fields(&HashMap::new(), &validators)
+			.expect_err("missing required fields must fail validation");
+
+		assert_eq!(error.field_errors()["username"], ["username is required"]);
 	}
 }

--- a/crates/reinhardt-core/tests/serializers_integration.rs
+++ b/crates/reinhardt-core/tests/serializers_integration.rs
@@ -186,7 +186,6 @@ fn char_field_with_error_messages_stays_char_field() {
 	// Assert
 	assert_eq!(serializer.username.max_length, Some(5));
 	assert!(serializer.username.required);
-	assert!(format!("{:?}", serializer.username).contains("CharField"));
 	assert_eq!(error.to_string(), "too long");
 }
 

--- a/crates/reinhardt-db/src/orm/query.rs
+++ b/crates/reinhardt-db/src/orm/query.rs
@@ -602,12 +602,21 @@ impl Filter {
 		}
 	}
 
-	/// Returns the model field that produced this filter, when it is known.
+	/// Returns the root model field that produced this filter, when it is known.
+	/// Related-model and expression-backed filters return `None`.
 	pub fn source_field_name(&self) -> Option<&str> {
+		if self.relation.is_some() {
+			return None;
+		}
 		match &self.field_source {
 			FilterField::Column(source_field) => Some(source_field),
 			FilterField::Expression(_) | FilterField::TypedPredicate(_) => None,
 		}
+	}
+
+	/// Returns whether this filter targets a field through a relation path.
+	pub fn is_related(&self) -> bool {
+		self.relation.is_some()
 	}
 
 	/// Returns the SQL expression used on the left side of this filter.
@@ -1566,11 +1575,47 @@ fn collect_subquery_outer_condition(condition: &FilterCondition, fields: &mut Ve
 	}
 }
 
+fn map_subquery_outer_fields<F>(value: &mut FilterValue, mapper: &mut F)
+where
+	F: FnMut(&mut String),
+{
+	match value {
+		FilterValue::FieldRef(field) if field.field.contains('.') => mapper(&mut field.field),
+		FilterValue::OuterRef(field) => mapper(&mut field.field),
+		FilterValue::List(values) => {
+			for value in values {
+				map_subquery_outer_fields(value, mapper);
+			}
+		}
+		FilterValue::Range(start, end) => {
+			map_subquery_outer_fields(start, mapper);
+			map_subquery_outer_fields(end, mapper);
+		}
+		_ => {}
+	}
+}
+
+fn map_subquery_outer_condition<F>(condition: &mut FilterCondition, mapper: &mut F)
+where
+	F: FnMut(&mut String),
+{
+	match condition {
+		FilterCondition::Single(filter) => map_subquery_outer_fields(&mut filter.value, mapper),
+		FilterCondition::And(conditions) | FilterCondition::Or(conditions) => {
+			for condition in conditions {
+				map_subquery_outer_condition(condition, mapper);
+			}
+		}
+		FilterCondition::Not(condition) => map_subquery_outer_condition(condition, mapper),
+	}
+}
+
 #[derive(Clone, Debug)]
 struct SubquerySql {
 	postgres: String,
 	mysql: String,
 	sqlite: String,
+	outer_references: Vec<(String, String)>,
 }
 
 #[derive(Clone)]
@@ -1591,12 +1636,13 @@ impl SubqueryStatements {
 }
 
 impl SubquerySql {
-	fn for_backend(&self, backend: crate::backends::types::DatabaseType) -> &str {
-		match backend {
+	fn for_backend(&self, backend: crate::backends::types::DatabaseType) -> String {
+		let template = match backend {
 			crate::backends::types::DatabaseType::Postgres => &self.postgres,
 			crate::backends::types::DatabaseType::Mysql => &self.mysql,
 			crate::backends::types::DatabaseType::Sqlite => &self.sqlite,
-		}
+		};
+		rewrite_subquery_fields(template, &self.outer_references)
 	}
 
 	fn add_lock(&mut self) {
@@ -1614,9 +1660,11 @@ impl SubquerySql {
 	}
 
 	fn rewrite_fields(&mut self, rewrites: &[(String, String)]) {
-		self.postgres = rewrite_subquery_fields(&self.postgres, rewrites);
-		self.mysql = rewrite_subquery_fields(&self.mysql, rewrites);
-		self.sqlite = rewrite_subquery_fields(&self.sqlite, rewrites);
+		for (_, field) in &mut self.outer_references {
+			if let Some((_, replacement)) = rewrites.iter().find(|(source, _)| source == field) {
+				*field = replacement.clone();
+			}
+		}
 	}
 }
 
@@ -3349,6 +3397,18 @@ where
 		fields
 	}
 
+	fn map_outer_reference_fields<F>(&mut self, mut mapper: F)
+	where
+		F: FnMut(&mut String),
+	{
+		for filter in &mut self.filters {
+			map_subquery_outer_fields(&mut filter.value, &mut mapper);
+		}
+		for condition in &mut self.filter_conditions {
+			map_subquery_outer_condition(condition, &mut mapper);
+		}
+	}
+
 	/// Returns whether this queryset contains an authorization subquery.
 	pub fn has_subquery_conditions(&self) -> bool {
 		!self.subquery_conditions.is_empty()
@@ -4802,7 +4862,7 @@ where
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let outer_fields = subquery_qs.outer_reference_fields();
-		let subquery_sql = subquery_qs.as_subquery_sql()?;
+		let subquery_sql = subquery_qs.as_correlated_subquery_sql(&outer_fields)?;
 
 		self.subquery_conditions.push(SubqueryCondition::Exists {
 			subquery: subquery_sql,
@@ -4878,7 +4938,7 @@ where
 		let subquery_qs = subquery_fn(QuerySet::<R>::new());
 		let lockable = subquery_qs.supports_scope_subquery_row_lock();
 		let outer_fields = subquery_qs.outer_reference_fields();
-		let subquery_sql = subquery_qs.as_subquery_sql()?;
+		let subquery_sql = subquery_qs.as_correlated_subquery_sql(&outer_fields)?;
 
 		self.subquery_conditions.push(SubqueryCondition::NotExists {
 			subquery: subquery_sql,
@@ -10568,16 +10628,15 @@ where
 	///
 	/// Scope predicates, ordering, limits, and offsets remain intact. Projection,
 	/// annotations, and eager-loading options are discarded because the session
-	/// list path decodes only the root model from each row.
+	/// list path decodes only the root model from each row. Grouping, typed
+	/// annotations, and HAVING predicates remain so incompatible manager
+	/// querysets fail closed instead of broadening their result set.
 	pub fn for_model_session(mut self) -> Self {
 		self.selected_fields = None;
 		self.selected_expressions.clear();
 		self.deferred_fields.clear();
 		self.annotations.clear();
 		self.backend_annotations.clear();
-		self.typed_annotations.clear();
-		self.typed_havings.clear();
-		self.group_by_fields.clear();
 		self.select_related_fields.clear();
 		self.typed_select_related.clear();
 		self.prefetch_related_fields.clear();
@@ -10701,7 +10760,39 @@ where
 				"({})",
 				self.to_sql_for_backend(crate::backends::types::DatabaseType::Sqlite)?
 			),
+			outer_references: Vec::new(),
 		})
+	}
+
+	fn as_correlated_subquery_sql(
+		&self,
+		outer_fields: &[String],
+	) -> reinhardt_core::exception::Result<SubquerySql> {
+		let placeholders = outer_fields
+			.iter()
+			.enumerate()
+			.map(|(index, field)| {
+				(
+					field.clone(),
+					format!("\u{1}reinhardt_outer_reference_{index}\u{1}"),
+				)
+			})
+			.collect::<Vec<_>>();
+		let mut template = self.clone();
+		template.map_outer_reference_fields(|field| {
+			if let Some((_, placeholder)) = placeholders
+				.iter()
+				.find(|(outer_field, _)| outer_field == field)
+			{
+				*field = placeholder.clone();
+			}
+		});
+		let mut subquery = template.as_subquery_sql()?;
+		subquery.outer_references = placeholders
+			.into_iter()
+			.map(|(field, placeholder)| (placeholder, field))
+			.collect();
+		Ok(subquery)
 	}
 
 	/// Defer loading of specific fields
@@ -15278,6 +15369,50 @@ mod tests {
 		assert!(sql.contains(r#""test_users"."id" NOT IN (SELECT "id" FROM "test_projects")"#));
 	}
 
+	#[test]
+	fn map_subquery_fields_rewrites_only_outer_references() {
+		use crate::orm::expressions::OuterRef;
+
+		let mut queryset = QuerySet::<TestUser>::new()
+			.filter_exists(|queryset: QuerySet<TestUser>| {
+				queryset
+					.filter(Filter::new(
+						"id",
+						FilterOperator::Eq,
+						FilterValue::Integer(7),
+					))
+					.filter(Filter::new(
+						"author_id",
+						FilterOperator::Eq,
+						FilterValue::OuterRef(OuterRef::new("id")),
+					))
+			})
+			.expect("EXISTS subquery should compile");
+
+		queryset.map_subquery_fields(|field| {
+			if field == "id" {
+				*field = "account_id".to_owned();
+			}
+		});
+
+		assert_eq!(
+			queryset.to_sql().expect("query SQL should compile"),
+			r#"SELECT * FROM "test_users" WHERE EXISTS (SELECT * FROM "test_users" WHERE ("id" = 7 AND "author_id" = "account_id"))"#
+		);
+	}
+
+	#[test]
+	fn related_filter_reports_relation_source() {
+		let filter =
+			crate::orm::relations::RelationPath::<TestUser, TestCorpusFile>::from_descriptor::<
+				TestUserCorpusFile,
+			>()
+			.field(TestCorpusFile::field_normalized_path())
+			.eq("/docs/index.md");
+
+		assert_eq!(filter.filter.source_field_name(), None);
+	}
+
 	#[rstest]
 	fn lock_scope_subqueries_locks_every_authorization_subquery() {
 		let mut queryset = QuerySet::<TestUser>::new()
@@ -15772,6 +15907,28 @@ mod tests {
 		assert_eq!(
 			error.to_string(),
 			"Database error: date and datetime projections are not supported on grouped querysets"
+		);
+	}
+
+	#[test]
+	fn for_model_session_rejects_manager_having_predicates() {
+		let queryset = QuerySet::<TestUser>::new()
+			.annotate(
+				crate::orm::func::count_all::<TestUser>()
+					.label("row_count")
+					.expect("annotation label should be valid"),
+			)
+			.expect("annotation should compile")
+			.having(crate::orm::func::count_all::<TestUser>().gt(1_i64));
+
+		let error = queryset
+			.for_model_session()
+			.build_full_model_select_statement()
+			.expect_err("manager HAVING predicates must not be discarded");
+
+		assert_eq!(
+			error.to_string(),
+			"Database error: Session::list requires a model-shaped QuerySet"
 		);
 	}
 

--- a/crates/reinhardt-utils/src/staticfiles/storage/azure.rs
+++ b/crates/reinhardt-utils/src/staticfiles/storage/azure.rs
@@ -367,6 +367,10 @@ impl AzureBlobStorage {
 			))
 		}
 	}
+
+	fn delete_status_is_success(status: StatusCode) -> bool {
+		status.is_success() || status == StatusCode::NOT_FOUND
+	}
 }
 
 #[async_trait]
@@ -423,7 +427,7 @@ impl Storage for AzureBlobStorage {
 			.send(Method::DELETE, self.blob_url(&blob_name), None, None, false)
 			.await?;
 		let status = response.status();
-		if !status.is_success() {
+		if !Self::delete_status_is_success(status) {
 			return Err(Self::map_status(status, &blob_name));
 		}
 		Ok(())
@@ -455,6 +459,13 @@ mod tests {
 			config.base_url,
 			"https://teststorage.blob.core.windows.net/testcontainer"
 		);
+	}
+
+	#[test]
+	fn delete_accepts_missing_blob_status() {
+		assert!(AzureBlobStorage::delete_status_is_success(
+			StatusCode::NOT_FOUND
+		));
 	}
 
 	#[test]

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -653,6 +653,9 @@ fn assigned_primary_key_filter<T: Model>(item: &T) -> Option<FilterCondition> {
 	let primary_key_value = serialized
 		.get(T::primary_key_field())
 		.or_else(|| serialized.get(&column))?;
+	if primary_key_value.is_null() {
+		return None;
+	}
 	let filter = primary_key_filter_for_model::<T>(primary_key_value).ok()?;
 	let FilterCondition::Single(mut filter) = filter else {
 		return None;
@@ -1960,6 +1963,42 @@ mod tests {
 		name: String,
 	}
 
+	#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+	struct StringKeyItem {
+		id: Option<String>,
+	}
+
+	#[derive(Clone)]
+	struct StringKeyItemFields;
+
+	impl reinhardt_db::orm::FieldSelector for StringKeyItemFields {
+		fn with_alias(self, _alias: &str) -> Self {
+			self
+		}
+	}
+
+	impl reinhardt_db::orm::Model for StringKeyItem {
+		type PrimaryKey = String;
+		type Fields = StringKeyItemFields;
+		type Objects = reinhardt_db::orm::Manager<Self>;
+
+		fn table_name() -> &'static str {
+			"string_key_items"
+		}
+
+		fn primary_key(&self) -> Option<Self::PrimaryKey> {
+			self.id.clone()
+		}
+
+		fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+			self.id = Some(value);
+		}
+
+		fn new_fields() -> Self::Fields {
+			StringKeyItemFields
+		}
+	}
+
 	#[derive(Clone)]
 	struct TestItemFields;
 
@@ -2133,6 +2172,11 @@ mod tests {
 
 		assert_eq!(filter.field, "id");
 		assert!(matches!(filter.value, FilterValue::Integer(42)));
+	}
+
+	#[test]
+	fn assigned_primary_key_filter_skips_null_string_key() {
+		assert!(assigned_primary_key_filter(&StringKeyItem { id: None }).is_none());
 	}
 
 	#[rstest]

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -360,12 +360,14 @@ fn collect_scope_annotation_expression(
 fn collect_scope_filter_condition(condition: &FilterCondition, fields: &mut Vec<String>) {
 	match condition {
 		FilterCondition::Single(filter) => {
-			fields.push(
-				filter
-					.source_field_name()
-					.unwrap_or(&filter.field)
-					.to_owned(),
-			);
+			if !filter.is_related() {
+				fields.push(
+					filter
+						.source_field_name()
+						.unwrap_or(&filter.field)
+						.to_owned(),
+				);
+			}
 			collect_scope_filter_value(&filter.value, fields);
 		}
 		FilterCondition::And(conditions) | FilterCondition::Or(conditions) => {
@@ -1129,12 +1131,14 @@ where
 			.iter()
 			.any(scope_filter_condition_contains_opaque_subquery);
 		for filter in queryset.filters() {
-			field_names.push(
-				filter
-					.source_field_name()
-					.unwrap_or(&filter.field)
-					.to_owned(),
-			);
+			if !filter.is_related() {
+				field_names.push(
+					filter
+						.source_field_name()
+						.unwrap_or(&filter.field)
+						.to_owned(),
+				);
+			}
 			collect_scope_filter_value(&filter.value, &mut field_names);
 		}
 		for condition in queryset.filter_conditions() {


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Preserves custom serializer error messages when required JSON keys are omitted.
- Keeps scoped query constraints fail-closed across related fields, manager HAVING predicates, and correlated outer references.
- Skips create refresh queries for unassigned string primary keys.
- Restores idempotent Azure blob deletion for missing blobs.
- Removes a loose debug-output assertion.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #6140 was merged before its automated review threads were resolved. These follow-up fixes preserve the intended release-line behavior without broadening scoped query results or returning errors after successful creates and deletes.

Related to: #6140

## How Was This Tested?

- cargo test -p reinhardt-core --all-features --lib serializers::validator::tests (14 passed)
- cargo test -p reinhardt-core --all-features --test serializers_integration (122 passed)
- cargo test -p reinhardt-db --all-features --lib orm::query::tests (247 passed)
- cargo test -p reinhardt-views --all-features --lib model_view_set_handler::tests (16 passed)
- cargo test -p reinhardt-utils --all-features --lib staticfiles::storage::azure::tests (14 passed)
- cargo make fmt-check
- cargo make clippy-check

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- PR #6140 automated review follow-up

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The source PR is already merged, so this PR targets develop/0.4.0 with the review fixes.
