### PR TITLE
fix(migrations): order makemigrations by foreign-key dependencies

### DIFF
--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -244,6 +244,11 @@ The `makemigrations` command supports the following flags and options:
 | `-n`, `--name <NAME>` | Name for the migration |
 | `--migrations-dir <DIR>` | Directory for migration files (default: `migrations`) |
 
+Initial migrations record `dependencies` for every external table provider
+referenced by inline foreign keys. Same-app `CreateTable` operations are
+emitted in topological order from that metadata so a fresh PostgreSQL database
+can apply the generated files without hand-editing.
+
 #### The `--force-empty-state` Flag
 
 By default, `makemigrations` builds the current project state by replaying

--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -1468,154 +1468,101 @@ impl BaseCommand for MakeMigrationsCommand {
 			};
 
 			// Check for migration conflicts before proceeding
-			{
-				let all_migrations = service.load_all().await.map_err(|e| {
-					CommandError::ExecutionError(format!(
-						"Failed to load migrations for conflict check: {}",
-						e
-					))
-				})?;
-				if !all_migrations.is_empty() {
-					let graph = build_migration_graph(&all_migrations);
+			let all_migrations = service.load_all().await.map_err(|e| {
+				CommandError::ExecutionError(format!(
+					"Failed to load migrations for conflict check: {}",
+					e
+				))
+			})?;
+			if !all_migrations.is_empty() {
+				let graph = build_migration_graph(&all_migrations);
 
-					let conflicts = graph.detect_conflicts();
-					if !conflicts.is_empty() {
-						let mut conflict_apps: Vec<&String> = conflicts.keys().collect();
-						conflict_apps.sort();
-						for app in &conflict_apps {
-							let leaves = &conflicts[*app];
-							let leaf_names: Vec<&str> =
-								leaves.iter().map(|k| k.name.as_str()).collect();
-							ctx.error(&format!(
-								"Conflicting migrations detected for '{}': {}",
-								app,
-								leaf_names.join(", ")
-							));
-						}
-						return Err(CommandError::ExecutionError(
-							"Run 'makemigrations --merge' to resolve migration conflicts."
-								.to_string(),
+				let conflicts = graph.detect_conflicts();
+				if !conflicts.is_empty() {
+					let mut conflict_apps: Vec<&String> = conflicts.keys().collect();
+					conflict_apps.sort();
+					for app in &conflict_apps {
+						let leaves = &conflicts[*app];
+						let leaf_names: Vec<&str> =
+							leaves.iter().map(|k| k.name.as_str()).collect();
+						ctx.error(&format!(
+							"Conflicting migrations detected for '{}': {}",
+							app,
+							leaf_names.join(", ")
 						));
 					}
+					return Err(CommandError::ExecutionError(
+						"Run 'makemigrations --merge' to resolve migration conflicts.".to_string(),
+					));
 				}
 			}
+			let existing_latest = latest_existing_migration_names(&all_migrations);
 
-			for app_name in &app_names {
-				// Filter target state for this app only
-				let app_target_state = target_project_state.filter_by_app(app_name);
-				eprintln!(
-					"[DEBUG] app_target_state for '{}': {} models",
+			// Autodetect against the full project graph so cross-app foreign
+			// keys remain visible. Per-app filtering hid provider tables and
+			// forced every `0001` migration to `dependencies: vec![]`.
+			let detector = reinhardt_db::migrations::MigrationAutodetector::new(
+				from_state.clone(),
+				target_project_state.clone(),
+			);
+			let generated_migrations = detector.generate_migrations();
+			let apps_to_write = expand_apps_with_fk_providers(
+				&app_names,
+				&generated_migrations,
+				&target_project_state,
+			);
+
+			let mut pending: Vec<(reinhardt_db::migrations::Migration, String, String)> =
+				Vec::new();
+			let mut this_run_names = std::collections::BTreeMap::new();
+			for migration in generated_migrations {
+				if !apps_to_write.contains(&migration.app_label) {
+					continue;
+				}
+				let app_name = migration.app_label.clone();
+				let migration_number = MigrationNumbering::next_number(&migrations_dir, &app_name);
+				let is_initial = migration_number == "0001";
+				let base_name = migration_name_opt.clone().unwrap_or_else(|| {
+					MigrationNamer::generate_name(&migration.operations, is_initial)
+				});
+				let final_name = format!("{}_{}", migration_number, base_name);
+				this_run_names.insert(app_name.clone(), final_name.clone());
+				pending.push((migration, migration_number, final_name));
+			}
+
+			for (migration, migration_number, final_name) in pending {
+				let app_name = migration.app_label.clone();
+				let dependencies = resolve_makemigrations_dependencies(
+					&app_name,
+					&migration_number,
+					&migration.operations,
+					&target_project_state,
+					&this_run_names,
+					&existing_latest,
+				);
+
+				let new_migration = reinhardt_db::migrations::Migration {
+					app_label: app_name.clone(),
+					name: final_name,
+					operations: migration.operations,
+					dependencies,
+					atomic: true,
+					replaces: Vec::new(),
+					initial: if migration_number == "0001" {
+						Some(true)
+					} else {
+						None
+					},
+					state_only: false,
+					database_only: false,
+					optional_dependencies: Vec::new(),
+					swappable_dependencies: Vec::new(),
+				};
+
+				results.push(MigrationResult {
 					app_name,
-					app_target_state.models.len()
-				);
-				for ((app, model_name), model_state) in &app_target_state.models {
-					eprintln!(
-						"[DEBUG]   - {}/{} ({} fields)",
-						app,
-						model_name,
-						model_state.fields.len()
-					);
-				}
-
-				// Filter from_state for this app only
-				let app_from_state = from_state.filter_by_app(app_name);
-				eprintln!(
-					"[DEBUG] app_from_state for '{}': {} models",
-					app_name,
-					app_from_state.models.len()
-				);
-				for ((app, model_name), model_state) in &app_from_state.models {
-					eprintln!(
-						"[DEBUG]   - {}/{} ({} fields)",
-						app,
-						model_name,
-						model_state.fields.len()
-					);
-				}
-
-				// Use MigrationAutodetector for proper ManyToMany support
-				let detector = reinhardt_db::migrations::MigrationAutodetector::new(
-					app_from_state,
-					app_target_state,
-				);
-				let generated_migrations = detector.generate_migrations();
-
-				// Process generated migrations for this app
-				for migration in generated_migrations {
-					if migration.app_label == app_name.as_str() {
-						// Generate migration name
-						let migration_number =
-							MigrationNumbering::next_number(&migrations_dir, app_name);
-						let is_initial = migration_number == "0001";
-						let base_name = migration_name_opt.clone().unwrap_or_else(|| {
-							MigrationNamer::generate_name(&migration.operations, is_initial)
-						});
-						let final_name = format!("{}_{}", migration_number, base_name);
-
-						// Determine dependencies
-						let dependencies = if migration_number == "0001" {
-							Vec::new() // Initial migration has no dependencies
-						} else {
-							// Get previous migration number
-							let prev_number_int = migration_number.parse::<u32>().map_err(|e| {
-								CommandError::ParseError(format!(
-									"invalid migration number '{}': {}",
-									migration_number, e
-								))
-							})? - 1;
-							let prev_number = format!("{:04}", prev_number_int);
-							// Find the previous migration by scanning the directory
-							let prev_migration_name = if let Ok(entries) =
-								std::fs::read_dir(migrations_dir.join(app_name))
-							{
-								let mut prev_names: Vec<String> = entries
-									.filter_map(|entry| {
-										let path = entry.ok()?.path();
-										let filename = path.file_stem()?.to_str()?.to_string();
-										if filename.starts_with(&prev_number) {
-											Some(filename)
-										} else {
-											None
-										}
-									})
-									.collect();
-								prev_names.sort();
-								prev_names.first().cloned()
-							} else {
-								None
-							};
-
-							if let Some(prev_name) = prev_migration_name {
-								vec![(app_name.clone(), prev_name)]
-							} else {
-								Vec::new()
-							}
-						};
-
-						let new_migration = reinhardt_db::migrations::Migration {
-							app_label: app_name.clone(),
-							name: final_name,
-							operations: migration.operations,
-							dependencies,
-							atomic: true,
-							replaces: Vec::new(),
-							initial: if migration_number == "0001" {
-								Some(true)
-							} else {
-								None
-							},
-							state_only: false,
-							database_only: false,
-							optional_dependencies: Vec::new(),
-							swappable_dependencies: Vec::new(),
-						};
-
-						results.push(MigrationResult {
-							app_name: app_name.clone(),
-							migration: new_migration,
-						});
-					}
-				}
+					migration: new_migration,
+				});
 			}
 
 			// 4. Write all migrations
@@ -1686,6 +1633,93 @@ impl BaseCommand for MakeMigrationsCommand {
 			Ok(())
 		}
 	}
+}
+
+#[cfg(feature = "migrations")]
+fn latest_existing_migration_names(
+	migrations: &[reinhardt_db::migrations::Migration],
+) -> std::collections::BTreeMap<String, String> {
+	let mut latest = std::collections::BTreeMap::new();
+	for migration in migrations {
+		latest
+			.entry(migration.app_label.clone())
+			.and_modify(|current: &mut String| {
+				if migration.name.as_str() > current.as_str() {
+					*current = migration.name.clone();
+				}
+			})
+			.or_insert_with(|| migration.name.clone());
+	}
+	latest
+}
+
+#[cfg(feature = "migrations")]
+fn expand_apps_with_fk_providers(
+	requested: &[String],
+	generated: &[reinhardt_db::migrations::Migration],
+	to_state: &reinhardt_db::migrations::autodetector::ProjectState,
+) -> std::collections::BTreeSet<String> {
+	use std::collections::BTreeSet;
+
+	let generated_apps: BTreeSet<String> = generated.iter().map(|m| m.app_label.clone()).collect();
+	let mut to_write: BTreeSet<String> = requested
+		.iter()
+		.filter(|app| generated_apps.contains(*app))
+		.cloned()
+		.collect();
+	let mut stack: Vec<String> = to_write.iter().cloned().collect();
+	while let Some(app) = stack.pop() {
+		let Some(migration) = generated.iter().find(|m| m.app_label == app) else {
+			continue;
+		};
+		for provider in reinhardt_db::migrations::MigrationAutodetector::foreign_key_provider_apps(
+			to_state,
+			&migration.operations,
+			&app,
+		) {
+			if generated_apps.contains(&provider) && to_write.insert(provider.clone()) {
+				stack.push(provider);
+			}
+		}
+	}
+	to_write
+}
+
+#[cfg(feature = "migrations")]
+fn resolve_makemigrations_dependencies(
+	app_name: &str,
+	migration_number: &str,
+	operations: &[reinhardt_db::migrations::Operation],
+	to_state: &reinhardt_db::migrations::autodetector::ProjectState,
+	this_run_names: &std::collections::BTreeMap<String, String>,
+	existing_latest: &std::collections::BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+	use std::collections::BTreeSet;
+
+	let mut dependencies = Vec::new();
+	let mut seen = BTreeSet::new();
+
+	if migration_number != "0001"
+		&& let Some(prev) = existing_latest.get(app_name)
+		&& seen.insert(app_name.to_string())
+	{
+		dependencies.push((app_name.to_string(), prev.clone()));
+	}
+
+	for provider_app in reinhardt_db::migrations::MigrationAutodetector::foreign_key_provider_apps(
+		to_state, operations, app_name,
+	) {
+		if !seen.insert(provider_app.clone()) {
+			continue;
+		}
+		if let Some(name) = this_run_names.get(&provider_app) {
+			dependencies.push((provider_app, name.clone()));
+		} else if let Some(name) = existing_latest.get(&provider_app) {
+			dependencies.push((provider_app, name.clone()));
+		}
+	}
+
+	dependencies
 }
 
 /// Interactive shell command
@@ -5259,6 +5293,200 @@ name = "db.sqlite3"
 		let option_names: Vec<&str> = options.iter().map(|o| o.long.as_str()).collect();
 		assert!(option_names.contains(&"dry-run"));
 		assert!(option_names.contains(&"empty"));
+	}
+
+	#[cfg(feature = "migrations")]
+	fn command_test_fk_model(
+		app: &str,
+		name: &str,
+		table: &str,
+		fk_table: Option<&str>,
+	) -> reinhardt_db::migrations::ModelState {
+		use reinhardt_db::migrations::{
+			FieldState, FieldType, ForeignKeyAction, ForeignKeyInfo, ModelState,
+		};
+
+		let mut model = ModelState::new(app, name);
+		model.table_name = table.to_string();
+		model.add_field(FieldState::new("id", FieldType::Integer, false));
+		if let Some(referenced) = fk_table {
+			model.add_field(FieldState::with_foreign_key(
+				"parent_id",
+				FieldType::Integer,
+				false,
+				ForeignKeyInfo {
+					referenced_table: referenced.to_string(),
+					referenced_column: "id".to_string(),
+					on_delete: ForeignKeyAction::Cascade,
+					on_update: ForeignKeyAction::Cascade,
+				},
+			));
+			model.add_foreign_key_constraint_from_field("parent_id");
+		}
+		model
+	}
+
+	#[test]
+	#[cfg(feature = "migrations")]
+	fn resolve_makemigrations_dependencies_wires_initial_cross_app_graph() {
+		use reinhardt_db::migrations::{MigrationAutodetector, ProjectState};
+		use std::collections::BTreeMap;
+
+		// Arrange
+		let mut to_state = ProjectState::new();
+		to_state.add_model(command_test_fk_model("auth", "User", "auth_users", None));
+		to_state.add_model(command_test_fk_model(
+			"organizations",
+			"Organization",
+			"organizations",
+			Some("auth_users"),
+		));
+		to_state.add_model(command_test_fk_model(
+			"clusters",
+			"Cluster",
+			"clusters",
+			Some("organizations"),
+		));
+		let generated =
+			MigrationAutodetector::new(ProjectState::new(), to_state.clone()).generate_migrations();
+		let mut this_run = BTreeMap::new();
+		this_run.insert("auth".to_string(), "0001_initial".to_string());
+		this_run.insert("organizations".to_string(), "0001_initial".to_string());
+		this_run.insert("clusters".to_string(), "0001_initial".to_string());
+		let existing = BTreeMap::new();
+		let org_ops = generated
+			.iter()
+			.find(|migration| migration.app_label == "organizations")
+			.expect("organizations migration")
+			.operations
+			.as_slice();
+		let cluster_ops = generated
+			.iter()
+			.find(|migration| migration.app_label == "clusters")
+			.expect("clusters migration")
+			.operations
+			.as_slice();
+
+		// Act
+		let org_deps = resolve_makemigrations_dependencies(
+			"organizations",
+			"0001",
+			org_ops,
+			&to_state,
+			&this_run,
+			&existing,
+		);
+		let cluster_deps = resolve_makemigrations_dependencies(
+			"clusters",
+			"0001",
+			cluster_ops,
+			&to_state,
+			&this_run,
+			&existing,
+		);
+		let auth_deps = resolve_makemigrations_dependencies(
+			"auth",
+			"0001",
+			generated
+				.iter()
+				.find(|migration| migration.app_label == "auth")
+				.expect("auth migration")
+				.operations
+				.as_slice(),
+			&to_state,
+			&this_run,
+			&existing,
+		);
+
+		// Assert
+		assert_eq!(
+			org_deps,
+			vec![("auth".to_string(), "0001_initial".to_string())]
+		);
+		assert_eq!(
+			cluster_deps,
+			vec![("organizations".to_string(), "0001_initial".to_string())]
+		);
+		assert!(
+			auth_deps.is_empty(),
+			"auth initial must not depend on another app, got {auth_deps:?}"
+		);
+	}
+
+	#[test]
+	#[cfg(feature = "migrations")]
+	fn resolve_makemigrations_dependencies_keeps_same_app_previous_migration() {
+		use reinhardt_db::migrations::{MigrationAutodetector, ProjectState};
+		use std::collections::BTreeMap;
+
+		// Arrange
+		let mut to_state = ProjectState::new();
+		to_state.add_model(command_test_fk_model("auth", "User", "auth_users", None));
+		to_state.add_model(command_test_fk_model(
+			"organizations",
+			"Organization",
+			"organizations",
+			Some("auth_users"),
+		));
+		let generated =
+			MigrationAutodetector::new(ProjectState::new(), to_state.clone()).generate_migrations();
+		let org_ops = generated
+			.iter()
+			.find(|migration| migration.app_label == "organizations")
+			.expect("organizations migration")
+			.operations
+			.as_slice();
+		let mut existing = BTreeMap::new();
+		existing.insert("organizations".to_string(), "0001_initial".to_string());
+		existing.insert("auth".to_string(), "0003_user_email".to_string());
+
+		// Act
+		let deps = resolve_makemigrations_dependencies(
+			"organizations",
+			"0002",
+			org_ops,
+			&to_state,
+			&BTreeMap::new(),
+			&existing,
+		);
+
+		// Assert
+		assert_eq!(
+			deps,
+			vec![
+				("organizations".to_string(), "0001_initial".to_string()),
+				("auth".to_string(), "0003_user_email".to_string()),
+			]
+		);
+	}
+
+	#[test]
+	#[cfg(feature = "migrations")]
+	fn expand_apps_with_fk_providers_includes_unmigrated_providers() {
+		use reinhardt_db::migrations::{MigrationAutodetector, ProjectState};
+
+		// Arrange
+		let mut to_state = ProjectState::new();
+		to_state.add_model(command_test_fk_model("auth", "User", "auth_users", None));
+		to_state.add_model(command_test_fk_model(
+			"organizations",
+			"Organization",
+			"organizations",
+			Some("auth_users"),
+		));
+		let generated =
+			MigrationAutodetector::new(ProjectState::new(), to_state.clone()).generate_migrations();
+
+		// Act
+		let expanded =
+			expand_apps_with_fk_providers(&["organizations".to_string()], &generated, &to_state);
+
+		// Assert
+		assert!(
+			expanded.contains("auth"),
+			"requesting organizations must also emit auth when auth has a pending initial, got {expanded:?}"
+		);
+		assert!(expanded.contains("organizations"));
 	}
 
 	#[tokio::test]

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -24,6 +24,7 @@ This crate provides the following modules:
 
 - **Migrations**: Schema migration system
   - Automatic migration generation from model changes
+  - Initial `CreateTable` operations follow foreign-key order from field metadata
   - Forward and backward migrations
   - Schema versioning and dependency management
   - Migration operations (CreateModel, AddField, AlterField, etc.)
@@ -883,6 +884,7 @@ Optimize how related objects are loaded:
     - Dry-run mode for previewing changes
     - Custom migration naming
     - App-specific migration generation
+    - Same-app `CreateTable` order and cross-app `dependencies` follow foreign-key providers
   - `migrate`: Apply migrations to database
     - Fake migrations support
     - Migration plan preview

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -40,7 +40,9 @@
 //! ### Migrations (`migrations` module)
 //!
 //! - **Schema Migrations**: Track and apply database schema changes
-//! - **Auto-detection**: Automatically detect model changes
+//! - **Auto-detection**: Automatically detect model changes. Initial
+//!   `CreateTable` operations follow foreign-key order derived from
+//!   `FieldState.foreign_key` metadata rather than lexicographic table names.
 //! - **Migration Files**: Generate migration files from model changes
 //! - **Rollback Support**: Reverse migrations when needed
 //! - **CockroachDB Migration Locking**: Serialize concurrent migrators with a

--- a/crates/reinhardt-db/src/migrations.rs
+++ b/crates/reinhardt-db/src/migrations.rs
@@ -4,7 +4,9 @@
 //!
 //! ## Features
 //!
-//! - **Auto-detection**: Detects model changes and generates migrations
+//! - **Auto-detection**: Detects model changes and generates migrations.
+//!   Same-app `CreateTable` operations follow foreign-key order from
+//!   `FieldState.foreign_key` and model constraints, not lexicographic table names.
 //! - **Migration Graph**: Manages dependencies between migrations
 //! - **AST-Based Entry Points**: Generates Rust 2024 Edition-compliant module files
 //! - **State Reconstruction**: Django-style `ProjectState` building from migration history

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1884,6 +1884,88 @@ pub struct DetectedChanges {
 	pub created_many_to_many: Vec<(String, String, String, ManyToManyMetadata)>,
 }
 
+/// Deterministic topological sort of `(app_label, model_name)` keys.
+///
+/// Only `nodes` participate in the graph. Edges that point at models outside
+/// that set (already-existing tables, or models belonging to another
+/// migration) are ignored so they cannot inject extra CreateTable operations
+/// or leave a created model with a non-zero in-degree that never drains.
+///
+/// Ready nodes are stored in a `BTreeSet` so equal-in-degree ties break
+/// lexicographically. Cycles fall back to lexicographic order of the
+/// remaining nodes after a warning, rather than `HashSet` iteration order.
+fn topological_sort_model_keys(
+	nodes: &[(String, String)],
+	dependencies: &std::collections::BTreeMap<(String, String), Vec<(String, String)>>,
+) -> Vec<(String, String)> {
+	use std::collections::{BTreeMap, BTreeSet};
+
+	let node_set: BTreeSet<(String, String)> = nodes.iter().cloned().collect();
+	let mut in_degree: BTreeMap<(String, String), usize> =
+		node_set.iter().cloned().map(|node| (node, 0)).collect();
+	let mut dependents: BTreeMap<(String, String), BTreeSet<(String, String)>> = BTreeMap::new();
+
+	for (dependent, deps) in dependencies {
+		if !node_set.contains(dependent) {
+			continue;
+		}
+		for dependency in deps {
+			if dependent == dependency || !node_set.contains(dependency) {
+				continue;
+			}
+			*in_degree.entry(dependent.clone()).or_insert(0) += 1;
+			dependents
+				.entry(dependency.clone())
+				.or_default()
+				.insert(dependent.clone());
+		}
+	}
+
+	let mut ready: BTreeSet<(String, String)> = in_degree
+		.iter()
+		.filter(|(_, degree)| **degree == 0)
+		.map(|(node, _)| node.clone())
+		.collect();
+	let mut ordered = Vec::with_capacity(node_set.len());
+
+	while let Some(node) = ready.iter().next().cloned() {
+		ready.remove(&node);
+		ordered.push(node.clone());
+		if let Some(children) = dependents.get(&node) {
+			for child in children {
+				if let Some(degree) = in_degree.get_mut(child) {
+					*degree = degree.saturating_sub(1);
+					if *degree == 0 {
+						ready.insert(child.clone());
+					}
+				}
+			}
+		}
+	}
+
+	if ordered.len() < node_set.len() {
+		let mut remaining: Vec<(String, String)> = node_set
+			.into_iter()
+			.filter(|node| !ordered.contains(node))
+			.collect();
+		remaining.sort();
+		eprintln!(
+			"⚠️  Warning: Circular dependency detected in models: [{}]",
+			remaining
+				.iter()
+				.map(|(app, name)| format!("{app}.{name}"))
+				.collect::<Vec<_>>()
+				.join(", ")
+		);
+		eprintln!(
+			"    Falling back to lexicographic order for remaining models. Migration operations may need manual reordering."
+		);
+		ordered.extend(remaining);
+	}
+
+	ordered
+}
+
 impl DetectedChanges {
 	/// Order models for migration operations based on dependencies
 	///
@@ -1924,82 +2006,20 @@ impl DetectedChanges {
 	/// assert_eq!(ordered[1], ("blog".to_string(), "Post".to_string()));
 	/// ```
 	pub fn order_models_by_dependency(&self) -> Vec<(String, String)> {
-		use std::collections::{HashMap, HashSet, VecDeque};
-
-		// Build in-degree map (count of incoming edges)
-		let mut in_degree: HashMap<(String, String), usize> = HashMap::new();
-		let mut all_models: HashSet<(String, String)> = HashSet::new();
-
-		// Collect all models (both created and dependencies)
-		for model in &self.created_models {
-			all_models.insert(model.clone());
-			in_degree.entry(model.clone()).or_insert(0);
+		let mut nodes = self.created_models.clone();
+		for moved in &self.moved_models {
+			nodes.push((moved.2.clone(), moved.3.clone()));
 		}
+		topological_sort_model_keys(&nodes, &self.model_dependencies)
+	}
 
-		for model in &self.moved_models {
-			let model_key = (model.2.clone(), model.3.clone()); // (to_app, to_model_name)
-			all_models.insert(model_key.clone());
-			in_degree.entry(model_key).or_insert(0);
-		}
-
-		// Build in-degree counts from dependencies
-		for (dependent, dependencies) in &self.model_dependencies {
-			for dependency in dependencies {
-				all_models.insert(dependency.clone());
-				in_degree.entry(dependency.clone()).or_insert(0);
-				*in_degree.entry(dependent.clone()).or_insert(0) += 1;
-			}
-		}
-
-		// Kahn's algorithm: Start with models that have no dependencies
-		let mut queue: VecDeque<(String, String)> = VecDeque::new();
-		for model in &all_models {
-			if in_degree.get(model).copied().unwrap_or(0) == 0 {
-				queue.push_back(model.clone());
-			}
-		}
-
-		let mut ordered = Vec::new();
-
-		while let Some(model) = queue.pop_front() {
-			ordered.push(model.clone());
-
-			// Reduce in-degree for models that depend on this model
-			// model_dependencies maps dependent -> dependencies
-			// So we need to find all models that have `model` in their dependencies
-			for (dependent, dependencies) in &self.model_dependencies {
-				if dependencies.contains(&model)
-					&& let Some(degree) = in_degree.get_mut(dependent)
-				{
-					*degree -= 1;
-					if *degree == 0 {
-						queue.push_back(dependent.clone());
-					}
-				}
-			}
-		}
-
-		// If not all models are ordered, there's a circular dependency
-		if ordered.len() < all_models.len() {
-			// Fall back to original order with a warning
-			let unordered_models: Vec<_> = all_models
-				.iter()
-				.filter(|model| !ordered.contains(model))
-				.map(|(app, name)| format!("{}.{}", app, name))
-				.collect();
-
-			eprintln!(
-				"⚠️  Warning: Circular dependency detected in models: [{}]",
-				unordered_models.join(", ")
-			);
-			eprintln!(
-				"    Falling back to original order. Migration operations may need manual reordering."
-			);
-
-			all_models.into_iter().collect()
-		} else {
-			ordered
-		}
+	/// Order `created_models` by foreign-key dependencies.
+	///
+	/// Only models that are themselves being created participate in the graph.
+	/// References to already-existing (or cross-app) tables do not inject extra
+	/// CreateTable operations and do not delay the dependent model.
+	pub fn order_created_models_by_dependency(&self) -> Vec<(String, String)> {
+		topological_sort_model_keys(&self.created_models, &self.model_dependencies)
 	}
 
 	/// Check for circular dependencies in model relationships
@@ -4054,9 +4074,19 @@ impl MigrationAutodetector {
 		// Detect model dependencies for operation ordering
 		self.detect_model_dependencies(&mut changes);
 
-		// Sort all changes to ensure deterministic ordering
-		// This guarantees that the same model set always produces the same migration order
-		changes.created_models.sort();
+		// Order newly created models by foreign-key dependencies so CreateTable
+		// operations are emitted with referenced tables first. Lexicographic
+		// sort is the wrong default here: `auth_api_keys` sorts before
+		// `auth_users` even when the former has an inline FK to the latter.
+		let created_set: std::collections::BTreeSet<_> =
+			changes.created_models.iter().cloned().collect();
+		changes.created_models = changes
+			.order_created_models_by_dependency()
+			.into_iter()
+			.filter(|model| created_set.contains(model))
+			.collect();
+
+		// Sort remaining change lists for deterministic output
 		changes.deleted_models.sort();
 		changes.added_fields.sort();
 		changes.removed_fields.sort();
@@ -5574,8 +5604,10 @@ impl MigrationAutodetector {
 			)
 		});
 
-		// Assemble in correct order
-		sorted.extend(create_tables);
+		// Assemble in correct order. CreateTable ops are topologically ordered
+		// so inline foreign keys do not reference tables created later in the
+		// same migration.
+		sorted.extend(Self::topological_sort_create_tables(create_tables));
 		sorted.extend(field_ops);
 		sorted.extend(operations); // Remaining operations
 
@@ -6314,6 +6346,7 @@ impl MigrationAutodetector {
 		// it. See reinhardt-web#4448.
 		Self::dedup_redundant_unique_add_constraints(&mut migrations_by_app);
 		for operations in migrations_by_app.values_mut() {
+			Self::order_create_tables_by_foreign_keys(operations);
 			Self::order_renamed_table_operations(operations);
 		}
 
@@ -6505,62 +6538,133 @@ impl MigrationAutodetector {
 	/// assert!(post_deps.is_some());
 	/// assert!(post_deps.unwrap().contains(&("accounts".to_string(), "User".to_string())));
 	/// ```
+	/// Detect foreign-key and relation dependencies between models.
+	///
+	/// Registered foreign-key ID columns typically keep a scalar `field_type`
+	/// (for example `FieldType::Integer`) and store the relationship on
+	/// `FieldState.foreign_key`. Detecting only relationship-shaped
+	/// `FieldType` variants therefore leaves `model_dependencies` empty for
+	/// the common inline-FK case. This method also inspects
+	/// `FieldState.foreign_key` and `ModelState.constraints`, and resolves
+	/// referenced tables through `ProjectState::find_model_by_table` so
+	/// custom `table_name` values such as `auth_users` are found.
 	fn detect_model_dependencies(&self, changes: &mut DetectedChanges) {
-		// Analyze all models in the final state
-		for ((app_label, model_name), model) in &self.to_state.models {
-			let mut dependencies = Vec::new();
+		use std::collections::BTreeSet;
 
-			// Check each field for foreign key relationships
+		for ((app_label, model_name), model) in &self.to_state.models {
+			let current = (app_label.clone(), model_name.clone());
+			let mut dependencies = Vec::new();
+			let mut seen = BTreeSet::new();
+
 			for field in model.fields.values() {
 				match &field.field_type {
-					// Handle structured ForeignKey variant
 					super::FieldType::ForeignKey { to_table, .. } => {
-						// Find model by table name in the project state
-						if let Some(dep) = self.find_model_by_table_name(to_table) {
-							// Avoid self-reference unless intentional
-							if dep != (app_label.clone(), model_name.clone()) {
-								dependencies.push(dep);
-							}
-						}
+						self.record_table_dependency(
+							to_table,
+							&current,
+							&mut dependencies,
+							&mut seen,
+						);
 					}
-					// Handle structured OneToOne variant
 					super::FieldType::OneToOne { to, .. } => {
-						// Format: "app.Model" or "Model"
-						if let Some(dep) = self.parse_model_reference(to, app_label)
-							&& dep != (app_label.clone(), model_name.clone())
-						{
-							dependencies.push(dep);
+						if let Some(dep) = self.parse_model_reference(to, app_label) {
+							self.record_model_dependency(
+								dep,
+								&current,
+								&mut dependencies,
+								&mut seen,
+							);
 						}
 					}
-					// Handle structured ManyToMany variant
 					super::FieldType::ManyToMany { to, .. } => {
-						// Format: "app.Model" or "Model"
-						if let Some(dep) = self.parse_model_reference(to, app_label)
-							&& dep != (app_label.clone(), model_name.clone())
-						{
-							dependencies.push(dep);
+						if let Some(dep) = self.parse_model_reference(to, app_label) {
+							self.record_model_dependency(
+								dep,
+								&current,
+								&mut dependencies,
+								&mut seen,
+							);
 						}
 					}
-					// Handle legacy Custom string format
 					super::FieldType::Custom(s) => {
-						if let Some(referenced_model) = self.extract_related_model(s, app_label)
-							&& referenced_model != (app_label.clone(), model_name.clone())
-						{
-							dependencies.push(referenced_model);
+						if let Some(dep) = self.extract_related_model(s, app_label) {
+							self.record_model_dependency(
+								dep,
+								&current,
+								&mut dependencies,
+								&mut seen,
+							);
 						}
 					}
-					// Skip other field types
 					_ => {}
+				}
+
+				if let Some(fk) = &field.foreign_key {
+					self.record_table_dependency(
+						&fk.referenced_table,
+						&current,
+						&mut dependencies,
+						&mut seen,
+					);
 				}
 			}
 
-			// Only store if there are actual dependencies
+			for constraint in &model.constraints {
+				if (constraint
+					.constraint_type
+					.eq_ignore_ascii_case("foreign_key")
+					|| constraint
+						.constraint_type
+						.eq_ignore_ascii_case("one_to_one"))
+					&& let Some(fk_info) = &constraint.foreign_key_info
+				{
+					self.record_table_dependency(
+						&fk_info.referenced_table,
+						&current,
+						&mut dependencies,
+						&mut seen,
+					);
+				}
+			}
+
 			if !dependencies.is_empty() {
-				changes
-					.model_dependencies
-					.insert((app_label.clone(), model_name.clone()), dependencies);
+				changes.model_dependencies.insert(current, dependencies);
 			}
 		}
+	}
+
+	fn record_table_dependency(
+		&self,
+		table_name: &str,
+		current: &(String, String),
+		dependencies: &mut Vec<(String, String)>,
+		seen: &mut std::collections::BTreeSet<(String, String)>,
+	) {
+		if let Some(dep) = self.resolve_model_by_table(table_name) {
+			self.record_model_dependency(dep, current, dependencies, seen);
+		}
+	}
+
+	fn record_model_dependency(
+		&self,
+		dep: (String, String),
+		current: &(String, String),
+		dependencies: &mut Vec<(String, String)>,
+		seen: &mut std::collections::BTreeSet<(String, String)>,
+	) {
+		if dep != *current && seen.insert(dep.clone()) {
+			dependencies.push(dep);
+		}
+	}
+
+	fn resolve_model_by_table(&self, table_name: &str) -> Option<(String, String)> {
+		if let Some(model) = self.to_state.find_model_by_table(table_name) {
+			return Some((model.app_label.clone(), model.name.clone()));
+		}
+		if let Some(model) = self.from_state.find_model_by_table(table_name) {
+			return Some((model.app_label.clone(), model.name.clone()));
+		}
+		self.find_model_by_table_name(table_name)
 	}
 
 	/// Extract related model from field type string
@@ -6662,22 +6766,220 @@ impl MigrationAutodetector {
 		}
 	}
 
+	/// Apps whose tables are referenced by foreign keys in `operations`.
+	///
+	/// Used by `makemigrations` to attach cross-app migration dependencies so
+	/// a fresh database applies provider-app initials before dependents.
+	pub fn foreign_key_provider_apps(
+		to_state: &ProjectState,
+		operations: &[super::Operation],
+		current_app: &str,
+	) -> Vec<String> {
+		use std::collections::BTreeSet;
+
+		let mut apps = BTreeSet::new();
+		for operation in operations {
+			for table in Self::referenced_tables_in_operation(operation) {
+				if let Some(model) = to_state.find_model_by_table(&table)
+					&& model.app_label != current_app
+				{
+					apps.insert(model.app_label.clone());
+				}
+			}
+		}
+		apps.into_iter().collect()
+	}
+
+	fn referenced_tables_in_operation(operation: &super::Operation) -> Vec<String> {
+		match operation {
+			super::Operation::CreateTable { constraints, .. } => {
+				Self::referenced_tables_from_constraints(constraints)
+			}
+			super::Operation::AddConstraint { constraint_sql, .. } => {
+				Self::referenced_tables_from_constraint_sql(constraint_sql)
+			}
+			_ => Vec::new(),
+		}
+	}
+
+	fn referenced_tables_from_constraints(
+		constraints: &[super::operations::Constraint],
+	) -> Vec<String> {
+		let mut tables = Vec::new();
+		for constraint in constraints {
+			match constraint {
+				super::operations::Constraint::ForeignKey {
+					referenced_table, ..
+				}
+				| super::operations::Constraint::OneToOne {
+					referenced_table, ..
+				} => {
+					tables.push(referenced_table.clone());
+				}
+				super::operations::Constraint::ManyToMany { target_table, .. } => {
+					tables.push(target_table.clone());
+				}
+				_ => {}
+			}
+		}
+		tables
+	}
+
+	fn referenced_tables_from_constraint_sql(constraint_sql: &str) -> Vec<String> {
+		let mut tables = Vec::new();
+		let mut rest = constraint_sql;
+		while let Some(index) = rest.find("REFERENCES ") {
+			let tail = rest[index + "REFERENCES ".len()..].trim_start();
+			if tail.is_empty() {
+				break;
+			}
+			let (table, remaining) = if let Some(stripped) = tail.strip_prefix('"') {
+				match stripped.find('"') {
+					Some(end) => (&stripped[..end], &stripped[end + 1..]),
+					None => break,
+				}
+			} else {
+				let end = tail
+					.find(|ch: char| ch == '(' || ch.is_whitespace())
+					.unwrap_or(tail.len());
+				(&tail[..end], &tail[end..])
+			};
+			if !table.is_empty() {
+				tables.push(table.to_string());
+			}
+			rest = remaining;
+		}
+		tables
+	}
+
+	fn order_create_tables_by_foreign_keys(operations: &mut [super::Operation]) {
+		let create_indices: Vec<usize> = operations
+			.iter()
+			.enumerate()
+			.filter(|(_, op)| matches!(op, super::Operation::CreateTable { .. }))
+			.map(|(i, _)| i)
+			.collect();
+		if create_indices.len() <= 1 {
+			return;
+		}
+		let create_ops: Vec<super::Operation> = create_indices
+			.iter()
+			.map(|&i| operations[i].clone())
+			.collect();
+		let sorted = Self::topological_sort_create_tables(create_ops);
+		for (slot, op) in create_indices.into_iter().zip(sorted) {
+			operations[slot] = op;
+		}
+	}
+
+	fn topological_sort_create_tables(
+		create_tables: Vec<super::Operation>,
+	) -> Vec<super::Operation> {
+		use std::collections::{BTreeMap, BTreeSet};
+
+		if create_tables.len() <= 1 {
+			return create_tables;
+		}
+
+		let names: Vec<String> = create_tables
+			.iter()
+			.filter_map(|op| match op {
+				super::Operation::CreateTable { name, .. } => Some(name.clone()),
+				_ => None,
+			})
+			.collect();
+		let name_set: BTreeSet<String> = names.iter().cloned().collect();
+		let mut in_degree: BTreeMap<String, usize> =
+			names.iter().cloned().map(|name| (name, 0)).collect();
+		let mut dependents: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+		for op in &create_tables {
+			let super::Operation::CreateTable {
+				name, constraints, ..
+			} = op
+			else {
+				continue;
+			};
+			for referenced in Self::referenced_tables_from_constraints(constraints) {
+				if referenced == *name || !name_set.contains(&referenced) {
+					continue;
+				}
+				*in_degree.entry(name.clone()).or_insert(0) += 1;
+				dependents
+					.entry(referenced)
+					.or_default()
+					.insert(name.clone());
+			}
+		}
+
+		let mut ready: BTreeSet<String> = in_degree
+			.iter()
+			.filter(|(_, degree)| **degree == 0)
+			.map(|(name, _)| name.clone())
+			.collect();
+		let mut ordered_names = Vec::with_capacity(names.len());
+		while let Some(name) = ready.iter().next().cloned() {
+			ready.remove(&name);
+			ordered_names.push(name.clone());
+			if let Some(children) = dependents.get(&name) {
+				for child in children {
+					if let Some(degree) = in_degree.get_mut(child) {
+						*degree = degree.saturating_sub(1);
+						if *degree == 0 {
+							ready.insert(child.clone());
+						}
+					}
+				}
+			}
+		}
+
+		if ordered_names.len() < names.len() {
+			let mut remaining: Vec<String> = names
+				.iter()
+				.filter(|name| !ordered_names.contains(name))
+				.cloned()
+				.collect();
+			remaining.sort();
+			eprintln!(
+				"⚠️  Warning: Circular foreign-key dependency detected among CreateTable operations: [{}]",
+				remaining.join(", ")
+			);
+			ordered_names.extend(remaining);
+		}
+
+		let mut by_name: BTreeMap<String, super::Operation> = BTreeMap::new();
+		let mut extras = Vec::new();
+		for op in create_tables {
+			match &op {
+				super::Operation::CreateTable { name, .. } => {
+					by_name.insert(name.clone(), op);
+				}
+				_ => extras.push(op),
+			}
+		}
+
+		let mut sorted: Vec<super::Operation> = ordered_names
+			.into_iter()
+			.filter_map(|name| by_name.remove(&name))
+			.collect();
+		sorted.extend(by_name.into_values());
+		sorted.extend(extras);
+		sorted
+	}
+
 	/// Find a model in the project state by its table name
 	///
-	/// This method searches through all models in both from_state and to_state
-	/// to find a model whose table name matches the given table name.
-	///
-	/// Table name matching supports:
-	/// - Django-style table names: "app_modelname" (e.g., "auth_user")
-	/// - Simple model name match: "modelname" (lowercase, e.g., "user")
-	///
-	/// # Arguments
-	/// * `table_name` - The table name to search for
-	///
-	/// # Returns
-	/// * `Some((app_label, model_name))` if found
-	/// * `None` if no matching model is found
+	/// Resolves against the model's actual `table_name` first. Django-style
+	/// `{app}_{model}` and lowercase model-name heuristics remain as fallbacks
+	/// for callers that pass a relation target without a registered table.
 	fn find_model_by_table_name(&self, table_name: &str) -> Option<(String, String)> {
+		if let Some(model) = self.to_state.find_model_by_table(table_name) {
+			return Some((model.app_label.clone(), model.name.clone()));
+		}
+		if let Some(model) = self.from_state.find_model_by_table(table_name) {
+			return Some((model.app_label.clone(), model.name.clone()));
+		}
+
 		// Search in to_state (target state has priority)
 		for (app_label, model_name) in self.to_state.models.keys() {
 			// Check Django-style table name: app_modelname
@@ -10140,5 +10442,295 @@ mod tests {
 			"expected the surviving op to be AddColumn, got: {:?}",
 			remaining[0]
 		);
+	}
+
+	fn integer_id_field() -> FieldState {
+		FieldState::new("id", super::super::FieldType::Integer, false)
+	}
+
+	fn integer_fk_field(name: &str, referenced_table: &str) -> FieldState {
+		FieldState::with_foreign_key(
+			name,
+			super::super::FieldType::Integer,
+			false,
+			ForeignKeyInfo {
+				referenced_table: referenced_table.to_string(),
+				referenced_column: "id".to_string(),
+				on_delete: ForeignKeyAction::Cascade,
+				on_update: ForeignKeyAction::Cascade,
+			},
+		)
+	}
+
+	fn model_with_table(
+		app_label: &str,
+		name: &str,
+		table_name: &str,
+		fields: Vec<FieldState>,
+	) -> ModelState {
+		let mut model = ModelState::new(app_label, name);
+		model.table_name = table_name.to_string();
+		for field in fields {
+			let field_name = field.name.clone();
+			model.add_field(field);
+			if model
+				.fields
+				.get(&field_name)
+				.and_then(|field| field.foreign_key.as_ref())
+				.is_some()
+			{
+				model.add_foreign_key_constraint_from_field(&field_name);
+			}
+		}
+		model
+	}
+
+	fn create_table_names(migration: &super::super::Migration) -> Vec<String> {
+		migration
+			.operations
+			.iter()
+			.filter_map(|operation| match operation {
+				super::super::Operation::CreateTable { name, .. } => Some(name.clone()),
+				_ => None,
+			})
+			.collect()
+	}
+
+	#[rstest]
+	fn detect_model_dependencies_reads_scalar_foreign_key_metadata() {
+		// Arrange: FK ID column keeps a scalar field type; the relationship
+		// lives on FieldState.foreign_key, which alphabetical detection missed.
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_with_table(
+			"auth",
+			"User",
+			"auth_users",
+			vec![integer_id_field()],
+		));
+		to_state.add_model(model_with_table(
+			"auth",
+			"ApiKey",
+			"auth_api_keys",
+			vec![
+				integer_id_field(),
+				integer_fk_field("user_id", "auth_users"),
+			],
+		));
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state);
+
+		// Act
+		let changes = detector.detect_changes();
+
+		// Assert
+		let deps = changes
+			.model_dependencies
+			.get(&("auth".to_string(), "ApiKey".to_string()))
+			.expect("ApiKey must record a dependency on User");
+		assert_eq!(
+			deps,
+			&vec![("auth".to_string(), "User".to_string())],
+			"scalar Integer FK columns must contribute model_dependencies"
+		);
+	}
+
+	#[rstest]
+	fn generate_migrations_orders_same_app_create_tables_by_foreign_key() {
+		// Arrange: auth_api_keys sorts before auth_users lexicographically.
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_with_table(
+			"auth",
+			"ApiKey",
+			"auth_api_keys",
+			vec![
+				integer_id_field(),
+				integer_fk_field("user_id", "auth_users"),
+			],
+		));
+		to_state.add_model(model_with_table(
+			"auth",
+			"User",
+			"auth_users",
+			vec![integer_id_field()],
+		));
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state);
+
+		// Act
+		let migrations = detector.generate_migrations();
+		let operations = detector.generate_operations();
+
+		// Assert
+		let auth = migrations
+			.iter()
+			.find(|migration| migration.app_label == "auth")
+			.expect("auth migration");
+		let table_names = create_table_names(auth);
+		let users = table_names
+			.iter()
+			.position(|name| name == "auth_users")
+			.expect("auth_users CreateTable");
+		let api_keys = table_names
+			.iter()
+			.position(|name| name == "auth_api_keys")
+			.expect("auth_api_keys CreateTable");
+		assert!(
+			users < api_keys,
+			"auth_users must be created before auth_api_keys, got {table_names:?}"
+		);
+
+		let operation_tables: Vec<String> = operations
+			.iter()
+			.filter_map(|operation| match operation {
+				super::super::Operation::CreateTable { name, .. } => Some(name.clone()),
+				_ => None,
+			})
+			.collect();
+		let users = operation_tables
+			.iter()
+			.position(|name| name == "auth_users")
+			.expect("auth_users in generate_operations");
+		let api_keys = operation_tables
+			.iter()
+			.position(|name| name == "auth_api_keys")
+			.expect("auth_api_keys in generate_operations");
+		assert!(
+			users < api_keys,
+			"generate_operations must also emit auth_users before auth_api_keys, got {operation_tables:?}"
+		);
+	}
+
+	#[rstest]
+	fn generate_migrations_records_cross_app_foreign_key_graph() {
+		// Arrange: auth <- organizations <- clusters <- deployments <- github
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_with_table(
+			"auth",
+			"User",
+			"auth_users",
+			vec![integer_id_field()],
+		));
+		to_state.add_model(model_with_table(
+			"organizations",
+			"Organization",
+			"organizations",
+			vec![
+				integer_id_field(),
+				integer_fk_field("owner_id", "auth_users"),
+			],
+		));
+		to_state.add_model(model_with_table(
+			"clusters",
+			"Cluster",
+			"clusters",
+			vec![
+				integer_id_field(),
+				integer_fk_field("organization_id", "organizations"),
+			],
+		));
+		to_state.add_model(model_with_table(
+			"deployments",
+			"Deployment",
+			"deployments",
+			vec![
+				integer_id_field(),
+				integer_fk_field("organization_id", "organizations"),
+				integer_fk_field("cluster_id", "clusters"),
+			],
+		));
+		to_state.add_model(model_with_table(
+			"github",
+			"Project",
+			"github_projects",
+			vec![
+				integer_id_field(),
+				integer_fk_field("organization_id", "organizations"),
+				integer_fk_field("deployment_id", "deployments"),
+			],
+		));
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state.clone());
+
+		// Act
+		let changes = detector.detect_changes();
+		let migrations = detector.generate_migrations();
+		let github_ops = migrations
+			.iter()
+			.find(|migration| migration.app_label == "github")
+			.expect("github migration")
+			.operations
+			.as_slice();
+		let providers =
+			MigrationAutodetector::foreign_key_provider_apps(&to_state, github_ops, "github");
+		let second_pass =
+			MigrationAutodetector::new(to_state.clone(), to_state).generate_migrations();
+
+		// Assert
+		assert_eq!(
+			changes
+				.model_dependencies
+				.get(&("organizations".to_string(), "Organization".to_string()))
+				.expect("organizations depends on auth"),
+			&vec![("auth".to_string(), "User".to_string())]
+		);
+		let cluster_deps = changes
+			.model_dependencies
+			.get(&("clusters".to_string(), "Cluster".to_string()))
+			.expect("clusters depends on organizations");
+		assert_eq!(
+			cluster_deps,
+			&vec![("organizations".to_string(), "Organization".to_string())]
+		);
+		let deployment_deps = changes
+			.model_dependencies
+			.get(&("deployments".to_string(), "Deployment".to_string()))
+			.expect("deployments depends on organizations and clusters");
+		assert!(
+			deployment_deps.contains(&("organizations".to_string(), "Organization".to_string()))
+		);
+		assert!(deployment_deps.contains(&("clusters".to_string(), "Cluster".to_string())));
+		assert_eq!(
+			providers,
+			vec!["deployments".to_string(), "organizations".to_string()]
+		);
+		assert!(
+			second_pass.is_empty(),
+			"second autodetect against the same state must not emit extra operations, got {second_pass:?}"
+		);
+	}
+
+	#[rstest]
+	fn generate_migrations_survives_circular_foreign_keys() {
+		// Arrange: A <-> B. Cycles must warn rather than panic, and both
+		// tables must still be created.
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_with_table(
+			"cycles",
+			"Alpha",
+			"cycles_alpha",
+			vec![
+				integer_id_field(),
+				integer_fk_field("beta_id", "cycles_beta"),
+			],
+		));
+		to_state.add_model(model_with_table(
+			"cycles",
+			"Beta",
+			"cycles_beta",
+			vec![
+				integer_id_field(),
+				integer_fk_field("alpha_id", "cycles_alpha"),
+			],
+		));
+		let detector = MigrationAutodetector::new(ProjectState::new(), to_state);
+
+		// Act
+		let migrations = detector.generate_migrations();
+
+		// Assert
+		let cycle_migration = migrations
+			.iter()
+			.find(|migration| migration.app_label == "cycles")
+			.expect("cycles migration");
+		let tables = create_table_names(cycle_migration);
+		assert!(tables.contains(&"cycles_alpha".to_string()));
+		assert!(tables.contains(&"cycles_beta".to_string()));
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- Same-app `CreateTable` operations now follow a deterministic topological order derived from actual foreign-key metadata (`FieldState.foreign_key` and model constraints), not lexicographic table names.
- Initial migrations record cross-app `dependencies` for every external table provider, so a fresh PostgreSQL database can apply generated files without hand-editing.
- `makemigrations` runs autodetection against the full project graph so provider tables remain visible when a dependent app is requested.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

crates.io `0.4.0-alpha.8` emitted initial `CreateTable` operations before tables referenced by inline foreign keys, and wrote `dependencies: vec![]` for every `0001` migration. That fails on a fresh PostgreSQL database with `42P01` (`relation "auth_users" does not exist`). Generated migration files are source artifacts and must apply unchanged.

The failure had three causes:

1. Dependency detection inspected relationship-shaped `field_type` variants but not scalar ID columns that store the relationship on `FieldState.foreign_key`.
2. Created models were sorted lexicographically, and operation sorting only grouped `CreateTable` ahead of other ops without ordering those tables.
3. `makemigrations` filtered project state per app before autodetection and forced empty dependencies on number `0001`.

Fixes #6146

Related to: kent8192/reinhardt-cloud#870

## How Was This Tested?

- `cargo test -p reinhardt-db --lib create_tables_by_foreign_key`
- `cargo test -p reinhardt-db --lib foreign_key` (36 unit tests, including the new scalar-FK, same-app order, cross-app graph, and cycle-survival cases)
- `cargo test -p reinhardt-db --lib migrations::autodetector` (56 tests)
- `cargo test -p reinhardt-commands --features migrations,postgres --lib resolve_makemigrations_dependencies`
- `cargo test -p reinhardt-commands --features migrations,postgres --lib expand_apps_with_fk_providers`
- `cargo clippy -p reinhardt-db --lib -- -D warnings`
- `cargo fmt --package reinhardt-db --package reinhardt-commands`

End-to-end application against a live PostgreSQL 16 instance was not run in this environment.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #6146
- Related: kent8192/reinhardt-cloud#870

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

**Additional Context:**

For an acyclic graph the expected app-level order is `auth` → `organizations` → `clusters` → `deployments` → `github`. Cycles warn and fall back to lexicographic order of the remaining nodes instead of panicking.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03104-6237-7924-a8b6-c8a042902dcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03104-6237-7924-a8b6-c8a042902dcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

