### PR TITLE
fix(forms): handle hidden required foreign keys in model forms

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3211,7 +3211,7 @@ fn generate_model_form_support(
 				|| field.config.skip
 				|| is_relationship_field_type(&field.ty)
 				|| model_form_declared_default(field).is_some()
-				|| is_auto_generated_field(field)
+				|| (is_auto_generated_field(field) && !field.is_fk_id_field)
 			{
 				return false;
 			}

--- a/crates/reinhardt-forms/src/model_form.rs
+++ b/crates/reinhardt-forms/src/model_form.rs
@@ -697,6 +697,34 @@ mod tests {
 
 	#[model(
 		app_label = "forms",
+		table_name = "model_form_hidden_relation_owners",
+		info = false
+	)]
+	#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+	struct HiddenRelationOwner {
+		#[field(primary_key = true)]
+		id: i64,
+	}
+
+	#[model(
+		app_label = "forms",
+		table_name = "model_form_hidden_relation_records",
+		form = true,
+		info = false
+	)]
+	#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+	struct HiddenRequiredRelationRecord {
+		#[field(primary_key = true)]
+		id: Option<i64>,
+		#[field(max_length = 200)]
+		title: String,
+		#[field(editable = false)]
+		#[rel(foreign_key)]
+		owner: reinhardt_db::associations::ForeignKeyField<HiddenRelationOwner>,
+	}
+
+	#[model(
+		app_label = "forms",
 		table_name = "model_form_skipped_default_records",
 		form = true,
 		info = false
@@ -1050,6 +1078,34 @@ mod tests {
 			.expect("the trusted value should be retained in the candidate");
 
 		assert_eq!(built.audit_actor, "system");
+	}
+
+	#[test]
+	fn generated_model_form_handles_required_non_editable_foreign_key() {
+		let mut data = HiddenRequiredRelationRecordModelFormData::<AllEditableModelFields>::empty();
+		data.set_title("Hidden relation".to_owned())
+			.expect("editable title should be accepted");
+
+		let mut form = ModelForm::<HiddenRequiredRelationRecord>::from_payload(data);
+		let error = form
+			.build_instance()
+			.expect_err("a missing hidden foreign key must not build a normal candidate");
+		assert!(matches!(
+			error,
+			ModelFormError::MissingModelField { field: "owner_id" }
+		));
+
+		let mut data = HiddenRequiredRelationRecordModelFormData::<AllEditableModelFields>::empty();
+		data.set_title("Trusted relation".to_owned())
+			.expect("editable title should be accepted");
+		let mut form = ModelForm::<HiddenRequiredRelationRecord>::from_payload(data);
+		form.set_trusted_field_value("owner_id", json!(42))
+			.expect("a trusted hidden foreign key should be accepted");
+
+		let built = form
+			.build_instance()
+			.expect("the trusted deferred path should build a candidate");
+		assert_eq!(built.owner_id, 42);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

This PR addresses:

- Prevents normal `ModelForm` construction from referencing an undeclared `deferred_field` when a required foreign-key relation is hidden with `editable = false`.
- Keeps the trusted deferred-field construction path available for server-supplied relation IDs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The generated normal constructor had no `deferred_field` parameter, but required hidden foreign-key IDs were emitted as if that parameter existed. The generator now treats the synthetic foreign-key ID as unresolved for normal construction, while the deferred constructor continues to accept trusted server-side values.

Fixes #6148

Related to: kent8192/reinhardt-cloud#872

## How Was This Tested?

- `cargo test -p reinhardt-forms --lib model_form::tests::generated_model_form_handles_required_non_editable_foreign_key -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable; existing ModelForm documentation already describes this behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable; this is macro/form construction logic)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

- Fixes #6148

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels
- [ ] `breaking-change` - Breaking change

### Scope Label
- [x] `forms` - Form handling, validation, rendering
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- This is based on `develop/0.4.0` because the affected ModelForm generator exists on that release line.
- The PR is intentionally left as Draft pending repository CI and maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
