### PR TITLE
fix(migrations): preserve default foreign-key indexes

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -3276,6 +3276,12 @@ fn generate_registration_code(
 					name: #index_name.to_string(),
 					fields: vec![#field_name.to_string()],
 					unique: false,
+					where_clause: None,
+					index_type: None,
+					expressions: None,
+					concurrently: false,
+					mysql_options: None,
+					operator_class: None,
 				});
 			}
 		})

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2097,7 +2097,17 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 	// Find all indexed fields
 	let indexed_fields: Vec<_> = field_infos
 		.iter()
-		.filter(|f| f.config.index.unwrap_or(false))
+		.filter(|f| {
+			f.config.index.unwrap_or(false)
+				&& !f.config.skip
+				&& !f.is_fk_id_field
+				&& !is_many_to_many_field_type(&f.ty)
+				&& !is_relationship_field_type(&f.ty)
+				&& !f
+					.rel
+					.as_ref()
+					.is_some_and(|rel| matches!(rel.rel_type, crate::rel::RelationType::ManyToMany))
+		})
 		.map(|f| f.name.to_string())
 		.collect();
 
@@ -2547,7 +2557,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 				vec![
 					#(
 						#orm_crate::inspection::IndexInfo {
-							name: format!("{}_{}_idx", <Self as #orm_crate::Model>::table_name(), #indexed_fields),
+							name: format!("idx_{}_{}", <Self as #orm_crate::Model>::table_name(), #indexed_fields),
 							fields: vec![#indexed_fields.to_string()],
 							unique: false,
 							condition: None,
@@ -3247,10 +3257,20 @@ fn generate_registration_code(
 	// Register explicit field indexes for migration state generation.
 	let index_registrations: Vec<TokenStream> = field_infos
 		.iter()
-		.filter(|field_info| field_info.config.index.unwrap_or(false))
+		.filter(|field_info| {
+			field_info.config.index.unwrap_or(false)
+				&& !field_info.config.skip
+				&& !field_info.is_fk_id_field
+				&& !is_many_to_many_field_type(&field_info.ty)
+				&& !is_relationship_field_type(&field_info.ty)
+				&& !field_info
+					.rel
+					.as_ref()
+					.is_some_and(|rel| matches!(rel.rel_type, crate::rel::RelationType::ManyToMany))
+		})
 		.map(|field_info| {
 			let field_name = field_info.name.to_string();
-			let index_name = format!("{}_{}_idx", table_name, field_name);
+			let index_name = format!("idx_{}_{}", table_name, field_name);
 			quote! {
 				metadata.add_index(#migrations_crate::IndexDefinition {
 					name: #index_name.to_string(),

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2217,6 +2217,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		table_name,
 		&field_infos,
 		&fk_field_infos,
+		&indexed_fields,
 		&unique_constraint_names,
 		&unique_constraint_field_lists,
 	)?;
@@ -3002,6 +3003,7 @@ fn generate_registration_code(
 	table_name: &str,
 	field_infos: &[FieldInfo],
 	fk_field_infos: &[ForeignKeyFieldInfo],
+	indexed_fields: &[String],
 	unique_constraint_names: &[String],
 	unique_constraint_field_lists: &[Vec<String>],
 ) -> Result<TokenStream> {
@@ -3244,6 +3246,21 @@ fn generate_registration_code(
 		});
 	}
 
+	// Register explicit field indexes for migration state generation.
+	let index_registrations: Vec<TokenStream> = indexed_fields
+		.iter()
+		.map(|field_name| {
+			let index_name = format!("{}_{}_idx", table_name, field_name);
+			quote! {
+				metadata.add_index(#migrations_crate::IndexDefinition {
+					name: #index_name.to_string(),
+					fields: vec![#field_name.to_string()],
+					unique: false,
+				});
+			}
+		})
+		.collect();
+
 	// Generate FK _id field registration code
 	let mut fk_id_registrations = Vec::new();
 	for fk_info in fk_field_infos {
@@ -3381,6 +3398,7 @@ fn generate_registration_code(
 			#(#field_registrations)*
 			#(#fk_id_registrations)*
 			#(#m2m_registrations)*
+			#(#index_registrations)*
 			#(#constraint_registrations)*
 
 			#migrations_crate::model_registry::global_registry().register_model(metadata);

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2217,7 +2217,6 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		table_name,
 		&field_infos,
 		&fk_field_infos,
-		&indexed_fields,
 		&unique_constraint_names,
 		&unique_constraint_field_lists,
 	)?;
@@ -3003,7 +3002,6 @@ fn generate_registration_code(
 	table_name: &str,
 	field_infos: &[FieldInfo],
 	fk_field_infos: &[ForeignKeyFieldInfo],
-	indexed_fields: &[String],
 	unique_constraint_names: &[String],
 	unique_constraint_field_lists: &[Vec<String>],
 ) -> Result<TokenStream> {
@@ -3247,9 +3245,11 @@ fn generate_registration_code(
 	}
 
 	// Register explicit field indexes for migration state generation.
-	let index_registrations: Vec<TokenStream> = indexed_fields
+	let index_registrations: Vec<TokenStream> = field_infos
 		.iter()
-		.map(|field_name| {
+		.filter(|field_info| field_info.config.index.unwrap_or(false))
+		.map(|field_info| {
+			let field_name = field_info.name.to_string();
 			let index_name = format!("{}_{}_idx", table_name, field_name);
 			quote! {
 				metadata.add_index(#migrations_crate::IndexDefinition {

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -28,6 +28,7 @@ This crate provides the following modules:
   - Schema versioning and dependency management
   - Migration operations (CreateModel, AddField, AlterField, etc.)
   - State management and autodetection
+  - Automatic non-unique indexes for default-indexed foreign-key ID columns
   - CockroachDB concurrent migrator serialization with a sentinel-row lock
   - **State Loader** (`MigrationStateLoader`): Django-style state reconstruction
     - Build `ProjectState` by replaying migration history

--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -254,6 +254,36 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 					operator_class: None,
 				});
 			}
+			"CreateIndexRepair" => {
+				let table = extract_string_field(&expr_struct.fields, "table")?;
+				let name = extract_optional_str_field(&expr_struct.fields, "name");
+				let columns = extract_string_vec_field(&expr_struct.fields, "columns");
+				let unique = extract_bool_field(&expr_struct.fields, "unique").unwrap_or(false);
+				let index_type = extract_index_type_field(&expr_struct.fields, "index_type");
+				let where_clause = extract_optional_str_field(&expr_struct.fields, "where_clause");
+				let concurrently =
+					extract_bool_field(&expr_struct.fields, "concurrently").unwrap_or(false);
+				let expressions = {
+					let values = extract_string_vec_field(&expr_struct.fields, "expressions");
+					(!values.is_empty()).then_some(values)
+				};
+
+				return Some(super::Operation::CreateIndexRepair {
+					table,
+					name,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options: None,
+					operator_class: extract_optional_str_field(
+						&expr_struct.fields,
+						"operator_class",
+					),
+				});
+			}
 			"DropIndex" => {
 				let table = extract_string_field(&expr_struct.fields, "table")?;
 				let columns = extract_string_vec_field(&expr_struct.fields, "columns");

--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -250,7 +250,10 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 					where_clause,
 					concurrently,
 					expressions: None,
-					mysql_options: None,
+					mysql_options: extract_mysql_options_field(
+						&expr_struct.fields,
+						"mysql_options",
+					),
 					operator_class: None,
 				});
 			}
@@ -277,7 +280,10 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 					where_clause,
 					concurrently,
 					expressions,
-					mysql_options: None,
+					mysql_options: extract_mysql_options_field(
+						&expr_struct.fields,
+						"mysql_options",
+					),
 					operator_class: extract_optional_str_field(
 						&expr_struct.fields,
 						"operator_class",
@@ -312,7 +318,10 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 					where_clause,
 					concurrently,
 					expressions,
-					mysql_options: None,
+					mysql_options: extract_mysql_options_field(
+						&expr_struct.fields,
+						"mysql_options",
+					),
 					operator_class: extract_optional_str_field(
 						&expr_struct.fields,
 						"operator_class",
@@ -559,6 +568,92 @@ fn extract_index_type_field(
 		}
 	}
 	None
+}
+
+/// Extract serialized MySQL ALTER TABLE options from an optional struct field.
+fn extract_mysql_options_field(
+	fields: &syn::punctuated::Punctuated<syn::FieldValue, syn::token::Comma>,
+	field_name: &str,
+) -> Option<super::operations::AlterTableOptions> {
+	for field in fields {
+		if let syn::Member::Named(ident) = &field.member
+			&& ident == field_name
+		{
+			let Expr::Call(expr_call) = &field.expr else {
+				continue;
+			};
+			if !matches!(&*expr_call.func, Expr::Path(path) if path.path.is_ident("Some"))
+				|| expr_call.args.len() != 1
+			{
+				continue;
+			}
+			let Expr::Struct(options) = &expr_call.args[0] else {
+				continue;
+			};
+			if options
+				.path
+				.segments
+				.last()
+				.is_none_or(|segment| segment.ident != "AlterTableOptions")
+			{
+				continue;
+			}
+			return Some(super::operations::AlterTableOptions {
+				algorithm: extract_mysql_algorithm_field(&options.fields, "algorithm"),
+				lock: extract_mysql_lock_field(&options.fields, "lock"),
+			});
+		}
+	}
+	None
+}
+
+fn extract_optional_enum_variant(
+	fields: &syn::punctuated::Punctuated<syn::FieldValue, syn::token::Comma>,
+	field_name: &str,
+) -> Option<String> {
+	for field in fields {
+		if let syn::Member::Named(ident) = &field.member
+			&& ident == field_name
+			&& let Expr::Call(expr_call) = &field.expr
+			&& let Expr::Path(func_path) = &*expr_call.func
+			&& func_path.path.is_ident("Some")
+			&& expr_call.args.len() == 1
+			&& let Expr::Path(variant_path) = &expr_call.args[0]
+		{
+			return variant_path
+				.path
+				.segments
+				.last()
+				.map(|segment| segment.ident.to_string());
+		}
+	}
+	None
+}
+
+fn extract_mysql_algorithm_field(
+	fields: &syn::punctuated::Punctuated<syn::FieldValue, syn::token::Comma>,
+	field_name: &str,
+) -> Option<super::operations::MySqlAlgorithm> {
+	match extract_optional_enum_variant(fields, field_name).as_deref() {
+		Some("Instant") => Some(super::operations::MySqlAlgorithm::Instant),
+		Some("Inplace") => Some(super::operations::MySqlAlgorithm::Inplace),
+		Some("Copy") => Some(super::operations::MySqlAlgorithm::Copy),
+		Some("Default") => Some(super::operations::MySqlAlgorithm::Default),
+		_ => None,
+	}
+}
+
+fn extract_mysql_lock_field(
+	fields: &syn::punctuated::Punctuated<syn::FieldValue, syn::token::Comma>,
+	field_name: &str,
+) -> Option<super::operations::MySqlLock> {
+	match extract_optional_enum_variant(fields, field_name).as_deref() {
+		Some("None") => Some(super::operations::MySqlLock::None),
+		Some("Shared") => Some(super::operations::MySqlLock::Shared),
+		Some("Exclusive") => Some(super::operations::MySqlLock::Exclusive),
+		Some("Default") => Some(super::operations::MySqlLock::Default),
+		_ => None,
+	}
 }
 
 /// Extract `Vec<String>` from vec!["str".to_string(), ...] pattern
@@ -1376,6 +1471,39 @@ mod tests {
 			Some("name".into())
 		);
 		assert_eq!(extract_string_literal(&parse_expr("42")), None);
+	}
+
+	#[test]
+	fn parses_index_repair_mysql_options() {
+		let operation = parse_single_operation(&parse_expr(
+			r#"Operation::CreateIndexRepair {
+				table: "accounts",
+				name: Some("accounts_email_idx".to_string()),
+				columns: vec!["email".to_string()],
+				unique: false,
+				index_type: None,
+				where_clause: None,
+				concurrently: false,
+				expressions: None,
+				mysql_options: Some(AlterTableOptions {
+					algorithm: Some(MySqlAlgorithm::Inplace),
+					lock: Some(MySqlLock::None),
+				}),
+				operator_class: None,
+			}"#,
+		))
+		.expect("CreateIndexRepair should parse");
+
+		assert!(matches!(
+			operation,
+			super::super::Operation::CreateIndexRepair {
+				name: Some(name),
+				mysql_options: Some(options),
+				..
+			} if name == "accounts_email_idx"
+				&& options.algorithm == Some(super::super::operations::MySqlAlgorithm::Inplace)
+				&& options.lock == Some(super::super::operations::MySqlLock::None)
+		));
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/ast_parser.rs
+++ b/crates/reinhardt-db/src/migrations/ast_parser.rs
@@ -289,6 +289,36 @@ fn parse_single_operation(expr: &Expr) -> Option<super::Operation> {
 				let columns = extract_string_vec_field(&expr_struct.fields, "columns");
 				return Some(super::Operation::DropIndex { table, columns });
 			}
+			"DropNamedIndex" => {
+				let table = extract_string_field(&expr_struct.fields, "table")?;
+				let name = extract_string_field(&expr_struct.fields, "name")?;
+				let columns = extract_string_vec_field(&expr_struct.fields, "columns");
+				let unique = extract_bool_field(&expr_struct.fields, "unique").unwrap_or(false);
+				let index_type = extract_index_type_field(&expr_struct.fields, "index_type");
+				let where_clause = extract_optional_str_field(&expr_struct.fields, "where_clause");
+				let concurrently =
+					extract_bool_field(&expr_struct.fields, "concurrently").unwrap_or(false);
+				let expressions = {
+					let values = extract_string_vec_field(&expr_struct.fields, "expressions");
+					(!values.is_empty()).then_some(values)
+				};
+
+				return Some(super::Operation::DropNamedIndex {
+					table,
+					name,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options: None,
+					operator_class: extract_optional_str_field(
+						&expr_struct.fields,
+						"operator_class",
+					),
+				});
+			}
 			"AddConstraint" => {
 				let table = extract_string_field(&expr_struct.fields, "table")?;
 				let constraint_sql = extract_string_field(&expr_struct.fields, "constraint_sql")?;
@@ -395,6 +425,13 @@ fn extract_string_vec(expr: &Expr) -> Vec<String> {
 	let mut result = Vec::new();
 
 	match expr {
+		Expr::Call(expr_call)
+			if let Expr::Path(expr_path) = &*expr_call.func
+				&& expr_path.path.is_ident("Some")
+				&& expr_call.args.len() == 1 =>
+		{
+			return extract_string_vec(&expr_call.args[0]);
+		}
 		Expr::Macro(expr_macro) if expr_macro.mac.path.is_ident("vec") => {
 			let tokens = &expr_macro.mac.tokens;
 			if let Ok(parsed) = syn::parse2::<syn::ExprArray>(quote::quote! { [#tokens] }) {

--- a/crates/reinhardt-db/src/migrations/auto_migration.rs
+++ b/crates/reinhardt-db/src/migrations/auto_migration.rs
@@ -248,11 +248,55 @@ impl AutoMigrationGenerator {
 				Operation::DropConstraint { .. } => None, // Cannot rollback without constraint SQL
 
 				// Index operations
-				Operation::CreateIndex { table, columns, .. } => Some(Operation::DropIndex {
+				Operation::CreateIndex {
+					table,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options,
+					operator_class,
+				} => Some(Operation::DropNamedIndex {
 					table: table.clone(),
+					name: super::operations::generated_index_name(
+						table,
+						columns,
+						expressions.as_deref(),
+					),
 					columns: columns.clone(),
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
 				}),
 				Operation::DropIndex { .. } => None, // Cannot rollback without index definition
+				Operation::DropNamedIndex {
+					table,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options,
+					operator_class,
+					..
+				} => Some(Operation::CreateIndex {
+					table: table.clone(),
+					columns: columns.clone(),
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
+				}),
 
 				// Special operations
 				Operation::RunSQL { reverse_sql, .. } => {

--- a/crates/reinhardt-db/src/migrations/auto_migration.rs
+++ b/crates/reinhardt-db/src/migrations/auto_migration.rs
@@ -274,9 +274,39 @@ impl AutoMigrationGenerator {
 					mysql_options: *mysql_options,
 					operator_class: operator_class.clone(),
 				}),
+				Operation::CreateIndexRepair {
+					table,
+					name,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options,
+					operator_class,
+				} => Some(Operation::DropNamedIndex {
+					table: table.clone(),
+					name: name.clone().unwrap_or_else(|| {
+						super::operations::generated_index_name(
+							table,
+							columns,
+							expressions.as_deref(),
+						)
+					}),
+					columns: columns.clone(),
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
+				}),
 				Operation::DropIndex { .. } => None, // Cannot rollback without index definition
 				Operation::DropNamedIndex {
 					table,
+					name,
 					columns,
 					unique,
 					index_type,
@@ -286,8 +316,9 @@ impl AutoMigrationGenerator {
 					mysql_options,
 					operator_class,
 					..
-				} => Some(Operation::CreateIndex {
+				} => Some(Operation::CreateIndexRepair {
 					table: table.clone(),
+					name: Some(name.clone()),
 					columns: columns.clone(),
 					unique: *unique,
 					index_type: *index_type,

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -226,8 +226,9 @@ pub struct IndexDefinition {
 
 impl IndexDefinition {
 	fn create_operation(&self, table: &str) -> super::Operation {
-		super::Operation::CreateIndex {
+		super::Operation::CreateIndexRepair {
 			table: table.to_string(),
+			name: Some(self.name.clone()),
 			columns: self.fields.clone(),
 			unique: self.unique,
 			index_type: self.index_type,
@@ -261,10 +262,11 @@ fn advanced_index_option_key(name: &str) -> String {
 	format!("{ADVANCED_INDEX_OPTION_PREFIX}{name}")
 }
 
-fn model_index_is_advanced(model: &ModelState, index: &IndexDefinition) -> bool {
-	model
-		.options
-		.contains_key(&advanced_index_option_key(&index.name))
+fn model_index_is_advanced(_model: &ModelState, index: &IndexDefinition) -> bool {
+	index.where_clause.is_some()
+		|| index.index_type.is_some()
+		|| index.expressions.is_some()
+		|| index.operator_class.is_some()
 }
 
 fn model_index_definitions_equivalent(
@@ -292,8 +294,6 @@ pub(crate) fn index_definitions_equivalent(
 		&& left.where_clause == right.where_clause
 		&& left.index_type == right.index_type
 		&& left.expressions == right.expressions
-		&& left.concurrently == right.concurrently
-		&& left.mysql_options == right.mysql_options
 		&& left.operator_class == right.operator_class
 }
 
@@ -1341,6 +1341,45 @@ impl ProjectState {
 						}
 					}
 				}
+				Operation::CreateIndexRepair {
+					table,
+					name,
+					columns,
+					unique,
+					index_type,
+					where_clause,
+					concurrently,
+					expressions,
+					mysql_options,
+					operator_class,
+				} => {
+					let name = name.clone().unwrap_or_else(|| {
+						super::operations::generated_index_name(
+							table,
+							columns,
+							expressions.as_deref(),
+						)
+					});
+					let index = IndexDefinition {
+						name,
+						fields: columns.clone(),
+						unique: *unique,
+						where_clause: where_clause.clone(),
+						index_type: *index_type,
+						expressions: expressions.clone(),
+						concurrently: *concurrently,
+						mysql_options: mysql_options.clone(),
+						operator_class: operator_class.clone(),
+					};
+					if let Some(model) = self.find_model_by_table_mut(table)
+						&& !model
+							.indexes
+							.iter()
+							.any(|existing| index_definitions_equivalent(existing, &index))
+					{
+						model.indexes.push(index);
+					}
+				}
 				Operation::DropIndex { table, columns } => {
 					if let Some(model) = self.find_model_by_table_mut(table) {
 						let removed_names: Vec<_> = model
@@ -1389,13 +1428,25 @@ impl ProjectState {
 						let removed_names: Vec<_> = model
 							.indexes
 							.iter()
-							.filter(|index| index.fields.iter().any(|field| field == column))
+							.filter(|index| {
+								index.fields.iter().any(|field| field == column)
+									|| index.expressions.as_deref().is_some_and(|expressions| {
+										expressions.iter().any(|expression| {
+											Self::expression_references_column(expression, column)
+										})
+									})
+							})
 							.map(|index| index.name.clone())
 							.collect();
 						model.fields.remove(column);
-						model
-							.indexes
-							.retain(|index| !index.fields.iter().any(|field| field == column));
+						model.indexes.retain(|index| {
+							!index.fields.iter().any(|field| field == column)
+								&& !index.expressions.as_deref().is_some_and(|expressions| {
+									expressions.iter().any(|expression| {
+										Self::expression_references_column(expression, column)
+									})
+								})
+						});
 						for name in removed_names {
 							model.options.remove(&advanced_index_option_key(&name));
 						}
@@ -1563,6 +1614,34 @@ impl ProjectState {
 				}
 			}
 		}
+	}
+
+	fn expression_references_column(expression: &str, column: &str) -> bool {
+		let mut token = String::new();
+		let mut in_string = false;
+
+		for character in expression.chars() {
+			if character == '\'' {
+				in_string = !in_string;
+				if !in_string {
+					token.clear();
+				}
+				continue;
+			}
+			if in_string {
+				continue;
+			}
+			if character.is_ascii_alphanumeric() || character == '_' {
+				token.push(character);
+			} else if !token.is_empty() {
+				if token.eq_ignore_ascii_case(column) {
+					return true;
+				}
+				token.clear();
+			}
+		}
+
+		!token.is_empty() && token.eq_ignore_ascii_case(column)
 	}
 
 	/// Helper: Find a model by table name (immutable)
@@ -5863,6 +5942,7 @@ impl MigrationAutodetector {
 			| super::Operation::AddConstraint { table, .. }
 			| super::Operation::DropConstraint { table, .. }
 			| super::Operation::CreateIndex { table, .. }
+			| super::Operation::CreateIndexRepair { table, .. }
 			| super::Operation::DropIndex { table, .. }
 			| super::Operation::DropNamedIndex { table, .. }
 			| super::Operation::CreateCompositePrimaryKey { table, .. }
@@ -6035,6 +6115,15 @@ impl MigrationAutodetector {
 					{
 						after_rename.push(operation);
 					}
+					super::Operation::CreateIndexRepair {
+						table: index_table,
+						columns,
+						..
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &new_name) =>
+					{
+						after_rename.push(operation);
+					}
 					_ => prefix_without_recreated_indexes.push(operation),
 				}
 			}
@@ -6058,6 +6147,15 @@ impl MigrationAutodetector {
 						before_rename.push(operation);
 					}
 					super::Operation::CreateIndex {
+						table: index_table,
+						columns,
+						..
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &new_name) =>
+					{
+						after_rename.push(operation);
+					}
+					super::Operation::CreateIndexRepair {
 						table: index_table,
 						columns,
 						..
@@ -7191,6 +7289,11 @@ impl MigrationAutodetector {
 					apps.insert(model.app_label.clone());
 				}
 			}
+			if let super::Operation::MoveModel { from_app, .. } = operation
+				&& from_app != current_app
+			{
+				apps.insert(from_app.clone());
+			}
 		}
 		apps.into_iter().collect()
 	}
@@ -7593,7 +7696,11 @@ mod tests {
 			operations
 				.iter()
 				.filter(|operation| {
-					matches!(operation, super::super::Operation::CreateIndex { .. })
+					matches!(
+						operation,
+						super::super::Operation::CreateIndex { .. }
+							| super::super::Operation::CreateIndexRepair { .. }
+					)
 				})
 				.count(),
 			1
@@ -7669,7 +7776,13 @@ mod tests {
 			.expect("advanced index replacement should drop the old index");
 		let create_position = replacement_operations
 			.iter()
-			.position(|operation| matches!(operation, super::super::Operation::CreateIndex { .. }))
+			.position(|operation| {
+				matches!(
+					operation,
+					super::super::Operation::CreateIndex { .. }
+						| super::super::Operation::CreateIndexRepair { .. }
+				)
+			})
 			.expect("advanced index replacement should create the ordinary index");
 		assert!(drop_position < create_position);
 		assert_eq!(
@@ -7799,10 +7912,23 @@ mod tests {
 			[
 				super::super::Operation::DropNamedIndex { name, .. },
 				super::super::Operation::MoveModel { .. },
-				super::super::Operation::CreateIndex { table, columns, unique: true, .. },
+				create,
 			] if name == "idx_legacy_user_email"
-				&& table == "accounts_user"
-				&& columns == &["email".to_string()]
+				&& matches!(
+					create,
+					super::super::Operation::CreateIndex {
+						table,
+						columns,
+						unique: true,
+						..
+					} | super::super::Operation::CreateIndexRepair {
+						table,
+						columns,
+						unique: true,
+						..
+					}
+					if table == "accounts_user" && columns == &["email".to_string()]
+				)
 		));
 	}
 
@@ -7901,7 +8027,13 @@ mod tests {
 			.expect("replacing an index should drop the previous definition");
 		let create_position = operations
 			.iter()
-			.position(|operation| matches!(operation, super::super::Operation::CreateIndex { .. }))
+			.position(|operation| {
+				matches!(
+					operation,
+					super::super::Operation::CreateIndex { .. }
+						| super::super::Operation::CreateIndexRepair { .. }
+				)
+			})
 			.expect("replacing an index should create the new definition");
 		assert!(drop_position < create_position);
 	}

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -276,6 +276,7 @@ fn model_index_definitions_equivalent(
 	right: &IndexDefinition,
 ) -> bool {
 	index_definitions_equivalent(left, right)
+		&& (left_model.table_name != right_model.table_name || left.name == right.name)
 		&& model_index_is_advanced(left_model, left) == model_index_is_advanced(right_model, right)
 }
 
@@ -1382,18 +1383,12 @@ impl ProjectState {
 				}
 				Operation::DropIndex { table, columns } => {
 					if let Some(model) = self.find_model_by_table_mut(table) {
-						let removed_names: Vec<_> = model
-							.indexes
-							.iter()
-							.filter(|index| index.fields.as_slice() == columns.as_slice())
-							.map(|index| index.name.clone())
-							.collect();
+						let generated_name =
+							super::operations::generated_index_name(table, columns, None);
+						model.indexes.retain(|index| index.name != generated_name);
 						model
-							.indexes
-							.retain(|index| index.fields.as_slice() != columns.as_slice());
-						for name in removed_names {
-							model.options.remove(&advanced_index_option_key(&name));
-						}
+							.options
+							.remove(&advanced_index_option_key(&generated_name));
 					}
 				}
 				Operation::DropNamedIndex { table, name, .. } => {
@@ -1428,24 +1423,12 @@ impl ProjectState {
 						let removed_names: Vec<_> = model
 							.indexes
 							.iter()
-							.filter(|index| {
-								index.fields.iter().any(|field| field == column)
-									|| index.expressions.as_deref().is_some_and(|expressions| {
-										expressions.iter().any(|expression| {
-											Self::expression_references_column(expression, column)
-										})
-									})
-							})
+							.filter(|index| Self::index_definition_references_column(index, column))
 							.map(|index| index.name.clone())
 							.collect();
 						model.fields.remove(column);
 						model.indexes.retain(|index| {
-							!index.fields.iter().any(|field| field == column)
-								&& !index.expressions.as_deref().is_some_and(|expressions| {
-									expressions.iter().any(|expression| {
-										Self::expression_references_column(expression, column)
-									})
-								})
+							!Self::index_definition_references_column(index, column)
 						});
 						for name in removed_names {
 							model.options.remove(&advanced_index_option_key(&name));
@@ -1616,11 +1599,24 @@ impl ProjectState {
 		}
 	}
 
+	fn index_definition_references_column(index: &IndexDefinition, column: &str) -> bool {
+		index.fields.iter().any(|field| field == column)
+			|| index.expressions.as_deref().is_some_and(|expressions| {
+				expressions
+					.iter()
+					.any(|expression| Self::expression_references_column(expression, column))
+			}) || index
+			.where_clause
+			.as_deref()
+			.is_some_and(|where_clause| Self::expression_references_column(where_clause, column))
+	}
+
 	fn expression_references_column(expression: &str, column: &str) -> bool {
 		let mut token = String::new();
 		let mut in_string = false;
+		let mut characters = expression.chars().peekable();
 
-		for character in expression.chars() {
+		while let Some(character) = characters.next() {
 			if character == '\'' {
 				in_string = !in_string;
 				if !in_string {
@@ -1634,7 +1630,13 @@ impl ProjectState {
 			if character.is_ascii_alphanumeric() || character == '_' {
 				token.push(character);
 			} else if !token.is_empty() {
-				if token.eq_ignore_ascii_case(column) {
+				let is_function_call = character == '('
+					|| (character.is_ascii_whitespace()
+						&& characters
+							.clone()
+							.find(|next| !next.is_ascii_whitespace())
+							.is_some_and(|next| next == '('));
+				if !is_function_call && token.eq_ignore_ascii_case(column) {
 					return true;
 				}
 				token.clear();
@@ -6083,6 +6085,50 @@ impl MigrationAutodetector {
 		}
 	}
 
+	fn operation_index_references_column(
+		operation: &super::Operation,
+		table_name: &str,
+		column: &str,
+	) -> bool {
+		match operation {
+			super::Operation::CreateIndex {
+				table,
+				columns,
+				expressions,
+				where_clause,
+				..
+			}
+			| super::Operation::CreateIndexRepair {
+				table,
+				columns,
+				expressions,
+				where_clause,
+				..
+			}
+			| super::Operation::DropNamedIndex {
+				table,
+				columns,
+				expressions,
+				where_clause,
+				..
+			} => {
+				table == table_name
+					&& (columns.iter().any(|field| field == column)
+						|| expressions.as_deref().is_some_and(|expressions| {
+							expressions.iter().any(|expression| {
+								ProjectState::expression_references_column(expression, column)
+							})
+						}) || where_clause.as_deref().is_some_and(|where_clause| {
+						ProjectState::expression_references_column(where_clause, column)
+					}))
+			}
+			super::Operation::DropIndex { table, columns } => {
+				table == table_name && columns.iter().any(|field| field == column)
+			}
+			_ => false,
+		}
+	}
+
 	fn order_renamed_column_operations(operations: &mut Vec<super::Operation>) {
 		let mut index = 0;
 		while index < operations.len() {
@@ -6106,21 +6152,11 @@ impl MigrationAutodetector {
 			let mut prefix_without_recreated_indexes = Vec::new();
 			for operation in prefix {
 				match &operation {
-					super::Operation::CreateIndex {
-						table: index_table,
-						columns,
-						..
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &new_name) =>
-					{
-						after_rename.push(operation);
-					}
-					super::Operation::CreateIndexRepair {
-						table: index_table,
-						columns,
-						..
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &new_name) =>
+					super::Operation::CreateIndex { .. }
+					| super::Operation::CreateIndexRepair { .. }
+						if Self::operation_index_references_column(
+							&operation, &table, &new_name,
+						) =>
 					{
 						after_rename.push(operation);
 					}
@@ -6129,38 +6165,19 @@ impl MigrationAutodetector {
 			}
 			for operation in remaining {
 				match &operation {
-					super::Operation::DropIndex {
-						table: index_table,
-						columns,
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &old_name) =>
+					super::Operation::DropIndex { .. }
+					| super::Operation::DropNamedIndex { .. }
+						if Self::operation_index_references_column(
+							&operation, &table, &old_name,
+						) =>
 					{
 						before_rename.push(operation);
 					}
-					super::Operation::DropNamedIndex {
-						table: index_table,
-						columns,
-						..
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &old_name) =>
-					{
-						before_rename.push(operation);
-					}
-					super::Operation::CreateIndex {
-						table: index_table,
-						columns,
-						..
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &new_name) =>
-					{
-						after_rename.push(operation);
-					}
-					super::Operation::CreateIndexRepair {
-						table: index_table,
-						columns,
-						..
-					} if index_table == &table
-						&& columns.iter().any(|column| column == &new_name) =>
+					super::Operation::CreateIndex { .. }
+					| super::Operation::CreateIndexRepair { .. }
+						if Self::operation_index_references_column(
+							&operation, &table, &new_name,
+						) =>
 					{
 						after_rename.push(operation);
 					}
@@ -7852,6 +7869,151 @@ mod tests {
 	}
 
 	#[test]
+	fn detects_same_table_index_name_changes() {
+		// Arrange
+		let index = |name: &str| IndexDefinition {
+			name: name.to_string(),
+			fields: vec!["email".to_string()],
+			unique: false,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
+		};
+		let from_model = build_model_state(
+			"blog",
+			"Post",
+			vec![FieldState::new("email", FieldType::VarChar(255), false)],
+			vec![index("old_email_idx")],
+			Vec::new(),
+		);
+		let to_model = build_model_state(
+			"blog",
+			"Post",
+			vec![FieldState::new("email", FieldType::VarChar(255), false)],
+			vec![index("new_email_idx")],
+			Vec::new(),
+		);
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(("blog".to_string(), "Post".to_string()), from_model)]),
+			build_project_state(vec![(("blog".to_string(), "Post".to_string()), to_model)]),
+		);
+
+		// Act
+		let operations = detector.generate_operations();
+
+		// Assert
+		assert!(matches!(
+			operations.as_slice(),
+			[
+				super::super::Operation::DropNamedIndex { name: old, .. },
+				super::super::Operation::CreateIndexRepair { name: Some(new), .. },
+			] if old == "old_email_idx" && new == "new_email_idx"
+		));
+	}
+
+	#[test]
+	fn replays_drop_index_only_removes_generated_name() {
+		// Arrange
+		let mut model = ModelState::new("blog", "Post");
+		model.table_name = "blog_posts".to_string();
+		model.add_field(FieldState::new("email", FieldType::VarChar(255), false));
+		model.indexes = vec![
+			IndexDefinition {
+				name: "idx_blog_posts_email".to_string(),
+				fields: vec!["email".to_string()],
+				unique: false,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
+			},
+			IndexDefinition {
+				name: "custom_email_idx".to_string(),
+				fields: vec!["email".to_string()],
+				unique: true,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
+			},
+		];
+		let mut state = ProjectState::new();
+		state.add_model(model);
+		let drop = super::super::Operation::DropIndex {
+			table: "blog_posts".to_string(),
+			columns: vec!["email".to_string()],
+		};
+
+		// Act
+		state.apply_migration_operations(&[drop], "blog");
+
+		// Assert
+		let indexes = &state
+			.find_model_by_table("blog_posts")
+			.expect("replayed model")
+			.indexes;
+		assert_eq!(indexes.len(), 1);
+		assert_eq!(indexes[0].name, "custom_email_idx");
+	}
+
+	#[test]
+	fn replays_drop_column_predicate_and_ignores_function_name() {
+		// Arrange
+		assert!(!ProjectState::expression_references_column(
+			"LOWER(email)",
+			"lower"
+		));
+		assert!(ProjectState::expression_references_column(
+			"LOWER(email)",
+			"email"
+		));
+		let mut model = ModelState::new("blog", "Post");
+		model.table_name = "blog_posts".to_string();
+		model.add_field(FieldState::new("email", FieldType::VarChar(255), false));
+		model.add_field(FieldState::new("active", FieldType::Boolean, false));
+		let mut state = ProjectState::new();
+		state.add_model(model);
+		let create = super::super::Operation::CreateIndexRepair {
+			table: "blog_posts".to_string(),
+			name: Some("active_email_idx".to_string()),
+			columns: vec!["email".to_string()],
+			unique: false,
+			index_type: None,
+			where_clause: Some("active = TRUE".to_string()),
+			concurrently: false,
+			expressions: Some(vec!["LOWER(email)".to_string()]),
+			mysql_options: None,
+			operator_class: None,
+		};
+
+		// Act
+		state.apply_migration_operations(&[create], "blog");
+		state.apply_migration_operations(
+			&[super::super::Operation::DropColumn {
+				table: "blog_posts".to_string(),
+				column: "active".to_string(),
+			}],
+			"blog",
+		);
+
+		// Assert
+		assert!(
+			state
+				.find_model_by_table("blog_posts")
+				.expect("replayed model")
+				.indexes
+				.is_empty()
+		);
+	}
+
+	#[test]
 	fn generate_migrations_recreates_generated_indexes_around_cross_app_move() {
 		// Arrange
 		let old_index = IndexDefinition {
@@ -7969,6 +8131,42 @@ mod tests {
 				super::super::Operation::DropIndex { .. },
 				super::super::Operation::RenameColumn { .. },
 				super::super::Operation::CreateIndex { .. },
+			]
+		));
+	}
+
+	#[test]
+	fn reorders_predicate_index_drop_before_column_rename() {
+		// Arrange
+		let mut operations = vec![
+			super::super::Operation::RenameColumn {
+				table: "blog_posts".to_string(),
+				old_name: "active_old".to_string(),
+				new_name: "active_new".to_string(),
+			},
+			super::super::Operation::DropNamedIndex {
+				table: "blog_posts".to_string(),
+				name: "active_email_idx".to_string(),
+				columns: vec!["email".to_string()],
+				unique: false,
+				index_type: None,
+				where_clause: Some("active_old = TRUE".to_string()),
+				concurrently: false,
+				expressions: None,
+				mysql_options: None,
+				operator_class: None,
+			},
+		];
+
+		// Act
+		MigrationAutodetector::order_renamed_column_operations(&mut operations);
+
+		// Assert
+		assert!(matches!(
+			&operations[..],
+			[
+				super::super::Operation::DropNamedIndex { .. },
+				super::super::Operation::RenameColumn { .. },
 			]
 		));
 	}

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1229,6 +1229,10 @@ impl ProjectState {
 					table,
 					columns,
 					unique,
+					index_type,
+					where_clause,
+					expressions,
+					operator_class,
 					..
 				} => {
 					let index = IndexDefinition {
@@ -1236,6 +1240,15 @@ impl ProjectState {
 						fields: columns.clone(),
 						unique: *unique,
 					};
+					if where_clause.is_some()
+						|| index_type.is_some()
+						|| expressions.is_some()
+						|| operator_class.is_some()
+					{
+						// IndexDefinition cannot represent advanced index metadata, so do
+						// not add a lossy schema entry that could emit a bogus rollback.
+						continue;
+					}
 					if let Some(model) = self.find_model_by_table_mut(table)
 						&& !model
 							.indexes
@@ -1276,6 +1289,9 @@ impl ProjectState {
 					// Find the model and remove the field
 					if let Some(model) = self.find_model_by_table_mut(table) {
 						model.fields.remove(column);
+						model
+							.indexes
+							.retain(|index| !index.fields.iter().any(|field| field == column));
 						model.constraints.retain(|constraint| {
 							!constraint.fields.iter().any(|field| field == column)
 						});
@@ -1310,6 +1326,13 @@ impl ProjectState {
 				Operation::RenameTable { old_name, new_name } => {
 					// Find the model with old table name and update it
 					if let Some(model) = self.find_model_by_table_mut(old_name) {
+						for index in &mut model.indexes {
+							let old_default = default_index_name(old_name, &index.fields);
+							let old_legacy = format!("{}_{}_idx", old_name, index.fields.join("_"));
+							if index.name == old_default || index.name == old_legacy {
+								index.name = default_index_name(new_name, &index.fields);
+							}
+						}
 						model.table_name = new_name.to_string();
 					}
 				}
@@ -1321,6 +1344,22 @@ impl ProjectState {
 					// Find the model and rename the field
 					if let Some(model) = self.find_model_by_table_mut(table) {
 						model.rename_field(old_name, new_name.to_string());
+						for index in &mut model.indexes {
+							if !index.fields.iter().any(|field| field == old_name) {
+								continue;
+							}
+							let old_fields = index.fields.clone();
+							let old_default = default_index_name(table, &old_fields);
+							let old_legacy = format!("{}_{}_idx", table, old_fields.join("_"));
+							for field in &mut index.fields {
+								if field == old_name {
+									*field = new_name.to_string();
+								}
+							}
+							if index.name == old_default || index.name == old_legacy {
+								index.name = default_index_name(table, &index.fields);
+							}
+						}
 						for constraint in &mut model.constraints {
 							for field in &mut constraint.fields {
 								if field == old_name {
@@ -5770,6 +5809,59 @@ impl MigrationAutodetector {
 		}
 	}
 
+	fn order_renamed_column_operations(operations: &mut Vec<super::Operation>) {
+		let mut index = 0;
+		while index < operations.len() {
+			let (table, old_name, new_name) = match &operations[index] {
+				super::Operation::RenameColumn {
+					table,
+					old_name,
+					new_name,
+				} => (table.clone(), old_name.clone(), new_name.clone()),
+				_ => {
+					index += 1;
+					continue;
+				}
+			};
+
+			let mut remaining = std::mem::take(operations);
+			let rename_operation = remaining.remove(index);
+			let prefix = remaining.drain(..index).collect::<Vec<_>>();
+			let mut before_rename = Vec::new();
+			let mut after_rename = Vec::new();
+			for operation in remaining {
+				match &operation {
+					super::Operation::DropIndex {
+						table: index_table,
+						columns,
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &old_name) =>
+					{
+						before_rename.push(operation);
+					}
+					super::Operation::CreateIndex {
+						table: index_table,
+						columns,
+						..
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &new_name) =>
+					{
+						after_rename.push(operation);
+					}
+					_ => after_rename.push(operation),
+				}
+			}
+
+			let rename_position = prefix.len() + before_rename.len();
+			let mut reordered = prefix;
+			reordered.extend(before_rename);
+			reordered.push(rename_operation);
+			reordered.extend(after_rename);
+			*operations = reordered;
+			index = rename_position + 1;
+		}
+	}
+
 	/// Performs the generate operations operation.
 	pub fn generate_operations(&self) -> Vec<super::Operation> {
 		let changes = self.detect_changes();
@@ -5831,6 +5923,9 @@ impl MigrationAutodetector {
 		// `column.unique = true` *and* a peer `AddConstraint` is emitted for
 		// it. See reinhardt-web#4448.
 		Self::dedup_redundant_unique_add_constraints(&mut by_app);
+		for operations in by_app.values_mut() {
+			Self::order_renamed_column_operations(operations);
+		}
 
 		// Flatten and sort by dependency to ensure correct execution order.
 		let operations: Vec<super::Operation> = by_app.into_values().flatten().collect();
@@ -6334,21 +6429,57 @@ impl MigrationAutodetector {
 		for (app_label, old_name, new_name) in &changes.renamed_models {
 			if let Some(model) = self.to_state.get_model(app_label, new_name) {
 				// Get the old table name from from_state
-				let old_table_name = self
-					.from_state
-					.get_model(app_label, old_name)
-					.map(|m| m.table_name.clone())
-					.unwrap_or_else(|| format!("{}_{}", app_label, old_name.to_lowercase()));
+				let Some(old_model) = self.from_state.get_model(app_label, old_name) else {
+					continue;
+				};
+				let old_table_name = old_model.table_name.clone();
 
 				// Defense-in-depth: skip no-op renames where table name is unchanged
 				if old_table_name != model.table_name {
-					migrations_by_app
-						.entry(app_label.clone())
-						.or_default()
-						.push(super::Operation::RenameTable {
-							old_name: old_table_name,
-							new_name: model.table_name.clone(),
+					let renamed_indexes = old_model
+						.indexes
+						.iter()
+						.filter_map(|old_index| {
+							model
+								.indexes
+								.iter()
+								.find(|new_index| {
+									index_definitions_equivalent(old_index, new_index)
+								})
+								.filter(|new_index| old_index.name != new_index.name)
+								.map(|new_index| {
+									(
+										old_index.fields.clone(),
+										new_index.fields.clone(),
+										new_index.unique,
+									)
+								})
+						})
+						.collect::<Vec<_>>();
+					let operations = migrations_by_app.entry(app_label.clone()).or_default();
+					for (old_columns, _, _) in &renamed_indexes {
+						operations.push(super::Operation::DropIndex {
+							table: old_table_name.clone(),
+							columns: old_columns.clone(),
 						});
+					}
+					operations.push(super::Operation::RenameTable {
+						old_name: old_table_name,
+						new_name: model.table_name.clone(),
+					});
+					for (_, new_columns, unique) in renamed_indexes {
+						operations.push(super::Operation::CreateIndex {
+							table: model.table_name.clone(),
+							columns: new_columns,
+							unique,
+							index_type: None,
+							where_clause: None,
+							concurrently: false,
+							expressions: None,
+							mysql_options: None,
+							operator_class: None,
+						});
+					}
 				}
 			}
 		}
@@ -6410,6 +6541,7 @@ impl MigrationAutodetector {
 		Self::dedup_redundant_unique_add_constraints(&mut migrations_by_app);
 		for operations in migrations_by_app.values_mut() {
 			Self::order_renamed_table_operations(operations);
+			Self::order_renamed_column_operations(operations);
 		}
 
 		// Create Migration objects for each app

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -212,6 +212,19 @@ pub struct IndexDefinition {
 	pub unique: bool,
 }
 
+/// Build the physical index name used by `Operation::CreateIndex`.
+pub(crate) fn default_index_name(table: &str, fields: &[String]) -> String {
+	format!("idx_{}_{}", table, fields.join("_"))
+}
+
+/// Compare indexes by schema semantics rather than generated names.
+pub(crate) fn index_definitions_equivalent(
+	left: &IndexDefinition,
+	right: &IndexDefinition,
+) -> bool {
+	left.fields == right.fields && left.unique == right.unique
+}
+
 /// Constraint definition for a model
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConstraintDefinition {
@@ -1175,6 +1188,7 @@ impl ProjectState {
 	/// - AlterColumn: Modifies a field
 	/// - RenameTable: Renames a model's table
 	/// - RenameColumn: Renames a field
+	/// - CreateIndex/DropIndex: Tracks model indexes
 	/// - Other operations are logged but not applied to state
 	pub fn apply_migration_operations(
 		&mut self,
@@ -1210,6 +1224,33 @@ impl ProjectState {
 					}
 
 					self.add_model(model);
+				}
+				Operation::CreateIndex {
+					table,
+					columns,
+					unique,
+					..
+				} => {
+					let index = IndexDefinition {
+						name: default_index_name(table, columns),
+						fields: columns.clone(),
+						unique: *unique,
+					};
+					if let Some(model) = self.find_model_by_table_mut(table)
+						&& !model
+							.indexes
+							.iter()
+							.any(|existing| index_definitions_equivalent(existing, &index))
+					{
+						model.indexes.push(index);
+					}
+				}
+				Operation::DropIndex { table, columns } => {
+					if let Some(model) = self.find_model_by_table_mut(table) {
+						model
+							.indexes
+							.retain(|index| index.fields.as_slice() != columns.as_slice());
+					}
 				}
 				Operation::DropTable { name } => {
 					// Find and remove the model with this table name
@@ -1313,7 +1354,7 @@ impl ProjectState {
 				}
 				// Other operations don't affect the schema state in ways we track.
 				_ => {
-					// Operations like CreateIndex, DropIndex, RunSQL, etc. are not
+					// Operations like RunSQL and other backend-only operations are not
 					// currently tracked in ProjectState.
 				}
 			}
@@ -4924,7 +4965,7 @@ impl MigrationAutodetector {
 					if !from_model
 						.indexes
 						.iter()
-						.any(|idx| idx.name == to_index.name)
+						.any(|idx| index_definitions_equivalent(idx, to_index))
 					{
 						changes.added_indexes.push((
 							app_label.clone(),
@@ -4951,7 +4992,7 @@ impl MigrationAutodetector {
 					if !to_model
 						.indexes
 						.iter()
-						.any(|idx| idx.name == from_index.name)
+						.any(|idx| index_definitions_equivalent(idx, from_index))
 					{
 						changes.removed_indexes.push((
 							app_label.clone(),
@@ -5843,6 +5884,22 @@ impl MigrationAutodetector {
 						interleave_in_parent: None,
 						partition: None,
 					});
+
+				for index in &model.indexes {
+					by_app.entry(app_label.clone()).or_default().push(
+						super::Operation::CreateIndex {
+							table: model.table_name.clone(),
+							columns: index.fields.clone(),
+							unique: index.unique,
+							index_type: None,
+							where_clause: None,
+							concurrently: false,
+							expressions: None,
+							mysql_options: None,
+							operator_class: None,
+						},
+					);
+				}
 			}
 		}
 
@@ -5867,6 +5924,26 @@ impl MigrationAutodetector {
 							field,
 						),
 						mysql_options: None,
+					});
+			}
+		}
+
+		// CreateIndex for indexes added to existing models.
+		for (app_label, model_name, index) in &changes.added_indexes {
+			if let Some(model) = self.to_state.get_model(app_label, model_name) {
+				by_app
+					.entry(app_label.clone())
+					.or_default()
+					.push(super::Operation::CreateIndex {
+						table: model.table_name.clone(),
+						columns: index.fields.clone(),
+						unique: index.unique,
+						index_type: None,
+						where_clause: None,
+						concurrently: false,
+						expressions: None,
+						mysql_options: None,
+						operator_class: None,
 					});
 			}
 		}
@@ -5911,6 +5988,24 @@ impl MigrationAutodetector {
 						mysql_options: None,
 					});
 			}
+		}
+
+		// DropIndex before dropping columns so the generated SQL remains valid
+		// on backends that do not remove dependent indexes automatically.
+		for (app_label, model_name, index_name) in &changes.removed_indexes {
+			let Some(model) = self.from_state.get_model(app_label, model_name) else {
+				continue;
+			};
+			let Some(index) = model.indexes.iter().find(|index| &index.name == index_name) else {
+				continue;
+			};
+			by_app
+				.entry(app_label.clone())
+				.or_default()
+				.push(super::Operation::DropIndex {
+					table: model.table_name.clone(),
+					columns: index.fields.clone(),
+				});
 		}
 
 		// DropColumn for removed fields.
@@ -6754,6 +6849,7 @@ impl ModelState {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::migrations::FieldType;
 	use rstest::rstest;
 
 	/// Helper to build a ProjectState with given models
@@ -6850,6 +6946,52 @@ mod tests {
 		assert_eq!(fk_info.referenced_columns, vec!["id".to_string()]);
 		assert_eq!(fk_info.on_delete, ForeignKeyAction::Cascade);
 		assert_eq!(fk_info.on_update, ForeignKeyAction::NoAction);
+	}
+
+	#[test]
+	fn generated_indexes_are_replayed_without_second_migration() {
+		// Arrange
+		let mut target = ProjectState::new();
+		let mut post = ModelState::new("blog", "Post");
+		post.table_name = "blog_posts".to_string();
+		post.add_field(FieldState::new("id", FieldType::Integer, false));
+		post.add_field(FieldState::new("author_id", FieldType::Uuid, false));
+		post.indexes.push(IndexDefinition {
+			name: "idx_blog_posts_author_id".to_string(),
+			fields: vec!["author_id".to_string()],
+			unique: false,
+		});
+		target.add_model(post);
+
+		// Act
+		let operations =
+			MigrationAutodetector::new(ProjectState::new(), target.clone()).generate_operations();
+		let mut replayed = ProjectState::new();
+		replayed.apply_migration_operations(&operations, "blog");
+		let second_run = MigrationAutodetector::new(replayed.clone(), target).generate_operations();
+
+		// Assert
+		assert_eq!(
+			operations
+				.iter()
+				.filter(|operation| {
+					matches!(operation, super::super::Operation::CreateIndex { .. })
+				})
+				.count(),
+			1
+		);
+		assert_eq!(
+			replayed
+				.find_model_by_table("blog_posts")
+				.unwrap()
+				.indexes
+				.len(),
+			1
+		);
+		assert!(
+			second_run.is_empty(),
+			"unexpected second migration: {second_run:?}"
+		);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1368,7 +1368,7 @@ impl ProjectState {
 						index_type: *index_type,
 						expressions: expressions.clone(),
 						concurrently: *concurrently,
-						mysql_options: mysql_options.clone(),
+						mysql_options: *mysql_options,
 						operator_class: operator_class.clone(),
 					};
 					if let Some(model) = self.find_model_by_table_mut(table)

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1321,7 +1321,7 @@ impl ProjectState {
 						index_type: *index_type,
 						expressions: expressions.clone(),
 						concurrently: *concurrently,
-						mysql_options: mysql_options.clone(),
+						mysql_options: *mysql_options,
 						operator_class: operator_class.clone(),
 					};
 					let is_advanced = where_clause.is_some()

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -212,6 +212,28 @@ pub struct IndexDefinition {
 	pub unique: bool,
 }
 
+const ADVANCED_INDEX_OPTION_PREFIX: &str = "__reinhardt_advanced_index__:";
+
+fn advanced_index_option_key(name: &str) -> String {
+	format!("{ADVANCED_INDEX_OPTION_PREFIX}{name}")
+}
+
+fn model_index_is_advanced(model: &ModelState, index: &IndexDefinition) -> bool {
+	model
+		.options
+		.contains_key(&advanced_index_option_key(&index.name))
+}
+
+fn model_index_definitions_equivalent(
+	left_model: &ModelState,
+	left: &IndexDefinition,
+	right_model: &ModelState,
+	right: &IndexDefinition,
+) -> bool {
+	index_definitions_equivalent(left, right)
+		&& model_index_is_advanced(left_model, left) == model_index_is_advanced(right_model, right)
+}
+
 /// Build the physical index name used by `Operation::CreateIndex`.
 pub(crate) fn default_index_name(table: &str, fields: &[String]) -> String {
 	format!("idx_{}_{}", table, fields.join("_"))
@@ -1240,29 +1262,37 @@ impl ProjectState {
 						fields: columns.clone(),
 						unique: *unique,
 					};
-					if where_clause.is_some()
+					let is_advanced = where_clause.is_some()
 						|| index_type.is_some()
 						|| expressions.is_some()
-						|| operator_class.is_some()
-					{
-						// IndexDefinition cannot represent advanced index metadata, so do
-						// not add a lossy schema entry that could emit a bogus rollback.
-						continue;
-					}
+						|| operator_class.is_some();
 					if let Some(model) = self.find_model_by_table_mut(table)
-						&& !model
-							.indexes
-							.iter()
-							.any(|existing| index_definitions_equivalent(existing, &index))
-					{
-						model.indexes.push(index);
+						&& !model.indexes.iter().any(|existing| {
+							index_definitions_equivalent(existing, &index)
+								&& model_index_is_advanced(model, existing) == is_advanced
+						}) {
+						model.indexes.push(index.clone());
+						if is_advanced {
+							model
+								.options
+								.insert(advanced_index_option_key(&index.name), "true".to_string());
+						}
 					}
 				}
 				Operation::DropIndex { table, columns } => {
 					if let Some(model) = self.find_model_by_table_mut(table) {
+						let removed_names: Vec<_> = model
+							.indexes
+							.iter()
+							.filter(|index| index.fields.as_slice() == columns.as_slice())
+							.map(|index| index.name.clone())
+							.collect();
 						model
 							.indexes
 							.retain(|index| index.fields.as_slice() != columns.as_slice());
+						for name in removed_names {
+							model.options.remove(&advanced_index_option_key(&name));
+						}
 					}
 				}
 				Operation::DropTable { name } => {
@@ -1288,10 +1318,19 @@ impl ProjectState {
 				Operation::DropColumn { table, column } => {
 					// Find the model and remove the field
 					if let Some(model) = self.find_model_by_table_mut(table) {
+						let removed_names: Vec<_> = model
+							.indexes
+							.iter()
+							.filter(|index| index.fields.iter().any(|field| field == column))
+							.map(|index| index.name.clone())
+							.collect();
 						model.fields.remove(column);
 						model
 							.indexes
 							.retain(|index| !index.fields.iter().any(|field| field == column));
+						for name in removed_names {
+							model.options.remove(&advanced_index_option_key(&name));
+						}
 						model.constraints.retain(|constraint| {
 							!constraint.fields.iter().any(|field| field == column)
 						});
@@ -1326,12 +1365,38 @@ impl ProjectState {
 				Operation::RenameTable { old_name, new_name } => {
 					// Find the model with old table name and update it
 					if let Some(model) = self.find_model_by_table_mut(old_name) {
+						let advanced_index_renames: Vec<_> = model
+							.indexes
+							.iter()
+							.filter(|index| model_index_is_advanced(model, index))
+							.map(|index| {
+								let old_default = default_index_name(old_name, &index.fields);
+								let old_legacy =
+									format!("{}_{}_idx", old_name, index.fields.join("_"));
+								let renamed_index_name =
+									if index.name == old_default || index.name == old_legacy {
+										default_index_name(new_name, &index.fields)
+									} else {
+										index.name.clone()
+									};
+								(index.name.clone(), renamed_index_name)
+							})
+							.collect();
 						for index in &mut model.indexes {
 							let old_default = default_index_name(old_name, &index.fields);
 							let old_legacy = format!("{}_{}_idx", old_name, index.fields.join("_"));
 							if index.name == old_default || index.name == old_legacy {
 								index.name = default_index_name(new_name, &index.fields);
 							}
+						}
+						for (old_index_name, new_index_name) in advanced_index_renames {
+							model
+								.options
+								.remove(&advanced_index_option_key(&old_index_name));
+							model.options.insert(
+								advanced_index_option_key(&new_index_name),
+								"true".to_string(),
+							);
 						}
 						model.table_name = new_name.to_string();
 					}
@@ -1343,6 +1408,29 @@ impl ProjectState {
 				} => {
 					// Find the model and rename the field
 					if let Some(model) = self.find_model_by_table_mut(table) {
+						let advanced_index_renames: Vec<_> = model
+							.indexes
+							.iter()
+							.filter(|index| model_index_is_advanced(model, index))
+							.map(|index| {
+								let old_fields = index.fields.clone();
+								let old_default = default_index_name(table, &old_fields);
+								let old_legacy = format!("{}_{}_idx", table, old_fields.join("_"));
+								let mut new_fields = old_fields.clone();
+								for field in &mut new_fields {
+									if field == old_name {
+										*field = new_name.clone();
+									}
+								}
+								let new_index_name =
+									if index.name == old_default || index.name == old_legacy {
+										default_index_name(table, &new_fields)
+									} else {
+										index.name.clone()
+									};
+								(index.name.clone(), new_index_name)
+							})
+							.collect();
 						model.rename_field(old_name, new_name.to_string());
 						for index in &mut model.indexes {
 							if !index.fields.iter().any(|field| field == old_name) {
@@ -1359,6 +1447,15 @@ impl ProjectState {
 							if index.name == old_default || index.name == old_legacy {
 								index.name = default_index_name(table, &index.fields);
 							}
+						}
+						for (old_index_name, new_index_name) in advanced_index_renames {
+							model
+								.options
+								.remove(&advanced_index_option_key(&old_index_name));
+							model.options.insert(
+								advanced_index_option_key(&new_index_name),
+								"true".to_string(),
+							);
 						}
 						for constraint in &mut model.constraints {
 							for field in &mut constraint.fields {
@@ -5001,11 +5098,9 @@ impl MigrationAutodetector {
 			{
 				for to_index in &to_model.indexes {
 					// Check if this index exists in from_model
-					if !from_model
-						.indexes
-						.iter()
-						.any(|idx| index_definitions_equivalent(idx, to_index))
-					{
+					if !from_model.indexes.iter().any(|idx| {
+						model_index_definitions_equivalent(from_model, idx, to_model, to_index)
+					}) {
 						changes.added_indexes.push((
 							app_label.clone(),
 							model_name.clone(),
@@ -5028,11 +5123,9 @@ impl MigrationAutodetector {
 			{
 				for from_index in &from_model.indexes {
 					// Check if this index still exists in to_model
-					if !to_model
-						.indexes
-						.iter()
-						.any(|idx| index_definitions_equivalent(idx, from_index))
-					{
+					if !to_model.indexes.iter().any(|idx| {
+						model_index_definitions_equivalent(from_model, from_index, to_model, idx)
+					}) {
 						changes.removed_indexes.push((
 							app_label.clone(),
 							model_name.clone(),
@@ -5829,6 +5922,21 @@ impl MigrationAutodetector {
 			let prefix = remaining.drain(..index).collect::<Vec<_>>();
 			let mut before_rename = Vec::new();
 			let mut after_rename = Vec::new();
+			let mut prefix_without_recreated_indexes = Vec::new();
+			for operation in prefix {
+				match &operation {
+					super::Operation::CreateIndex {
+						table: index_table,
+						columns,
+						..
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &new_name) =>
+					{
+						after_rename.push(operation);
+					}
+					_ => prefix_without_recreated_indexes.push(operation),
+				}
+			}
 			for operation in remaining {
 				match &operation {
 					super::Operation::DropIndex {
@@ -5852,8 +5960,8 @@ impl MigrationAutodetector {
 				}
 			}
 
-			let rename_position = prefix.len() + before_rename.len();
-			let mut reordered = prefix;
+			let rename_position = prefix_without_recreated_indexes.len() + before_rename.len();
+			let mut reordered = prefix_without_recreated_indexes;
 			reordered.extend(before_rename);
 			reordered.push(rename_operation);
 			reordered.extend(after_rename);
@@ -6023,26 +6131,6 @@ impl MigrationAutodetector {
 			}
 		}
 
-		// CreateIndex for indexes added to existing models.
-		for (app_label, model_name, index) in &changes.added_indexes {
-			if let Some(model) = self.to_state.get_model(app_label, model_name) {
-				by_app
-					.entry(app_label.clone())
-					.or_default()
-					.push(super::Operation::CreateIndex {
-						table: model.table_name.clone(),
-						columns: index.fields.clone(),
-						unique: index.unique,
-						index_type: None,
-						where_clause: None,
-						concurrently: false,
-						expressions: None,
-						mysql_options: None,
-						operator_class: None,
-					});
-			}
-		}
-
 		// RenameColumn for confirmed field renames.
 		for (app_label, model_name, old_name, new_name) in &changes.renamed_fields {
 			if let Some(model) = self.to_state.get_model(app_label, model_name) {
@@ -6085,8 +6173,8 @@ impl MigrationAutodetector {
 			}
 		}
 
-		// DropIndex before dropping columns so the generated SQL remains valid
-		// on backends that do not remove dependent indexes automatically.
+		// DropIndex before recreating indexes or dropping columns so the generated
+		// SQL remains valid when an index changes only its uniqueness.
 		for (app_label, model_name, index_name) in &changes.removed_indexes {
 			let Some(model) = self.from_state.get_model(app_label, model_name) else {
 				continue;
@@ -6101,6 +6189,26 @@ impl MigrationAutodetector {
 					table: model.table_name.clone(),
 					columns: index.fields.clone(),
 				});
+		}
+
+		// CreateIndex for indexes added to existing models.
+		for (app_label, model_name, index) in &changes.added_indexes {
+			if let Some(model) = self.to_state.get_model(app_label, model_name) {
+				by_app
+					.entry(app_label.clone())
+					.or_default()
+					.push(super::Operation::CreateIndex {
+						table: model.table_name.clone(),
+						columns: index.fields.clone(),
+						unique: index.unique,
+						index_type: None,
+						where_clause: None,
+						concurrently: false,
+						expressions: None,
+						mysql_options: None,
+						operator_class: None,
+					});
+			}
 		}
 
 		// DropColumn for removed fields.
@@ -6444,7 +6552,9 @@ impl MigrationAutodetector {
 								.indexes
 								.iter()
 								.find(|new_index| {
-									index_definitions_equivalent(old_index, new_index)
+									model_index_definitions_equivalent(
+										old_model, old_index, model, new_index,
+									)
 								})
 								.filter(|new_index| old_index.name != new_index.name)
 								.map(|new_index| {
@@ -7124,6 +7234,153 @@ mod tests {
 			second_run.is_empty(),
 			"unexpected second migration: {second_run:?}"
 		);
+	}
+
+	#[test]
+	fn replays_advanced_indexes_for_replacement_and_removal() {
+		// Arrange
+		let create_advanced_index = super::super::Operation::CreateIndex {
+			table: "blog_posts".to_string(),
+			columns: vec!["slug".to_string()],
+			unique: false,
+			index_type: None,
+			where_clause: Some("published = TRUE".to_string()),
+			concurrently: false,
+			expressions: None,
+			mysql_options: None,
+			operator_class: None,
+		};
+		let mut replayed = ProjectState::new();
+		let mut old_model = ModelState::new("blog", "Post");
+		old_model.table_name = "blog_posts".to_string();
+		old_model.add_field(FieldState::new("slug", FieldType::VarChar(255), false));
+		replayed.add_model(old_model);
+		replayed.apply_migration_operations(&[create_advanced_index], "blog");
+		let mut replacement_model = ModelState::new("blog", "Post");
+		replacement_model.table_name = "blog_posts".to_string();
+		replacement_model.add_field(FieldState::new("slug", FieldType::VarChar(255), false));
+		replacement_model.indexes.push(IndexDefinition {
+			name: "idx_blog_posts_slug".to_string(),
+			fields: vec!["slug".to_string()],
+			unique: false,
+		});
+		let mut replacement_target = ProjectState::new();
+		replacement_target.add_model(replacement_model);
+
+		// Act
+		let replacement_operations =
+			MigrationAutodetector::new(replayed.clone(), replacement_target).generate_operations();
+		let mut removal_target = ProjectState::new();
+		let mut removal_model = ModelState::new("blog", "Post");
+		removal_model.table_name = "blog_posts".to_string();
+		removal_model.add_field(FieldState::new("slug", FieldType::VarChar(255), false));
+		removal_target.add_model(removal_model);
+		let removal_operations =
+			MigrationAutodetector::new(replayed, removal_target).generate_operations();
+
+		// Assert
+		let drop_position = replacement_operations
+			.iter()
+			.position(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+			.expect("advanced index replacement should drop the old index");
+		let create_position = replacement_operations
+			.iter()
+			.position(|operation| matches!(operation, super::super::Operation::CreateIndex { .. }))
+			.expect("advanced index replacement should create the ordinary index");
+		assert!(drop_position < create_position);
+		assert_eq!(
+			removal_operations
+				.iter()
+				.filter(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+				.count(),
+			1
+		);
+	}
+
+	#[test]
+	fn reorders_index_recreation_around_column_rename() {
+		// Arrange
+		let create_index = |columns: &[&str]| super::super::Operation::CreateIndex {
+			table: "blog_posts".to_string(),
+			columns: columns.iter().map(|column| (*column).to_string()).collect(),
+			unique: false,
+			index_type: None,
+			where_clause: None,
+			concurrently: false,
+			expressions: None,
+			mysql_options: None,
+			operator_class: None,
+		};
+		let mut operations = vec![
+			create_index(&["slug_new"]),
+			super::super::Operation::RenameColumn {
+				table: "blog_posts".to_string(),
+				old_name: "slug".to_string(),
+				new_name: "slug_new".to_string(),
+			},
+			super::super::Operation::DropIndex {
+				table: "blog_posts".to_string(),
+				columns: vec!["slug".to_string()],
+			},
+		];
+
+		// Act
+		MigrationAutodetector::order_renamed_column_operations(&mut operations);
+
+		// Assert
+		assert!(matches!(
+			&operations[..],
+			[
+				super::super::Operation::DropIndex { .. },
+				super::super::Operation::RenameColumn { .. },
+				super::super::Operation::CreateIndex { .. },
+			]
+		));
+	}
+
+	#[test]
+	fn drops_replaced_index_before_creating_new_definition() {
+		// Arrange
+		let old_model = build_model_state(
+			"blog",
+			"Post",
+			vec![FieldState::new("email", FieldType::VarChar(255), false)],
+			vec![IndexDefinition {
+				name: "idx_blog_post_email".to_string(),
+				fields: vec!["email".to_string()],
+				unique: false,
+			}],
+			Vec::new(),
+		);
+		let new_model = build_model_state(
+			"blog",
+			"Post",
+			vec![FieldState::new("email", FieldType::VarChar(255), false)],
+			vec![IndexDefinition {
+				name: "idx_blog_post_email".to_string(),
+				fields: vec!["email".to_string()],
+				unique: true,
+			}],
+			Vec::new(),
+		);
+		let from_state =
+			build_project_state(vec![(("blog".to_string(), "Post".to_string()), old_model)]);
+		let to_state =
+			build_project_state(vec![(("blog".to_string(), "Post".to_string()), new_model)]);
+
+		// Act
+		let operations = MigrationAutodetector::new(from_state, to_state).generate_operations();
+
+		// Assert
+		let drop_position = operations
+			.iter()
+			.position(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+			.expect("replacing an index should drop the previous definition");
+		let create_position = operations
+			.iter()
+			.position(|operation| matches!(operation, super::super::Operation::CreateIndex { .. }))
+			.expect("replacing an index should create the new definition");
+		assert!(drop_position < create_position);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -210,6 +210,49 @@ pub struct IndexDefinition {
 	pub fields: Vec<String>,
 	/// Whether this is a unique index
 	pub unique: bool,
+	/// Partial index condition.
+	pub where_clause: Option<String>,
+	/// Index method.
+	pub index_type: Option<super::operations::IndexType>,
+	/// Expression-index definitions.
+	pub expressions: Option<Vec<String>>,
+	/// Whether the index was created concurrently.
+	pub concurrently: bool,
+	/// MySQL index options.
+	pub mysql_options: Option<super::operations::AlterTableOptions>,
+	/// PostgreSQL operator class.
+	pub operator_class: Option<String>,
+}
+
+impl IndexDefinition {
+	fn create_operation(&self, table: &str) -> super::Operation {
+		super::Operation::CreateIndex {
+			table: table.to_string(),
+			columns: self.fields.clone(),
+			unique: self.unique,
+			index_type: self.index_type,
+			where_clause: self.where_clause.clone(),
+			concurrently: self.concurrently,
+			expressions: self.expressions.clone(),
+			mysql_options: self.mysql_options,
+			operator_class: self.operator_class.clone(),
+		}
+	}
+
+	fn drop_operation(&self, table: &str) -> super::Operation {
+		super::Operation::DropNamedIndex {
+			table: table.to_string(),
+			name: self.name.clone(),
+			columns: self.fields.clone(),
+			unique: self.unique,
+			index_type: self.index_type,
+			where_clause: self.where_clause.clone(),
+			concurrently: self.concurrently,
+			expressions: self.expressions.clone(),
+			mysql_options: self.mysql_options,
+			operator_class: self.operator_class.clone(),
+		}
+	}
 }
 
 const ADVANCED_INDEX_OPTION_PREFIX: &str = "__reinhardt_advanced_index__:";
@@ -236,7 +279,7 @@ fn model_index_definitions_equivalent(
 
 /// Build the physical index name used by `Operation::CreateIndex`.
 pub(crate) fn default_index_name(table: &str, fields: &[String]) -> String {
-	format!("idx_{}_{}", table, fields.join("_"))
+	super::operations::generated_index_name(table, fields, None)
 }
 
 /// Compare indexes by schema semantics rather than generated names.
@@ -244,7 +287,14 @@ pub(crate) fn index_definitions_equivalent(
 	left: &IndexDefinition,
 	right: &IndexDefinition,
 ) -> bool {
-	left.fields == right.fields && left.unique == right.unique
+	left.fields == right.fields
+		&& left.unique == right.unique
+		&& left.where_clause == right.where_clause
+		&& left.index_type == right.index_type
+		&& left.expressions == right.expressions
+		&& left.concurrently == right.concurrently
+		&& left.mysql_options == right.mysql_options
+		&& left.operator_class == right.operator_class
 }
 
 /// Constraint definition for a model
@@ -1253,14 +1303,26 @@ impl ProjectState {
 					unique,
 					index_type,
 					where_clause,
+					concurrently,
 					expressions,
+					mysql_options,
 					operator_class,
-					..
 				} => {
+					let name = super::operations::generated_index_name(
+						table,
+						columns,
+						expressions.as_deref(),
+					);
 					let index = IndexDefinition {
-						name: default_index_name(table, columns),
+						name,
 						fields: columns.clone(),
 						unique: *unique,
+						where_clause: where_clause.clone(),
+						index_type: *index_type,
+						expressions: expressions.clone(),
+						concurrently: *concurrently,
+						mysql_options: mysql_options.clone(),
+						operator_class: operator_class.clone(),
 					};
 					let is_advanced = where_clause.is_some()
 						|| index_type.is_some()
@@ -1293,6 +1355,12 @@ impl ProjectState {
 						for name in removed_names {
 							model.options.remove(&advanced_index_option_key(&name));
 						}
+					}
+				}
+				Operation::DropNamedIndex { table, name, .. } => {
+					if let Some(model) = self.find_model_by_table_mut(table) {
+						model.indexes.retain(|index| index.name != *name);
+						model.options.remove(&advanced_index_option_key(name));
 					}
 				}
 				Operation::DropTable { name } => {
@@ -5764,6 +5832,7 @@ impl MigrationAutodetector {
 			| super::Operation::DropConstraint { table, .. }
 			| super::Operation::CreateIndex { table, .. }
 			| super::Operation::DropIndex { table, .. }
+			| super::Operation::DropNamedIndex { table, .. }
 			| super::Operation::CreateCompositePrimaryKey { table, .. }
 			| super::Operation::SetAutoIncrementValue { table, .. } => table == table_name,
 			super::Operation::CreateTable { name, .. } | super::Operation::DropTable { name } => {
@@ -5947,6 +6016,15 @@ impl MigrationAutodetector {
 					{
 						before_rename.push(operation);
 					}
+					super::Operation::DropNamedIndex {
+						table: index_table,
+						columns,
+						..
+					} if index_table == &table
+						&& columns.iter().any(|column| column == &old_name) =>
+					{
+						before_rename.push(operation);
+					}
 					super::Operation::CreateIndex {
 						table: index_table,
 						columns,
@@ -6089,19 +6167,10 @@ impl MigrationAutodetector {
 					});
 
 				for index in &model.indexes {
-					by_app.entry(app_label.clone()).or_default().push(
-						super::Operation::CreateIndex {
-							table: model.table_name.clone(),
-							columns: index.fields.clone(),
-							unique: index.unique,
-							index_type: None,
-							where_clause: None,
-							concurrently: false,
-							expressions: None,
-							mysql_options: None,
-							operator_class: None,
-						},
-					);
+					by_app
+						.entry(app_label.clone())
+						.or_default()
+						.push(index.create_operation(&model.table_name));
 				}
 			}
 		}
@@ -6173,7 +6242,7 @@ impl MigrationAutodetector {
 			}
 		}
 
-		// DropIndex before recreating indexes or dropping columns so the generated
+		// DropNamedIndex before recreating indexes or dropping columns so the generated
 		// SQL remains valid when an index changes only its uniqueness.
 		for (app_label, model_name, index_name) in &changes.removed_indexes {
 			let Some(model) = self.from_state.get_model(app_label, model_name) else {
@@ -6185,10 +6254,7 @@ impl MigrationAutodetector {
 			by_app
 				.entry(app_label.clone())
 				.or_default()
-				.push(super::Operation::DropIndex {
-					table: model.table_name.clone(),
-					columns: index.fields.clone(),
-				});
+				.push(index.drop_operation(&model.table_name));
 		}
 
 		// CreateIndex for indexes added to existing models.
@@ -6197,17 +6263,7 @@ impl MigrationAutodetector {
 				by_app
 					.entry(app_label.clone())
 					.or_default()
-					.push(super::Operation::CreateIndex {
-						table: model.table_name.clone(),
-						columns: index.fields.clone(),
-						unique: index.unique,
-						index_type: None,
-						where_clause: None,
-						concurrently: false,
-						expressions: None,
-						mysql_options: None,
-						operator_class: None,
-					});
+					.push(index.create_operation(&model.table_name));
 			}
 		}
 
@@ -6557,38 +6613,19 @@ impl MigrationAutodetector {
 									)
 								})
 								.filter(|new_index| old_index.name != new_index.name)
-								.map(|new_index| {
-									(
-										old_index.fields.clone(),
-										new_index.fields.clone(),
-										new_index.unique,
-									)
-								})
+								.map(|new_index| (old_index.clone(), new_index.clone()))
 						})
 						.collect::<Vec<_>>();
 					let operations = migrations_by_app.entry(app_label.clone()).or_default();
-					for (old_columns, _, _) in &renamed_indexes {
-						operations.push(super::Operation::DropIndex {
-							table: old_table_name.clone(),
-							columns: old_columns.clone(),
-						});
+					for (old_index, _) in &renamed_indexes {
+						operations.push(old_index.drop_operation(&old_table_name));
 					}
 					operations.push(super::Operation::RenameTable {
 						old_name: old_table_name,
 						new_name: model.table_name.clone(),
 					});
-					for (_, new_columns, unique) in renamed_indexes {
-						operations.push(super::Operation::CreateIndex {
-							table: model.table_name.clone(),
-							columns: new_columns,
-							unique,
-							index_type: None,
-							where_clause: None,
-							concurrently: false,
-							expressions: None,
-							mysql_options: None,
-							operator_class: None,
-						});
+					for (_, new_index) in renamed_indexes {
+						operations.push(new_index.create_operation(&model.table_name));
 					}
 				}
 			}
@@ -6621,25 +6658,56 @@ impl MigrationAutodetector {
 					.unwrap_or_else(|| format!("{}_{}", to_app, to_model_name.to_lowercase()))
 			});
 
+			let renamed_indexes = if *rename_table {
+				match (
+					self.from_state.get_model(from_app, from_model_name),
+					self.to_state.get_model(to_app, to_model_name),
+				) {
+					(Some(old_model), Some(new_model)) => old_model
+						.indexes
+						.iter()
+						.filter_map(|old_index| {
+							new_model
+								.indexes
+								.iter()
+								.find(|new_index| {
+									model_index_definitions_equivalent(
+										old_model, old_index, new_model, new_index,
+									)
+								})
+								.filter(|new_index| old_index.name != new_index.name)
+								.map(|new_index| (old_index.clone(), new_index.clone()))
+						})
+						.collect::<Vec<_>>(),
+					_ => Vec::new(),
+				}
+			} else {
+				Vec::new()
+			};
+			let operations = migrations_by_app.entry(to_app.clone()).or_default();
+			for (old_index, _) in &renamed_indexes {
+				operations.push(old_index.drop_operation(&old_table_name));
+			}
 			// Add MoveModel operation to the target app's migrations
-			migrations_by_app.entry(to_app.clone()).or_default().push(
-				super::Operation::MoveModel {
-					model_name: from_model_name.clone(),
-					from_app: from_app.clone(),
-					to_app: to_app.clone(),
-					rename_table: *rename_table,
-					old_table_name: if *rename_table {
-						Some(old_table_name)
-					} else {
-						None
-					},
-					new_table_name: if *rename_table {
-						Some(new_table_name)
-					} else {
-						None
-					},
+			operations.push(super::Operation::MoveModel {
+				model_name: from_model_name.clone(),
+				from_app: from_app.clone(),
+				to_app: to_app.clone(),
+				rename_table: *rename_table,
+				old_table_name: if *rename_table {
+					Some(old_table_name)
+				} else {
+					None
 				},
-			);
+				new_table_name: if *rename_table {
+					Some(new_table_name.clone())
+				} else {
+					None
+				},
+			});
+			for (_, new_index) in renamed_indexes {
+				operations.push(new_index.create_operation(&new_table_name));
+			}
 		}
 
 		// Second-line defence against redundant single-column `AddConstraint
@@ -7202,6 +7270,12 @@ mod tests {
 			name: "idx_blog_posts_author_id".to_string(),
 			fields: vec!["author_id".to_string()],
 			unique: false,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
 		});
 		target.add_model(post);
 
@@ -7263,6 +7337,12 @@ mod tests {
 			name: "idx_blog_posts_slug".to_string(),
 			fields: vec!["slug".to_string()],
 			unique: false,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
 		});
 		let mut replacement_target = ProjectState::new();
 		replacement_target.add_model(replacement_model);
@@ -7281,7 +7361,9 @@ mod tests {
 		// Assert
 		let drop_position = replacement_operations
 			.iter()
-			.position(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+			.position(|operation| {
+				matches!(operation, super::super::Operation::DropNamedIndex { .. })
+			})
 			.expect("advanced index replacement should drop the old index");
 		let create_position = replacement_operations
 			.iter()
@@ -7291,10 +7373,135 @@ mod tests {
 		assert_eq!(
 			removal_operations
 				.iter()
-				.filter(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+				.filter(|operation| {
+					matches!(operation, super::super::Operation::DropNamedIndex { .. })
+				})
 				.count(),
 			1
 		);
+	}
+
+	#[test]
+	fn replays_expression_index_name_and_definition_for_removal() {
+		// Arrange
+		let create_expression_index = super::super::Operation::CreateIndex {
+			table: "blog_posts".to_string(),
+			columns: vec!["slug".to_string()],
+			unique: true,
+			index_type: Some(super::super::operations::IndexType::BTree),
+			where_clause: Some("published = TRUE".to_string()),
+			concurrently: false,
+			expressions: Some(vec!["LOWER(slug)".to_string()]),
+			mysql_options: None,
+			operator_class: None,
+		};
+		let mut replayed = ProjectState::new();
+		let mut old_model = ModelState::new("blog", "Post");
+		old_model.table_name = "blog_posts".to_string();
+		old_model.add_field(FieldState::new("slug", FieldType::VarChar(255), false));
+		replayed.add_model(old_model);
+		replayed.apply_migration_operations(&[create_expression_index], "blog");
+		let replayed_index = &replayed
+			.find_model_by_table("blog_posts")
+			.expect("replayed model")
+			.indexes[0];
+		assert_eq!(replayed_index.name, "idx_blog_posts_expr");
+		assert_eq!(
+			replayed_index.expressions,
+			Some(vec!["LOWER(slug)".to_string()])
+		);
+
+		let mut removal_target = ProjectState::new();
+		let mut target_model = ModelState::new("blog", "Post");
+		target_model.table_name = "blog_posts".to_string();
+		target_model.add_field(FieldState::new("slug", FieldType::VarChar(255), false));
+		removal_target.add_model(target_model);
+
+		// Act
+		let removal_operations =
+			MigrationAutodetector::new(replayed, removal_target).generate_operations();
+
+		// Assert
+		assert!(matches!(
+			removal_operations.as_slice(),
+			[super::super::Operation::DropNamedIndex {
+				name,
+				unique: true,
+				where_clause: Some(predicate),
+				expressions: Some(expressions),
+				..
+			}] if name == "idx_blog_posts_expr"
+				&& predicate == "published = TRUE"
+				&& expressions == &["LOWER(slug)".to_string()]
+		));
+	}
+
+	#[test]
+	fn generate_migrations_recreates_generated_indexes_around_cross_app_move() {
+		// Arrange
+		let old_index = IndexDefinition {
+			name: "idx_legacy_user_email".to_string(),
+			fields: vec!["email".to_string()],
+			unique: true,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
+		};
+		let new_index = IndexDefinition {
+			name: "idx_accounts_user_email".to_string(),
+			..old_index.clone()
+		};
+		let old_model = build_model_state(
+			"legacy",
+			"User",
+			vec![
+				FieldState::new("id", FieldType::Integer, false),
+				FieldState::new("email", FieldType::VarChar(255), false),
+			],
+			vec![old_index],
+			Vec::new(),
+		);
+		let new_model = build_model_state(
+			"accounts",
+			"User",
+			vec![
+				FieldState::new("id", FieldType::Integer, false),
+				FieldState::new("email", FieldType::VarChar(255), false),
+			],
+			vec![new_index],
+			Vec::new(),
+		);
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(
+				("legacy".to_string(), "User".to_string()),
+				old_model,
+			)]),
+			build_project_state(vec![(
+				("accounts".to_string(), "User".to_string()),
+				new_model,
+			)]),
+		);
+
+		// Act
+		let migrations = detector
+			.try_generate_migrations()
+			.expect("cross-app move should generate a migration");
+
+		// Assert
+		let operations = &migrations[0].operations;
+		assert!(matches!(
+			operations.as_slice(),
+			[
+				super::super::Operation::DropNamedIndex { name, .. },
+				super::super::Operation::MoveModel { .. },
+				super::super::Operation::CreateIndex { table, columns, unique: true, .. },
+			] if name == "idx_legacy_user_email"
+				&& table == "accounts_user"
+				&& columns == &["email".to_string()]
+		));
 	}
 
 	#[test]
@@ -7349,6 +7556,12 @@ mod tests {
 				name: "idx_blog_post_email".to_string(),
 				fields: vec!["email".to_string()],
 				unique: false,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
 			}],
 			Vec::new(),
 		);
@@ -7360,6 +7573,12 @@ mod tests {
 				name: "idx_blog_post_email".to_string(),
 				fields: vec!["email".to_string()],
 				unique: true,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
 			}],
 			Vec::new(),
 		);
@@ -7374,7 +7593,9 @@ mod tests {
 		// Assert
 		let drop_position = operations
 			.iter()
-			.position(|operation| matches!(operation, super::super::Operation::DropIndex { .. }))
+			.position(|operation| {
+				matches!(operation, super::super::Operation::DropNamedIndex { .. })
+			})
 			.expect("replacing an index should drop the previous definition");
 		let create_position = operations
 			.iter()
@@ -8219,11 +8440,23 @@ mod tests {
 				name: "idx_title".to_string(),
 				fields: vec!["title".to_string()],
 				unique: false,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
 			},
 			IndexDefinition {
 				name: "idx_slug_unique".to_string(),
 				fields: vec!["slug".to_string()],
 				unique: true,
+				where_clause: None,
+				index_type: None,
+				expressions: None,
+				concurrently: false,
+				mysql_options: None,
+				operator_class: None,
 			},
 		];
 		let model = build_model_state(
@@ -8382,6 +8615,12 @@ mod tests {
 			name: "idx_created".to_string(),
 			fields: vec!["created_at".to_string()],
 			unique: false,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
 		}];
 		let constraints = vec![ConstraintDefinition {
 			name: "ck_status".to_string(),

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -199,20 +199,27 @@ impl ModelMetadata {
 
 		// Foreign-key ID fields carry db_index=true by default. Materialize that
 		// metadata as a non-unique index unless the field is already unique.
-		for (field_name, field_meta) in &self.fields {
-			let has_default_index =
-				field_meta.params.get("db_index").map(String::as_str) == Some("true");
-			let is_unique = field_meta.params.get("unique").map(String::as_str) == Some("true")
-				|| field_meta.params.get("primary_key").map(String::as_str) == Some("true");
-			if !has_default_index || is_unique {
-				continue;
-			}
+		let mut synthesized_indexes = self
+			.fields
+			.iter()
+			.filter_map(|(field_name, field_meta)| {
+				let has_default_index =
+					field_meta.params.get("db_index").map(String::as_str) == Some("true");
+				let is_unique = field_meta.params.get("unique").map(String::as_str) == Some("true")
+					|| field_meta.params.get("primary_key").map(String::as_str) == Some("true");
+				if !has_default_index || is_unique {
+					return None;
+				}
 
-			let index = IndexDefinition {
-				name: default_index_name(&self.table_name, std::slice::from_ref(field_name)),
-				fields: vec![field_name.clone()],
-				unique: false,
-			};
+				Some(IndexDefinition {
+					name: default_index_name(&self.table_name, std::slice::from_ref(field_name)),
+					fields: vec![field_name.clone()],
+					unique: false,
+				})
+			})
+			.collect::<Vec<_>>();
+		synthesized_indexes.sort_by(|left, right| left.name.cmp(&right.name));
+		for index in synthesized_indexes {
 			if !model_state
 				.indexes
 				.iter()

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -215,6 +215,12 @@ impl ModelMetadata {
 					name: default_index_name(&self.table_name, std::slice::from_ref(field_name)),
 					fields: vec![field_name.clone()],
 					unique: false,
+					where_clause: None,
+					index_type: None,
+					expressions: None,
+					concurrently: false,
+					mysql_options: None,
+					operator_class: None,
 				})
 			})
 			.collect::<Vec<_>>();
@@ -1018,6 +1024,12 @@ mod tests {
 			name: "posts_author_explicit".to_string(),
 			fields: vec!["author_id".to_string()],
 			unique: false,
+			where_clause: None,
+			index_type: None,
+			expressions: None,
+			concurrently: false,
+			mysql_options: None,
+			operator_class: None,
 		});
 
 		// Act

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -12,7 +12,9 @@
 //! See [`ModelMetadata`] for the architecture comparison diagram.
 
 use super::ConstraintDefinition;
-use super::autodetector::{FieldState, ModelState};
+use super::autodetector::{
+	FieldState, IndexDefinition, ModelState, default_index_name, index_definitions_equivalent,
+};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -65,6 +67,12 @@ pub struct ModelMetadata {
 	/// externally-constructible struct does not break the public API.
 	/// Read via [`Self::constraints`]; write via [`Self::add_constraint`].
 	constraints: Vec<ConstraintDefinition>,
+	/// Model-level index definitions declared via model metadata.
+	///
+	/// Kept private so that adding the field to a previously
+	/// externally-constructible struct does not break the public API.
+	/// Read via [`Self::indexes`]; write via [`Self::add_index`].
+	indexes: Vec<IndexDefinition>,
 }
 
 impl ModelMetadata {
@@ -82,6 +90,7 @@ impl ModelMetadata {
 			options: HashMap::new(),
 			many_to_many_fields: Vec::new(),
 			constraints: Vec::new(),
+			indexes: Vec::new(),
 		}
 	}
 
@@ -113,6 +122,16 @@ impl ModelMetadata {
 	/// inside [`Self::to_model_state`] from `FieldMetadata` parameters.
 	pub fn constraints(&self) -> &[ConstraintDefinition] {
 		&self.constraints
+	}
+
+	/// Adds a model-level index declared by the model macro or caller.
+	pub fn add_index(&mut self, index: IndexDefinition) {
+		self.indexes.push(index);
+	}
+
+	/// Returns model-level indexes registered by the model macro or caller.
+	pub fn indexes(&self) -> &[IndexDefinition] {
+		&self.indexes
 	}
 
 	/// Convert to ModelState for migrations
@@ -173,6 +192,35 @@ impl ModelMetadata {
 
 		// Copy ManyToMany relationship metadata
 		model_state.many_to_many_fields = self.many_to_many_fields.clone();
+
+		// Copy explicitly declared indexes before synthesizing default indexes so
+		// an equivalent explicit index is not duplicated.
+		model_state.indexes.extend(self.indexes.iter().cloned());
+
+		// Foreign-key ID fields carry db_index=true by default. Materialize that
+		// metadata as a non-unique index unless the field is already unique.
+		for (field_name, field_meta) in &self.fields {
+			let has_default_index =
+				field_meta.params.get("db_index").map(String::as_str) == Some("true");
+			let is_unique = field_meta.params.get("unique").map(String::as_str) == Some("true")
+				|| field_meta.params.get("primary_key").map(String::as_str) == Some("true");
+			if !has_default_index || is_unique {
+				continue;
+			}
+
+			let index = IndexDefinition {
+				name: default_index_name(&self.table_name, &[field_name.clone()]),
+				fields: vec![field_name.clone()],
+				unique: false,
+			};
+			if !model_state
+				.indexes
+				.iter()
+				.any(|existing| index_definitions_equivalent(existing, &index))
+			{
+				model_state.indexes.push(index);
+			}
+		}
 
 		// Generate Unique constraints from field params
 		for (field_name, field_meta) in &self.fields {
@@ -909,5 +957,67 @@ mod tests {
 			 Got params={:?}",
 			id_state.params
 		);
+	}
+
+	#[test]
+	fn to_model_state_materializes_default_db_index() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("blog", "Post", "blog_posts");
+		metadata.add_field(
+			"author_id".to_string(),
+			FieldMetadata::new(FieldType::Uuid).with_param("db_index", "true"),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		assert_eq!(model_state.indexes.len(), 1);
+		assert_eq!(model_state.indexes[0].fields, vec!["author_id"]);
+		assert!(!model_state.indexes[0].unique);
+	}
+
+	#[test]
+	fn to_model_state_skips_index_for_unique_field_or_disabled_field() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("blog", "Post", "blog_posts");
+		metadata.add_field(
+			"author_id".to_string(),
+			FieldMetadata::new(FieldType::Uuid)
+				.with_param("db_index", "true")
+				.with_param("unique", "true"),
+		);
+		metadata.add_field(
+			"category_id".to_string(),
+			FieldMetadata::new(FieldType::Uuid).with_param("db_index", "false"),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		assert!(model_state.indexes.is_empty());
+	}
+
+	#[test]
+	fn to_model_state_deduplicates_equivalent_explicit_index() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("blog", "Post", "blog_posts");
+		metadata.add_field(
+			"author_id".to_string(),
+			FieldMetadata::new(FieldType::Uuid).with_param("db_index", "true"),
+		);
+		metadata.add_index(IndexDefinition {
+			name: "posts_author_explicit".to_string(),
+			fields: vec!["author_id".to_string()],
+			unique: false,
+		});
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		assert_eq!(model_state.indexes.len(), 1);
+		assert_eq!(model_state.indexes[0].name, "posts_author_explicit");
 	}
 }

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -209,7 +209,7 @@ impl ModelMetadata {
 			}
 
 			let index = IndexDefinition {
-				name: default_index_name(&self.table_name, &[field_name.clone()]),
+				name: default_index_name(&self.table_name, std::slice::from_ref(field_name)),
 				fields: vec![field_name.clone()],
 				unique: false,
 			};

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -2752,6 +2752,7 @@ impl Operation {
 			}
 			Operation::DropNamedIndex {
 				table,
+				name,
 				columns,
 				unique,
 				index_type,
@@ -2762,8 +2763,9 @@ impl Operation {
 				operator_class,
 				..
 			} => {
-				let create = Operation::CreateIndex {
+				let create = Operation::CreateIndexRepair {
 					table: table.clone(),
+					name: Some(name.clone()),
 					columns: columns.clone(),
 					unique: *unique,
 					index_type: *index_type,
@@ -3794,6 +3796,7 @@ impl Operation {
 			}
 			Operation::DropNamedIndex {
 				table,
+				name,
 				columns,
 				unique,
 				index_type,
@@ -3803,8 +3806,9 @@ impl Operation {
 				mysql_options,
 				operator_class,
 				..
-			} => Ok(Some(Operation::CreateIndex {
+			} => Ok(Some(Operation::CreateIndexRepair {
 				table: table.clone(),
+				name: Some(name.clone()),
 				columns: columns.clone(),
 				unique: *unique,
 				index_type: *index_type,

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -139,6 +139,19 @@ impl std::fmt::Display for IndexType {
 		}
 	}
 }
+
+pub(crate) fn generated_index_name(
+	table: &str,
+	columns: &[String],
+	expressions: Option<&[String]>,
+) -> String {
+	let suffix = if expressions.is_some_and(|expressions| !expressions.is_empty()) {
+		"expr".to_string()
+	} else {
+		columns.join("_")
+	};
+	format!("idx_{table}_{suffix}")
+}
 // ============================================================================
 // MySQL-Specific ALTER TABLE Options
 // ============================================================================
@@ -950,6 +963,37 @@ pub enum Operation {
 		/// The columns.
 		columns: Vec<String>,
 	},
+	/// Drops an index while retaining its physical name and definition.
+	DropNamedIndex {
+		/// The table containing the index.
+		table: String,
+		/// Physical index name.
+		name: String,
+		/// Indexed columns.
+		#[serde(default)]
+		columns: Vec<String>,
+		/// Whether the index is unique.
+		#[serde(default)]
+		unique: bool,
+		/// Index method.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		index_type: Option<IndexType>,
+		/// Partial-index predicate.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		where_clause: Option<String>,
+		/// Whether the index was created concurrently.
+		#[serde(default)]
+		concurrently: bool,
+		/// Expression-index definitions.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		expressions: Option<Vec<String>>,
+		/// MySQL index options.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		mysql_options: Option<AlterTableOptions>,
+		/// PostgreSQL operator class.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		operator_class: Option<String>,
+	},
 	/// RunSQL variant.
 	RunSQL {
 		/// The sql.
@@ -1273,6 +1317,7 @@ impl Operation {
 			| Operation::DropConstraint { .. }
 			| Operation::CreateIndex { .. }
 			| Operation::DropIndex { .. }
+			| Operation::DropNamedIndex { .. }
 			| Operation::RunSQL { .. }
 			| Operation::RunRust { .. }
 			| Operation::AlterTableComment { .. }
@@ -1806,7 +1851,11 @@ impl Operation {
 						(content, columns.join("_"))
 					};
 
-				let idx_name = format!("idx_{}_{}", table, name_suffix);
+				let idx_name = if name_suffix == "expr" {
+					format!("idx_{table}_expr")
+				} else {
+					generated_index_name(table, columns, None)
+				};
 
 				// Index type clause (USING type) - PostgreSQL, CockroachDB
 				let using_clause = match (index_type, dialect) {
@@ -1884,7 +1933,7 @@ impl Operation {
 				sql
 			}
 			Operation::DropIndex { table, columns } => {
-				let idx_name = format!("idx_{}_{}", table, columns.join("_"));
+				let idx_name = generated_index_name(table, columns, None);
 				match dialect {
 					SqlDialect::Mysql => {
 						format!(
@@ -1898,6 +1947,16 @@ impl Operation {
 					}
 				}
 			}
+			Operation::DropNamedIndex { table, name, .. } => match dialect {
+				SqlDialect::Mysql => format!(
+					"DROP INDEX {} ON {};",
+					quote_identifier(name),
+					quote_identifier(table)
+				),
+				SqlDialect::Postgres | SqlDialect::Sqlite | SqlDialect::Cockroachdb => {
+					format!("DROP INDEX {};", quote_identifier(name))
+				}
+			},
 			Operation::RunSQL { sql, .. } => sql.to_string(),
 			Operation::RunRust { code, .. } => {
 				// For SQL generation, RunRust is a no-op comment
@@ -2449,11 +2508,15 @@ impl Operation {
 				quote_identifier(new_name),
 				quote_identifier(old_name)
 			)])),
-			Operation::CreateIndex { table, columns, .. } => {
-				// Use the same naming convention as to_sql(): idx_{table}_{columns_joined}
+			Operation::CreateIndex {
+				table,
+				columns,
+				expressions,
+				..
+			} => {
+				// Use the same naming convention as to_sql(), including expression indexes.
 				// This ensures the rollback DROP INDEX targets the correct index name
-				let columns_joined = columns.join("_");
-				let index_name = format!("idx_{}_{}", table, columns_joined);
+				let index_name = generated_index_name(table, columns, expressions.as_deref());
 				// MySQL requires `DROP INDEX <name> ON <table>`; PostgreSQL/SQLite/CockroachDB
 				// only need the index name. Mirror the dialect dispatch used by the forward
 				// `Operation::DropIndex` SQL generator above.
@@ -2589,8 +2652,7 @@ impl Operation {
 				// Enhancement opportunity: Full index reconstruction would preserve
 				// index_type, where_clause, operator_class, and other advanced properties.
 				// The current implementation generates a basic CREATE INDEX statement.
-				let columns_joined = columns.join("_");
-				let index_name = format!("idx_{}_{}", table, columns_joined);
+				let index_name = generated_index_name(table, columns, None);
 				let columns_list = columns
 					.iter()
 					.map(|c| quote_identifier(c).to_string())
@@ -2602,6 +2664,31 @@ impl Operation {
 					quote_identifier(table),
 					columns_list
 				)]))
+			}
+			Operation::DropNamedIndex {
+				table,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+				..
+			} => {
+				let create = Operation::CreateIndex {
+					table: table.clone(),
+					columns: columns.clone(),
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
+				};
+				Ok(Some(vec![create.to_sql(dialect)]))
 			}
 			Operation::DropConstraint {
 				table,
@@ -3558,9 +3645,27 @@ impl Operation {
 				old_name: new_name.clone(),
 				new_name: old_name.clone(),
 			})),
-			Operation::CreateIndex { table, columns, .. } => Ok(Some(Operation::DropIndex {
+			Operation::CreateIndex {
+				table,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => Ok(Some(Operation::DropNamedIndex {
 				table: table.clone(),
+				name: generated_index_name(table, columns, expressions.as_deref()),
 				columns: columns.clone(),
+				unique: *unique,
+				index_type: *index_type,
+				where_clause: where_clause.clone(),
+				concurrently: *concurrently,
+				expressions: expressions.clone(),
+				mysql_options: *mysql_options,
+				operator_class: operator_class.clone(),
 			})),
 			Operation::DropIndex { table, columns } => {
 				// Basic index recreation (without advanced properties)
@@ -3577,6 +3682,28 @@ impl Operation {
 					operator_class: None,
 				}))
 			}
+			Operation::DropNamedIndex {
+				table,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+				..
+			} => Ok(Some(Operation::CreateIndex {
+				table: table.clone(),
+				columns: columns.clone(),
+				unique: *unique,
+				index_type: *index_type,
+				where_clause: where_clause.clone(),
+				concurrently: *concurrently,
+				expressions: expressions.clone(),
+				mysql_options: *mysql_options,
+				operator_class: operator_class.clone(),
+			})),
 			// Operations that are not reversible as Operations
 			Operation::RunSQL { .. } | Operation::RunRust { .. } | Operation::BulkLoad { .. } => {
 				Ok(None)
@@ -3760,6 +3887,9 @@ impl Operation {
 			Operation::DropIndex { table, columns } => {
 				let idx_name = format!("idx_{}_{}", table, columns.join("_"));
 				OperationStatement::IndexDrop(self.build_drop_index(&idx_name))
+			}
+			Operation::DropNamedIndex { name, .. } => {
+				OperationStatement::IndexDrop(self.build_drop_index(name))
 			}
 			Operation::RunSQL { sql, .. } => OperationStatement::RawSql(sql.to_string()),
 			Operation::RunRust { code, .. } => {
@@ -4388,6 +4518,9 @@ impl MigrationOperation for Operation {
 			Operation::DropIndex { table, .. } => {
 				Some(format!("drop_index_{}", table.to_lowercase()))
 			}
+			Operation::DropNamedIndex { table, .. } => {
+				Some(format!("drop_index_{}", table.to_lowercase()))
+			}
 			Operation::RunSQL { .. } => None,  // Triggers auto-naming
 			Operation::RunRust { .. } => None, // Triggers auto-naming
 			Operation::AlterTableComment { table, .. } => {
@@ -4474,6 +4607,7 @@ impl MigrationOperation for Operation {
 				}
 			}
 			Operation::DropIndex { table, .. } => format!("Drop index on {}", table),
+			Operation::DropNamedIndex { table, .. } => format!("Drop index on {}", table),
 			Operation::RunSQL { sql, .. } => {
 				let preview = if sql.len() > 50 {
 					format!("{}...", &sql[..50])
@@ -4606,6 +4740,33 @@ impl MigrationOperation for Operation {
 				Operation::DropIndex {
 					table: table.clone(),
 					columns: sorted_columns,
+				}
+			}
+			Operation::DropNamedIndex {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => {
+				let mut sorted_columns = columns.clone();
+				sorted_columns.sort();
+				Operation::DropNamedIndex {
+					table: table.clone(),
+					name: name.clone(),
+					columns: sorted_columns,
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
 				}
 			}
 			// AlterUniqueTogether: Sort field lists and sort within each list

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -956,6 +956,36 @@ pub enum Operation {
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		operator_class: Option<String>,
 	},
+	/// Creates an index while retaining an explicit physical name.
+	CreateIndexRepair {
+		/// The table.
+		table: String,
+		/// Explicit physical index name. `None` uses the legacy generated name.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		name: Option<String>,
+		/// The columns.
+		columns: Vec<String>,
+		/// Whether the index is unique.
+		unique: bool,
+		/// Index method.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		index_type: Option<IndexType>,
+		/// Partial index condition.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		where_clause: Option<String>,
+		/// Create index concurrently.
+		#[serde(default)]
+		concurrently: bool,
+		/// Expression-index definitions.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		expressions: Option<Vec<String>>,
+		/// MySQL index options.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		mysql_options: Option<AlterTableOptions>,
+		/// PostgreSQL operator class.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		operator_class: Option<String>,
+	},
 	/// DropIndex variant.
 	DropIndex {
 		/// The table.
@@ -1316,6 +1346,7 @@ impl Operation {
 			Operation::AddConstraint { .. }
 			| Operation::DropConstraint { .. }
 			| Operation::CreateIndex { .. }
+			| Operation::CreateIndexRepair { .. }
 			| Operation::DropIndex { .. }
 			| Operation::DropNamedIndex { .. }
 			| Operation::RunSQL { .. }
@@ -1932,6 +1963,38 @@ impl Operation {
 				sql.push(';');
 				sql
 			}
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => {
+				let create = Operation::CreateIndex {
+					table: table.clone(),
+					columns: columns.clone(),
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
+				};
+				let sql = create.to_sql(dialect);
+				name.as_ref().map_or(sql.clone(), |name| {
+					let generated_name =
+						generated_index_name(table, columns, expressions.as_deref());
+					let generated_name = quote_identifier(&generated_name);
+					let name = quote_identifier(name);
+					sql.replacen(generated_name.as_ref(), name.as_ref(), 1)
+				})
+			}
 			Operation::DropIndex { table, columns } => {
 				let idx_name = generated_index_name(table, columns, None);
 				match dialect {
@@ -2520,6 +2583,28 @@ impl Operation {
 				// MySQL requires `DROP INDEX <name> ON <table>`; PostgreSQL/SQLite/CockroachDB
 				// only need the index name. Mirror the dialect dispatch used by the forward
 				// `Operation::DropIndex` SQL generator above.
+				let sql = match dialect {
+					SqlDialect::Mysql => format!(
+						"DROP INDEX {} ON {};",
+						quote_identifier(&index_name),
+						quote_identifier(table)
+					),
+					SqlDialect::Postgres | SqlDialect::Sqlite | SqlDialect::Cockroachdb => {
+						format!("DROP INDEX {};", quote_identifier(&index_name))
+					}
+				};
+				Ok(Some(vec![sql]))
+			}
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				expressions,
+				..
+			} => {
+				let index_name = name.clone().unwrap_or_else(|| {
+					generated_index_name(table, columns, expressions.as_deref())
+				});
 				let sql = match dialect {
 					SqlDialect::Mysql => format!(
 						"DROP INDEX {} ON {};",
@@ -3667,6 +3752,31 @@ impl Operation {
 				mysql_options: *mysql_options,
 				operator_class: operator_class.clone(),
 			})),
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => Ok(Some(Operation::DropNamedIndex {
+				table: table.clone(),
+				name: name.clone().unwrap_or_else(|| {
+					generated_index_name(table, columns, expressions.as_deref())
+				}),
+				columns: columns.clone(),
+				unique: *unique,
+				index_type: *index_type,
+				where_clause: where_clause.clone(),
+				concurrently: *concurrently,
+				expressions: expressions.clone(),
+				mysql_options: *mysql_options,
+				operator_class: operator_class.clone(),
+			})),
 			Operation::DropIndex { table, columns } => {
 				// Basic index recreation (without advanced properties)
 				// Note: Cannot determine if the original index was unique from DropIndex alone
@@ -3882,6 +3992,25 @@ impl Operation {
 				let idx_name = format!("idx_{}_{}", table, columns.join("_"));
 				OperationStatement::IndexCreate(
 					self.build_create_index(&idx_name, table, columns, *unique),
+				)
+			}
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				unique,
+				expressions,
+				..
+			} => {
+				let generated_name;
+				let idx_name = if let Some(name) = name.as_deref() {
+					name
+				} else {
+					generated_name = generated_index_name(table, columns, expressions.as_deref());
+					&generated_name
+				};
+				OperationStatement::IndexCreate(
+					self.build_create_index(idx_name, table, columns, *unique),
 				)
 			}
 			Operation::DropIndex { table, columns } => {
@@ -4515,6 +4644,13 @@ impl MigrationOperation for Operation {
 					Some(format!("create_index_{}", table.to_lowercase()))
 				}
 			}
+			Operation::CreateIndexRepair { table, unique, .. } => {
+				if *unique {
+					Some(format!("create_unique_index_{}", table.to_lowercase()))
+				} else {
+					Some(format!("create_index_{}", table.to_lowercase()))
+				}
+			}
 			Operation::DropIndex { table, .. } => {
 				Some(format!("drop_index_{}", table.to_lowercase()))
 			}
@@ -4600,6 +4736,13 @@ impl MigrationOperation for Operation {
 				constraint_name,
 			} => format!("Drop constraint {} from {}", constraint_name, table),
 			Operation::CreateIndex { table, unique, .. } => {
+				if *unique {
+					format!("Create unique index on {}", table)
+				} else {
+					format!("Create index on {}", table)
+				}
+			}
+			Operation::CreateIndexRepair { table, unique, .. } => {
 				if *unique {
 					format!("Create unique index on {}", table)
 				} else {
@@ -4722,6 +4865,34 @@ impl MigrationOperation for Operation {
 
 				Operation::CreateIndex {
 					table: table.clone(),
+					columns: sorted_columns,
+					unique: *unique,
+					index_type: *index_type,
+					where_clause: where_clause.clone(),
+					concurrently: *concurrently,
+					expressions: expressions.clone(),
+					mysql_options: *mysql_options,
+					operator_class: operator_class.clone(),
+				}
+			}
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => {
+				let mut sorted_columns = columns.clone();
+				sorted_columns.sort();
+
+				Operation::CreateIndexRepair {
+					table: table.clone(),
+					name: name.clone(),
 					columns: sorted_columns,
 					unique: *unique,
 					index_type: *index_type,

--- a/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
+++ b/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
@@ -582,6 +582,68 @@ impl ToTokens for Operation {
 					}
 				});
 			}
+			Operation::DropNamedIndex {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => {
+				let columns_iter = columns.iter();
+				let index_type_token = match index_type {
+					Some(it) => {
+						let variant = match it {
+							IndexType::BTree => quote! { IndexType::BTree },
+							IndexType::Hash => quote! { IndexType::Hash },
+							IndexType::Gin => quote! { IndexType::Gin },
+							IndexType::Gist => quote! { IndexType::Gist },
+							IndexType::Brin => quote! { IndexType::Brin },
+							IndexType::Fulltext => quote! { IndexType::Fulltext },
+							IndexType::Spatial => quote! { IndexType::Spatial },
+						};
+						quote! { Some(#variant) }
+					}
+					None => quote! { None },
+				};
+				let where_clause_token = match where_clause {
+					Some(value) => quote! { Some(#value.to_string()) },
+					None => quote! { None },
+				};
+				let expressions_token = match expressions {
+					Some(values) => {
+						let values_iter = values.iter();
+						quote! { Some(vec![#(#values_iter.to_string()),*]) }
+					}
+					None => quote! { None },
+				};
+				let mysql_options_token = match mysql_options {
+					Some(options) => quote! { Some(#options) },
+					None => quote! { None },
+				};
+				let operator_class_token = match operator_class {
+					Some(value) => quote! { Some(#value.to_string()) },
+					None => quote! { None },
+				};
+				tokens.extend(quote! {
+					Operation::DropNamedIndex {
+						table: #table.to_string(),
+						name: #name.to_string(),
+						columns: vec![#(#columns_iter.to_string()),*],
+						unique: #unique,
+						index_type: #index_type_token,
+						where_clause: #where_clause_token,
+						concurrently: #concurrently,
+						expressions: #expressions_token,
+						mysql_options: #mysql_options_token,
+						operator_class: #operator_class_token,
+					}
+				});
+			}
 			Operation::RunSQL { sql, reverse_sql } => {
 				let reverse_sql_token = match reverse_sql {
 					Some(s) => quote! { Some(#s.to_string()) },

--- a/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
+++ b/crates/reinhardt-db/src/migrations/operations/to_tokens.rs
@@ -573,6 +573,72 @@ impl ToTokens for Operation {
 					}
 				});
 			}
+			Operation::CreateIndexRepair {
+				table,
+				name,
+				columns,
+				unique,
+				index_type,
+				where_clause,
+				concurrently,
+				expressions,
+				mysql_options,
+				operator_class,
+			} => {
+				let columns_iter = columns.iter();
+				let name_token = match name {
+					Some(value) => quote! { Some(#value.to_string()) },
+					None => quote! { None },
+				};
+				let index_type_token = match index_type {
+					Some(it) => {
+						let variant = match it {
+							IndexType::BTree => quote! { IndexType::BTree },
+							IndexType::Hash => quote! { IndexType::Hash },
+							IndexType::Gin => quote! { IndexType::Gin },
+							IndexType::Gist => quote! { IndexType::Gist },
+							IndexType::Brin => quote! { IndexType::Brin },
+							IndexType::Fulltext => quote! { IndexType::Fulltext },
+							IndexType::Spatial => quote! { IndexType::Spatial },
+						};
+						quote! { Some(#variant) }
+					}
+					None => quote! { None },
+				};
+				let where_clause_token = match where_clause {
+					Some(value) => quote! { Some(#value.to_string()) },
+					None => quote! { None },
+				};
+				let expressions_token = match expressions {
+					Some(values) => {
+						let values_iter = values.iter();
+						quote! { Some(vec![#(#values_iter.to_string()),*]) }
+					}
+					None => quote! { None },
+				};
+				let mysql_options_token = match mysql_options {
+					Some(options) => quote! { Some(#options) },
+					None => quote! { None },
+				};
+				let operator_class_token = match operator_class {
+					Some(value) => quote! { Some(#value.to_string()) },
+					None => quote! { None },
+				};
+				tokens.extend(quote! {
+					Operation::CreateIndexRepair {
+						table: #table.to_string(),
+						name: #name_token,
+						columns: vec![#(#columns_iter.to_string()),*],
+						unique: #unique,
+						index_type: #index_type_token,
+						where_clause: #where_clause_token,
+						concurrently: #concurrently,
+						expressions: #expressions_token,
+						mysql_options: #mysql_options_token,
+						operator_class: #operator_class_token,
+					}
+				});
+			}
 			Operation::DropIndex { table, columns } => {
 				let columns_iter = columns.iter();
 				tokens.extend(quote! {

--- a/tests/integration/tests/migrations/macro_unique_together_integration.rs
+++ b/tests/integration/tests/migrations/macro_unique_together_integration.rs
@@ -23,12 +23,14 @@ use reinhardt_db::migrations::model_registry::global_registry;
 use reinhardt_macros::model;
 use rstest::*;
 use serde::{Deserialize, Serialize};
+use serial_test::serial;
 
 // ---------------------------------------------------------------------------
 // Test fixtures: minimal models that exercise the `unique_together` parser.
 // ---------------------------------------------------------------------------
 
 #[allow(dead_code)]
+// The fixture is registered by the macro; its fields are read through metadata.
 #[model(
 	app_label = "macro_unique_together_test",
 	table_name = "macro_unique_together_test_membership",
@@ -43,6 +45,7 @@ pub(crate) struct Membership {
 }
 
 #[allow(dead_code)]
+// The fixture is registered by the macro; its fields are read through metadata.
 #[model(
 	app_label = "macro_unique_together_test",
 	table_name = "macro_unique_together_test_no_constraint"
@@ -56,6 +59,7 @@ pub(crate) struct PlainModel {
 }
 
 #[allow(dead_code)]
+// The fixture is registered by the macro; its fields are read through metadata.
 #[model(
 	app_label = "macro_unique_together_test",
 	table_name = "macro_unique_together_test_indexed"
@@ -73,6 +77,7 @@ pub(crate) struct IndexedModel {
 // ---------------------------------------------------------------------------
 
 #[rstest]
+#[serial(global_registry)]
 fn unique_together_propagates_into_model_metadata() {
 	// Arrange
 	let registry = global_registry();
@@ -109,6 +114,7 @@ fn unique_together_propagates_into_model_metadata() {
 }
 
 #[rstest]
+#[serial(global_registry)]
 fn to_model_state_carries_unique_together_constraints() {
 	// Arrange
 	let registry = global_registry();
@@ -136,6 +142,7 @@ fn to_model_state_carries_unique_together_constraints() {
 }
 
 #[rstest]
+#[serial(global_registry)]
 fn models_without_unique_together_emit_no_extra_constraints() {
 	// Arrange
 	let registry = global_registry();
@@ -153,6 +160,7 @@ fn models_without_unique_together_emit_no_extra_constraints() {
 }
 
 #[rstest]
+#[serial(global_registry)]
 fn field_index_propagates_into_migration_metadata() {
 	// Arrange
 	let registry = global_registry();

--- a/tests/integration/tests/migrations/macro_unique_together_integration.rs
+++ b/tests/integration/tests/migrations/macro_unique_together_integration.rs
@@ -55,6 +55,19 @@ pub(crate) struct PlainModel {
 	pub name: String,
 }
 
+#[allow(dead_code)]
+#[model(
+	app_label = "macro_unique_together_test",
+	table_name = "macro_unique_together_test_indexed"
+)]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct IndexedModel {
+	#[field(primary_key = true)]
+	pub id: i64,
+	#[field(max_length = 255, index = true)]
+	pub email: String,
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -137,4 +150,22 @@ fn models_without_unique_together_emit_no_extra_constraints() {
 		 attribute is declared, got {:?}",
 		metadata.constraints()
 	);
+}
+
+#[rstest]
+fn field_index_propagates_into_migration_metadata() {
+	// Arrange
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("macro_unique_together_test", "IndexedModel")
+		.expect("IndexedModel should be registered by the #[model] macro");
+
+	// Act
+	let model_state = metadata.to_model_state();
+
+	// Assert
+	assert_eq!(metadata.indexes().len(), 1);
+	assert_eq!(model_state.indexes.len(), 1);
+	assert_eq!(model_state.indexes[0].fields, vec!["email"]);
+	assert!(!model_state.indexes[0].unique);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Restores migration index materialization for default-indexed foreign-key ID columns.
- Tracks generated index operations in replayed project state so repeated `makemigrations` runs are stable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes nor adds functionality)
- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`ModelMetadata` already records `db_index=true` for generated foreign-key ID fields, but the migration state conversion dropped that information. The autodetector also did not emit or replay `CreateIndex`/`DropIndex` operations. This caused initial migrations to omit default foreign-key indexes and could produce repeated changes on subsequent runs.

Fixes #6147

## How Was This Tested?

- `cargo fmt --all -- --check`
- `git diff --check`
- The focused `reinhardt-db` test target compiled successfully. Test execution was blocked before test startup by macOS `dyld_start` while loading the generated test binary.
- Added regression coverage for default, disabled, unique, explicit, and replayed index cases.

## Checklist

- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings during compilation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`

## Labels to Apply

- [x] `bug`
- [x] `database`
- [x] `orm`
- [x] `high`

**Additional Context:**

The remaining test-runner limitation is environmental: the generated macOS test binary remained in `dyld_start` with no test code running, so the process was interrupted without modifying repository state.
