### PR TITLE
fix(migrations): register field CHECK constraints in generated migrations

### DIFF
--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2997,6 +2997,9 @@ fn generate_field_metadata(
 }
 
 /// Generate automatic registration code using ctor
+// Keep the independent model metadata collections explicit so the generated
+// registration code mirrors the source model structure.
+#[allow(clippy::too_many_arguments)]
 fn generate_registration_code(
 	struct_name: &syn::Ident,
 	app_label: &str,

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -2219,6 +2219,7 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 		&fk_field_infos,
 		&unique_constraint_names,
 		&unique_constraint_field_lists,
+		&check_constraints,
 	)?;
 
 	// Generate relationship registration code for RELATIONSHIPS registry
@@ -3004,6 +3005,7 @@ fn generate_registration_code(
 	fk_field_infos: &[ForeignKeyFieldInfo],
 	unique_constraint_names: &[String],
 	unique_constraint_field_lists: &[Vec<String>],
+	check_constraints: &[(String, String)],
 ) -> Result<TokenStream> {
 	let migrations_crate = get_reinhardt_migrations_crate();
 	let orm_crate = get_reinhardt_orm_crate();
@@ -3343,27 +3345,44 @@ fn generate_registration_code(
 	let type_path = quote! { #struct_name }.to_string();
 
 	// Build per-constraint registration blocks for ModelMetadata.
-	// We walk three parallel vectors (names + field lists) and emit one
-	// `metadata.add_constraint(...)` call per declared `unique_together`.
-	// See reinhardt-web#4022.
-	let constraint_registrations: Vec<TokenStream> = unique_constraint_names
+	// Field-level CHECK constraints and model-level UNIQUE constraints both
+	// feed ModelState, which is consumed by the migration autodetector.
+	let mut constraint_registrations: Vec<TokenStream> = check_constraints
 		.iter()
-		.zip(unique_constraint_field_lists.iter())
-		.map(|(name, fields)| {
-			let field_lits = fields.iter().map(|f| quote! { #f.to_string() });
+		.map(|(field_name, expression)| {
+			let name = format!("{field_name}_check");
 			quote! {
 				metadata.add_constraint(
 					#migrations_crate::ConstraintDefinition {
 						name: #name.to_string(),
-						constraint_type: "unique".to_string(),
-						fields: vec![ #(#field_lits),* ],
-						expression: None,
+						constraint_type: "check".to_string(),
+						fields: Vec::new(),
+						expression: Some(#expression.to_string()),
 						foreign_key_info: None,
 					}
 				);
 			}
 		})
 		.collect();
+	constraint_registrations.extend(
+		unique_constraint_names
+			.iter()
+			.zip(unique_constraint_field_lists.iter())
+			.map(|(name, fields)| {
+				let field_lits = fields.iter().map(|f| quote! { #f.to_string() });
+				quote! {
+					metadata.add_constraint(
+						#migrations_crate::ConstraintDefinition {
+							name: #name.to_string(),
+							constraint_type: "unique".to_string(),
+							fields: vec![ #(#field_lits),* ],
+							expression: None,
+							foreign_key_info: None,
+						}
+					);
+				}
+			}),
+	);
 
 	let code = quote! {
 		#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -106,8 +106,8 @@ impl ModelMetadata {
 		self.constraints.push(constraint);
 	}
 
-	/// Returns model-level constraints registered by the `#[model(...)]`
-	/// macro (currently composite UNIQUE from `unique_together`).
+	/// Returns constraints registered by the `#[model(...)]` macro, such as
+	/// composite UNIQUE constraints and field-level CHECK constraints.
 	///
 	/// Field-level `unique = true` is not included here; it is synthesized
 	/// inside [`Self::to_model_state`] from `FieldMetadata` parameters.

--- a/tests/integration/tests/migrations/macro_unique_together_integration.rs
+++ b/tests/integration/tests/migrations/macro_unique_together_integration.rs
@@ -20,6 +20,7 @@
 //!    to the autodetector.
 
 use reinhardt_db::migrations::model_registry::global_registry;
+use reinhardt_db::migrations::{Constraint, MigrationAutodetector, Operation, ProjectState};
 use reinhardt_macros::model;
 use rstest::*;
 use serde::{Deserialize, Serialize};
@@ -53,6 +54,20 @@ pub(crate) struct PlainModel {
 	pub id: i64,
 	#[field(max_length = 255)]
 	pub name: String,
+}
+
+// The derive macro registers this fixture in the global model registry.
+#[allow(dead_code)]
+#[model(
+	app_label = "macro_field_check_test",
+	table_name = "macro_field_check_test_account"
+)]
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct Account {
+	#[field(primary_key = true)]
+	pub id: i64,
+	#[field(max_length = 20, check = "role IN ('admin', 'member')")]
+	pub role: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -136,5 +151,51 @@ fn models_without_unique_together_emit_no_extra_constraints() {
 		"ModelMetadata.constraints() must stay empty when no unique_together \
 		 attribute is declared, got {:?}",
 		metadata.constraints()
+	);
+}
+
+#[rstest]
+fn field_check_reaches_initial_migration_and_stabilizes() {
+	// Arrange
+	let registry = global_registry();
+	let metadata = registry
+		.get_model("macro_field_check_test", "Account")
+		.expect("Account model should be registered by the #[model] macro");
+
+	// Act
+	let model_state = metadata.to_model_state();
+	let mut target_state = ProjectState::new();
+	target_state.add_model(model_state);
+	let operations =
+		MigrationAutodetector::new(ProjectState::new(), target_state.clone()).generate_operations();
+
+	// Assert: the initial CreateTable operation contains the declared CHECK.
+	let constraints = operations
+		.iter()
+		.find_map(|operation| match operation {
+			Operation::CreateTable {
+				name, constraints, ..
+			} if name == "macro_field_check_test_account" => Some(constraints),
+			_ => None,
+		})
+		.expect("initial migration should create the Account table");
+	assert_eq!(
+		constraints,
+		&vec![Constraint::Check {
+			name: "role_check".to_string(),
+			expression: "role IN ('admin', 'member')".to_string(),
+		}],
+		"field-level CHECK metadata must be included in CreateTable"
+	);
+
+	// Replay the generated migration and ensure a second autodetection is a no-op.
+	let mut replayed_state = ProjectState::new();
+	replayed_state.apply_migration_operations(&operations, "macro_field_check_test");
+	let second_operations =
+		MigrationAutodetector::new(replayed_state, target_state).generate_operations();
+	assert!(
+		second_operations.is_empty(),
+		"re-running makemigrations after the generated CHECK migration should be a no-op: \
+			{second_operations:?}"
 	);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- Propagating field-level `#[field(check = "...")]` declarations into `ModelMetadata` so generated migrations include the declared CHECK constraints.
- Preserving the generated constraint name and expression in the migration `CreateTable` operation.
- Adding regression coverage for initial migration generation and repeat no-op detection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Field-level CHECK constraints were available in ORM constraint metadata but were omitted from the model registration metadata consumed by migration autodetection. As a result, initial migrations silently omitted model-declared CHECK constraints.

Fixes #6145

## How Was This Tested?

- `cargo test --package reinhardt-integration-tests --test migrations macro_unique_together_integration -- --nocapture` (4 passed)
- `cargo test --package reinhardt-integration-tests --test macros constraint_integration -- --nocapture` (4 passed)
- `cargo make fmt-check` passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- `cargo make clippy-check` was attempted but could not complete because concurrent shared sccache/build jobs stopped making progress; no clippy diagnostics were emitted.

## Performance Impact

- None expected.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Focused tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

- #6145

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

### Scope Label

- [x] `database` - Database layer, schema, migrations

### Additional Context

The migration regression test replays the generated operations and verifies that a second autodetection produces no changes.
