### PR TITLE
feat(pages): evict query cache at auth boundaries

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -948,6 +948,13 @@ argument set changed. Use `invalidate_family(list_project_jobs::family())` when
 a mutation may affect every cached argument set. Invalidation is an explicit
 success-path effect of `use_action`; failed mutations leave the cache unchanged.
 
+Use `client.remove(&list_project_jobs::key(project_id))` or
+`client.remove_family(list_project_jobs::family())` at an authentication
+boundary when cached data must not cross principals. Eviction physically drops
+the cached result, retry state, and active request; existing handles are reset,
+and the next observer starts from `Pending` (or `Idle` when disabled) instead of
+seeing the previous principal's success.
+
 For non-server-function data, define a manual typed family and provide the
 fetcher when building each descriptor:
 

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -99,6 +99,10 @@
 //! [`QueryClient::invalidate`] for one exact key or
 //! [`QueryClient::invalidate_family`] after a successful [`use_action`]
 //! mutation. Disabled uncached observers report [`QueryStatus::Idle`];
+//! use [`QueryClient::remove`] or [`QueryClient::remove_family`] at an
+//! authentication boundary when cached data must not cross principals.
+//! Eviction clears the cached result, retry state, and active request so the
+//! next observer starts from [`QueryStatus::Pending`] (or `Idle` when disabled).
 //! enabled observers progress through [`QueryStatus::Pending`],
 //! [`QueryStatus::Success`], or [`QueryStatus::Error`]. Successful data remains
 //! visible if a background sequence ultimately fails, with the terminal error

--- a/crates/reinhardt-pages/src/reactive.rs
+++ b/crates/reinhardt-pages/src/reactive.rs
@@ -133,7 +133,9 @@ pub use query::{
 	NoRetry, QueryClient, QueryDefaults, QueryDescriptor, QueryFamily, QueryHandle, QueryKey,
 	QueryOptions, QuerySnapshot, QueryStatus, RetryPolicy, queries, use_query,
 };
-pub(crate) use query::{QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease};
+pub(crate) use query::{
+	QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease, QueryResultError,
+};
 pub use resource::{Resource, ResourceState, use_resource, use_resource_with_key};
 pub use resource_value::{
 	LatestResourceState, LatestResourceValue, LatestResourceValueBuilder, use_latest_resource_value,

--- a/crates/reinhardt-pages/src/reactive/entity/store.rs
+++ b/crates/reinhardt-pages/src/reactive/entity/store.rs
@@ -351,6 +351,35 @@ impl EntityArena {
 		});
 	}
 
+	pub(crate) fn tombstone_identities(&self, identities: &HashSet<EntityIdentity>) {
+		if identities.is_empty() {
+			return;
+		}
+		let ticket = self.issue_mutation_ticket();
+		let buckets = self
+			.inner
+			.gc_buckets
+			.borrow()
+			.values()
+			.cloned()
+			.collect::<Vec<_>>();
+		let publications = identities
+			.iter()
+			.filter_map(|identity| {
+				buckets
+					.iter()
+					.find_map(|bucket| bucket.tombstone(self, identity, ticket))
+			})
+			.collect::<Vec<_>>();
+		#[cfg(any(wasm, test))]
+		self.invalidate_hydration_identities(identities);
+		batch(|| {
+			for publication in publications {
+				publication.publish();
+			}
+		});
+	}
+
 	fn update_entities_with_precommit(
 		&self,
 		update: impl FnOnce(&mut EntityWriter<'_>),
@@ -1184,6 +1213,12 @@ where
 }
 
 trait ErasedEntityBucket {
+	fn tombstone(
+		&self,
+		arena: &EntityArena,
+		identity: &EntityIdentity,
+		ticket: EntityWriteTicket,
+	) -> Option<Box<dyn EntityPublication>>;
 	fn deadline_is_current(&self, identity: &EntityIdentity, generation: u64) -> bool;
 	fn gc_deadline(&self, identity: &EntityIdentity) -> Option<(u64, u64)>;
 	fn gc_deadlines(&self) -> Vec<(EntityIdentity, u64, u64)>;
@@ -1232,6 +1267,23 @@ impl<E> ErasedEntityBucket for ErasedEntityBucketImpl<E>
 where
 	E: Entity,
 {
+	fn tombstone(
+		&self,
+		arena: &EntityArena,
+		identity: &EntityIdentity,
+		ticket: EntityWriteTicket,
+	) -> Option<Box<dyn EntityPublication>> {
+		let id = Self::parse_id(identity)?;
+		Some(
+			TypedEntityOperation::<E> {
+				id,
+				identity: identity.clone(),
+				state: StagedEntityState::Removed,
+			}
+			.commit(arena, ticket),
+		)
+	}
+
 	#[cfg(any(wasm, test))]
 	fn hydrate_group(
 		&self,

--- a/crates/reinhardt-pages/src/reactive/entity/store.rs
+++ b/crates/reinhardt-pages/src/reactive/entity/store.rs
@@ -57,6 +57,8 @@ struct EntityArenaInner {
 	hydration_groups: RefCell<BTreeMap<String, EntityHydrationGroup>>,
 	#[cfg(any(wasm, test))]
 	hydration_ticket: Cell<Option<EntityWriteTicket>>,
+	#[cfg(any(wasm, test))]
+	hydration_blocked: Cell<bool>,
 }
 
 impl EntityArena {
@@ -80,6 +82,8 @@ impl EntityArena {
 				hydration_groups: RefCell::new(BTreeMap::new()),
 				#[cfg(any(wasm, test))]
 				hydration_ticket: Cell::new(None),
+				#[cfg(any(wasm, test))]
+				hydration_blocked: Cell::new(false),
 			}),
 		}
 	}
@@ -169,6 +173,9 @@ impl EntityArena {
 	/// Stages the browser-side entity table for typed registration and deferred recipes.
 	#[cfg(any(wasm, test))]
 	pub(crate) fn install_hydration_envelope(&self, envelope: EntityHydrationEnvelope) {
+		if self.inner.hydration_blocked.get() {
+			return;
+		}
 		if envelope.version != ENTITY_TABLE_VERSION {
 			panic!(
 				"normalized entity hydration table has unsupported version {}; expected {}",
@@ -218,6 +225,13 @@ impl EntityArena {
 		for (bucket, group) in registered {
 			bucket.hydrate_group(self, &group, ticket);
 		}
+	}
+
+	#[cfg(any(wasm, test))]
+	pub(crate) fn reset_hydration(&self) {
+		self.inner.hydration_blocked.set(true);
+		self.inner.hydration_groups.borrow_mut().clear();
+		self.inner.hydration_ticket.set(None);
 	}
 
 	#[cfg(any(wasm, test))]
@@ -351,11 +365,11 @@ impl EntityArena {
 		});
 	}
 
-	pub(crate) fn tombstone_identities(&self, identities: &HashSet<EntityIdentity>) {
-		if identities.is_empty() {
-			return;
-		}
-		let ticket = self.issue_mutation_ticket();
+	fn tombstone_publications(
+		&self,
+		identities: &HashSet<EntityIdentity>,
+		ticket: EntityWriteTicket,
+	) -> Vec<Box<dyn EntityPublication>> {
 		let buckets = self
 			.inner
 			.gc_buckets
@@ -363,21 +377,14 @@ impl EntityArena {
 			.values()
 			.cloned()
 			.collect::<Vec<_>>();
-		let publications = identities
+		identities
 			.iter()
 			.filter_map(|identity| {
 				buckets
 					.iter()
 					.find_map(|bucket| bucket.tombstone(self, identity, ticket))
 			})
-			.collect::<Vec<_>>();
-		#[cfg(any(wasm, test))]
-		self.invalidate_hydration_identities(identities);
-		batch(|| {
-			for publication in publications {
-				publication.publish();
-			}
-		});
+			.collect::<Vec<_>>()
 	}
 
 	fn update_entities_with_precommit(
@@ -981,6 +988,7 @@ pub(crate) struct EntityOverlay<'a> {
 	arena: &'a EntityArena,
 	operations: Vec<Box<dyn ErasedEntityOperation>>,
 	operation_indices: HashMap<EntityIdentity, usize>,
+	virtual_removals: HashSet<EntityIdentity>,
 	rejected_operation: bool,
 }
 
@@ -1023,7 +1031,18 @@ impl<'a> EntityOverlay<'a> {
 			arena,
 			operations,
 			operation_indices,
+			virtual_removals: HashSet::new(),
 			rejected_operation,
+		}
+	}
+
+	pub(crate) fn tombstones(arena: &'a EntityArena, identities: &HashSet<EntityIdentity>) -> Self {
+		Self {
+			arena,
+			operations: Vec::new(),
+			operation_indices: HashMap::new(),
+			virtual_removals: identities.clone(),
+			rejected_operation: false,
 		}
 	}
 
@@ -1033,6 +1052,9 @@ impl<'a> EntityOverlay<'a> {
 	{
 		self.arena.register_entity_type::<E>();
 		let identity = EntityIdentity::of::<E>(id);
+		if self.virtual_removals.contains(&identity) {
+			return None;
+		}
 		if let Some(&index) = self.operation_indices.get(&identity) {
 			let operation = &self.operations[index];
 			return operation
@@ -1046,6 +1068,7 @@ impl<'a> EntityOverlay<'a> {
 		self.operations
 			.iter()
 			.map(|operation| operation.identity().clone())
+			.chain(self.virtual_removals.iter().cloned())
 			.collect()
 	}
 
@@ -1054,6 +1077,7 @@ impl<'a> EntityOverlay<'a> {
 			.iter()
 			.filter(|operation| operation.is_removed())
 			.map(|operation| operation.identity().clone())
+			.chain(self.virtual_removals.iter().cloned())
 			.collect()
 	}
 
@@ -1063,6 +1087,9 @@ impl<'a> EntityOverlay<'a> {
 	{
 		self.arena.register_entity_type::<E>();
 		let identity = EntityIdentity::of::<E>(id);
+		if self.virtual_removals.contains(&identity) {
+			return true;
+		}
 		if let Some(&index) = self.operation_indices.get(&identity) {
 			let operation = &self.operations[index];
 			return operation.is_removed();
@@ -1087,11 +1114,15 @@ impl<'a> EntityOverlay<'a> {
 			let identities = self.affected_identities();
 			self.arena.invalidate_hydration_identities(&identities);
 		}
-		let publications = self
+		let mut publications = self
 			.operations
 			.iter()
 			.map(|operation| operation.commit(self.arena, ticket))
-			.collect();
+			.collect::<Vec<_>>();
+		publications.extend(
+			self.arena
+				.tombstone_publications(&self.virtual_removals, ticket),
+		);
 		(publications, valid)
 	}
 }

--- a/crates/reinhardt-pages/src/reactive/entity/store.rs
+++ b/crates/reinhardt-pages/src/reactive/entity/store.rs
@@ -232,6 +232,20 @@ impl EntityArena {
 		self.inner.hydration_blocked.set(true);
 		self.inner.hydration_groups.borrow_mut().clear();
 		self.inner.hydration_ticket.set(None);
+
+		let identities = self
+			.inner
+			.gc_buckets
+			.borrow()
+			.values()
+			.flat_map(|bucket| bucket.identities())
+			.collect::<HashSet<_>>();
+		if identities.is_empty() {
+			return;
+		}
+		let ticket = self.issue_mutation_ticket();
+		let overlay = EntityOverlay::tombstones(self, &identities);
+		self.commit_overlay(overlay, ticket, |_| {}, |_| {});
 	}
 
 	#[cfg(any(wasm, test))]
@@ -1244,6 +1258,8 @@ where
 }
 
 trait ErasedEntityBucket {
+	#[cfg(any(wasm, test))]
+	fn identities(&self) -> Vec<EntityIdentity>;
 	fn tombstone(
 		&self,
 		arena: &EntityArena,
@@ -1298,6 +1314,16 @@ impl<E> ErasedEntityBucket for ErasedEntityBucketImpl<E>
 where
 	E: Entity,
 {
+	#[cfg(any(wasm, test))]
+	fn identities(&self) -> Vec<EntityIdentity> {
+		self.bucket
+			.borrow()
+			.records
+			.keys()
+			.map(|id| EntityIdentity::of::<E>(id))
+			.collect()
+	}
+
 	fn tombstone(
 		&self,
 		arena: &EntityArena,

--- a/crates/reinhardt-pages/src/reactive/query.rs
+++ b/crates/reinhardt-pages/src/reactive/query.rs
@@ -22,7 +22,9 @@ pub use client::QueryClient;
 pub(crate) use client::TestQueryRuntime;
 #[cfg(test)]
 pub(super) use client::acquire_query;
-pub(crate) use client::{QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease};
+pub(crate) use client::{
+	QueryAcquireOptions, QueryConsumer, QueryErrorPolicy, QueryLease, QueryResultError,
+};
 #[cfg(feature = "testing")]
 pub use client::{
 	query_browser_resource_counts, query_browser_resource_probe_for_test,

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -294,6 +294,8 @@ pub(super) struct QueryClientInner {
 	#[cfg(any(wasm, test))]
 	consumed_hydration_identities: RefCell<HashSet<QueryIdentity>>,
 	#[cfg(any(wasm, test))]
+	consumed_hydration_families: RefCell<HashSet<&'static str>>,
+	#[cfg(any(wasm, test))]
 	hydration_table_installed: Cell<bool>,
 	families: RefCell<HashMap<&'static str, QueryFamilyMetadata>>,
 	deadlines: RefCell<BinaryHeap<Reverse<ClientDeadline>>>,
@@ -434,6 +436,8 @@ impl QueryClient {
 			entity_dependents: RefCell::new(HashMap::new()),
 			#[cfg(any(wasm, test))]
 			consumed_hydration_identities: RefCell::new(HashSet::new()),
+			#[cfg(any(wasm, test))]
+			consumed_hydration_families: RefCell::new(HashSet::new()),
 			#[cfg(any(wasm, test))]
 			hydration_table_installed: Cell::new(false),
 			families: RefCell::new(HashMap::new()),
@@ -1626,6 +1630,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.cloned()
 			.collect::<HashSet<_>>();
 		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
+			owner.entities.tombstone_identities(&previous);
 			let dependent: Rc<dyn EntityDependent> = self.clone();
 			owner.replace_reverse_dependencies(dependent, &previous, &HashSet::new());
 		}
@@ -2805,6 +2810,14 @@ where
 	}
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum QueryResultError<E> {
+	/// The query fetcher returned an application error.
+	Fetch(E),
+	/// The query was evicted before its result became available.
+	Evicted,
+}
+
 struct QueryResultFuture<T: Clone + 'static, E: Clone + 'static> {
 	ssr_guard: Option<SsrRetrySequenceGuard<T, E>>,
 	lease: Rc<QueryLeaseInner<T, E>>,
@@ -2833,11 +2846,17 @@ impl<T: Clone + 'static, E: Clone + 'static> Drop for SsrRetrySequenceGuard<T, E
 }
 
 impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> {
-	type Output = Result<T, E>;
+	type Output = Result<T, QueryResultError<E>>;
 
 	fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = self.get_mut();
 		let entry = Rc::clone(&this.lease.entry);
+		if entry.evicted.get() {
+			if let Some(guard) = this.ssr_guard.as_mut() {
+				guard.armed = false;
+			}
+			return Poll::Ready(Err(QueryResultError::Evicted));
+		}
 		let inline_task = entry.inline_task.borrow_mut().take();
 		let ready_inline_task = if let Some(mut task) = inline_task {
 			if task.as_mut().poll(context).is_pending() {
@@ -2864,7 +2883,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 				if let Some(guard) = this.ssr_guard.as_mut() {
 					guard.armed = false;
 				}
-				return Poll::Ready(result.clone());
+				return Poll::Ready(result.clone().map_err(QueryResultError::Fetch));
 			}
 		} else {
 			match entry.state.with_untracked(|state| state.clone()) {
@@ -2878,7 +2897,7 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 					if let Some(guard) = this.ssr_guard.as_mut() {
 						guard.armed = false;
 					}
-					return Poll::Ready(Err(error));
+					return Poll::Ready(Err(QueryResultError::Fetch(error)));
 				}
 				ResourceState::Loading => {}
 			}
@@ -2907,7 +2926,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryLease<T, E> {
 
 	// Route preparation awaits this result while the public hook remains
 	// synchronous.
-	pub(crate) async fn result(&self) -> Result<T, E> {
+	pub(crate) async fn result(&self) -> Result<T, QueryResultError<E>> {
 		let lease = Rc::clone(&self.inner);
 		let ssr_guard = (self.inner.entry.runtime.executes_inline()
 			&& lease.generation.get().is_some())
@@ -3047,6 +3066,14 @@ impl QueryClient {
 		T: Clone + Serialize + DeserializeOwned + 'static,
 		E: Clone + Serialize + DeserializeOwned + 'static,
 	{
+		if self
+			.inner
+			.consumed_hydration_families
+			.borrow()
+			.contains(&key.family_id())
+		{
+			return Ok(());
+		}
 		let identity = key.identity().clone();
 		if self
 			.inner
@@ -3143,6 +3170,14 @@ impl QueryClient {
 			));
 		}
 		let identity = key.identity().clone();
+		if self
+			.inner
+			.consumed_hydration_families
+			.borrow()
+			.contains(&key.family_id())
+		{
+			return Ok(());
+		}
 		if self
 			.inner
 			.consumed_hydration_identities
@@ -3305,6 +3340,11 @@ impl QueryClient {
 	/// Evicts one exact typed query and clears any active handles of its cached entry.
 	pub fn remove<T, E>(&self, key: &QueryKey<T, E>) {
 		self.validate_registered_family_types(key.family_id(), key.family_types());
+		#[cfg(any(wasm, test))]
+		self.inner
+			.consumed_hydration_identities
+			.borrow_mut()
+			.insert(key.identity().clone());
 		let cached = self.inner.entries.borrow_mut().remove(key.identity());
 		if let Some(cached) = cached {
 			(cached.evict)();
@@ -3335,6 +3375,11 @@ impl QueryClient {
 		family: QueryFamily<Args, T, E>,
 	) {
 		self.validate_registered_family_types(family.id(), family.family_types());
+		#[cfg(any(wasm, test))]
+		self.inner
+			.consumed_hydration_families
+			.borrow_mut()
+			.insert(family.id());
 		let removed = {
 			let mut entries = self.inner.entries.borrow_mut();
 			let identities = entries

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -2949,6 +2949,10 @@ impl<T: Clone + 'static, E: Clone + 'static> Future for QueryResultFuture<T, E> 
 }
 
 impl<T: Clone + 'static, E: Clone + 'static> QueryLease<T, E> {
+	pub(crate) fn is_evicted(&self) -> bool {
+		self.inner.entry.evicted.get()
+	}
+
 	pub(crate) fn promote_to_mounted_route(&self, generation: u64) {
 		if matches!(self.inner.consumer.get(), QueryConsumer::Navigation(_)) {
 			self.inner
@@ -3373,13 +3377,16 @@ impl QueryClient {
 		}
 	}
 
+	#[cfg(any(wasm, test))]
+	pub(crate) fn reset_hydration(&self) {
+		self.inner.entities.reset_hydration();
+	}
+
 	/// Evicts one exact typed query and clears any active handles of its cached entry.
 	pub fn remove<T, E>(&self, key: &QueryKey<T, E>) {
 		self.validate_registered_family_types(key.family_id(), key.family_types());
 		#[cfg(any(wasm, test))]
 		self.inner.hydration_table_installed.set(true);
-		#[cfg(any(wasm, test))]
-		self.inner.entities.reset_hydration();
 		#[cfg(any(wasm, test))]
 		self.inner
 			.consumed_hydration_identities
@@ -3417,8 +3424,6 @@ impl QueryClient {
 		self.validate_registered_family_types(family.id(), family.family_types());
 		#[cfg(any(wasm, test))]
 		self.inner.hydration_table_installed.set(true);
-		#[cfg(any(wasm, test))]
-		self.inner.entities.reset_hydration();
 		#[cfg(any(wasm, test))]
 		self.inner
 			.consumed_hydration_families

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -316,6 +316,7 @@ struct CachedQueryEntry {
 	hydration_id: String,
 	typed: Rc<dyn Any>,
 	invalidate: Rc<dyn Fn()>,
+	evict: Rc<dyn Fn()>,
 	cancel: Rc<dyn Fn()>,
 	poll_due: Rc<dyn Fn(u64)>,
 	retry_due: Rc<dyn Fn(u64)>,
@@ -1048,6 +1049,7 @@ pub(super) struct QueryEntry<T: Clone + 'static, E: Clone + 'static> {
 	inline_task: RefCell<Option<QueryTask>>,
 	retry_wait_guard: RefCell<Option<AbortableTaskGuard>>,
 	ssr_waiter_count: Cell<usize>,
+	evicted: Cell<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1106,8 +1108,10 @@ impl<T: Clone + 'static, E: Clone + 'static> Drop for QueryLeaseInner<T, E> {
 		}
 		if remaining == 0 {
 			entry.cancel_active_work();
-			entry.schedule_garbage_collection();
-		} else {
+			if !entry.evicted.get() {
+				entry.schedule_garbage_collection();
+			}
+		} else if !entry.evicted.get() {
 			entry.remove_retry_candidate(self.registration_id);
 			entry.refresh_polling_deadline();
 		}
@@ -1216,6 +1220,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			inline_task: RefCell::new(None),
 			retry_wait_guard: RefCell::new(None),
 			ssr_waiter_count: Cell::new(0),
+			evicted: Cell::new(false),
 		}
 	}
 
@@ -1603,6 +1608,33 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		self.wake_waiters();
 	}
 
+	fn evict(self: &Rc<Self>) {
+		self.evicted.set(true);
+		self.cancel_active_work();
+		self.invalidated.set(false);
+		self.refetch_error.set(None);
+		self.last_fetched_ms.set(None);
+		self.state.set(ResourceState::Loading);
+		self.completed.borrow_mut().take();
+		self.normalization_missing.set(false);
+		self.normalization_recovery_requested.set(false);
+		self.normalization_recovery_in_flight.set(false);
+		let previous = self
+			.dependencies
+			.borrow()
+			.keys()
+			.cloned()
+			.collect::<HashSet<_>>();
+		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
+			let dependent: Rc<dyn EntityDependent> = self.clone();
+			owner.replace_reverse_dependencies(dependent, &previous, &HashSet::new());
+		}
+		self.recipe.borrow_mut().take();
+		self.dependencies.borrow_mut().clear();
+		self.suspend_polling();
+		self.observers.borrow_mut().clear();
+	}
+
 	fn cancel_sequence_if_current(&self, completion_generation: u64) {
 		let is_current = self
 			.retry
@@ -1926,6 +1958,10 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		self: &Rc<Self>,
 		observer: &Rc<QueryLeaseInner<T, E>>,
 	) -> u64 {
+		if self.evicted.get() {
+			observer.manual_refetch_pending.set(false);
+			return self.next_generation.get();
+		}
 		observer.manual_refetch_pending.set(true);
 		self.start_sequence_with(true, Some(Rc::downgrade(observer)))
 	}
@@ -1952,6 +1988,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 		force: bool,
 		manual_observer: Option<Weak<QueryLeaseInner<T, E>>>,
 	) -> u64 {
+		if self.evicted.get() {
+			return self.next_generation.get();
+		}
 		if self.has_request() {
 			if force {
 				self.refetch_after_in_flight.set(true);
@@ -2104,6 +2143,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	pub(super) fn complete_attempt(self: &Rc<Self>, generation: u64, result: Result<T, E>) {
+		if self.evicted.get() {
+			return;
+		}
 		let request_ticket_lease = self
 			.request
 			.borrow_mut()
@@ -2642,6 +2684,9 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 	}
 
 	fn invalidate(self: &Rc<Self>) {
+		if self.evicted.get() {
+			return;
+		}
 		self.invalidated.set(true);
 		self.invalidation_generation
 			.set(self.invalidation_generation.get().wrapping_add(1));
@@ -3257,6 +3302,16 @@ impl QueryClient {
 		}
 	}
 
+	/// Evicts one exact typed query and clears any active handles of its cached entry.
+	pub fn remove<T, E>(&self, key: &QueryKey<T, E>) {
+		self.validate_registered_family_types(key.family_id(), key.family_types());
+		let cached = self.inner.entries.borrow_mut().remove(key.identity());
+		if let Some(cached) = cached {
+			(cached.evict)();
+			self.inner.refresh_browser_timer();
+		}
+	}
+
 	/// Marks all cached entries in one typed query family stale.
 	pub fn invalidate_family<Args: 'static, T: 'static, E: 'static>(
 		&self,
@@ -3272,6 +3327,30 @@ impl QueryClient {
 		{
 			(cached.invalidate)();
 		}
+	}
+
+	/// Evicts every cached entry in one typed query family.
+	pub fn remove_family<Args: 'static, T: 'static, E: 'static>(
+		&self,
+		family: QueryFamily<Args, T, E>,
+	) {
+		self.validate_registered_family_types(family.id(), family.family_types());
+		let removed = {
+			let mut entries = self.inner.entries.borrow_mut();
+			let identities = entries
+				.iter()
+				.filter(|(_, cached)| cached.family_id == family.id())
+				.map(|(identity, _)| identity.clone())
+				.collect::<Vec<_>>();
+			identities
+				.into_iter()
+				.filter_map(|identity| entries.remove(&identity))
+				.collect::<Vec<_>>()
+		};
+		for cached in removed {
+			(cached.evict)();
+		}
+		self.inner.refresh_browser_timer();
 	}
 }
 
@@ -3326,6 +3405,10 @@ where
 		invalidate: Rc::new({
 			let entry = Rc::clone(entry);
 			move || entry.invalidate()
+		}),
+		evict: Rc::new({
+			let entry = Rc::clone(entry);
+			move || entry.evict()
 		}),
 		cancel: Rc::new({
 			let entry = Rc::clone(entry);

--- a/crates/reinhardt-pages/src/reactive/query/client.rs
+++ b/crates/reinhardt-pages/src/reactive/query/client.rs
@@ -795,6 +795,42 @@ impl QueryClientInner {
 		prepared
 	}
 
+	fn commit_entity_tombstones(
+		&self,
+		identities: &HashSet<EntityIdentity>,
+		excluded: Option<&QueryIdentity>,
+	) {
+		if identities.is_empty() {
+			return;
+		}
+		let ticket = self.entities.issue_mutation_ticket();
+		let overlay = EntityOverlay::tombstones(&self.entities, identities);
+		let removed = RemovedEntities::borrowed(identities);
+		let prepared = self.prepare_entity_change(&overlay, &removed, excluded);
+		let (commit_structures, publish_signals): (Vec<_>, Vec<_>) = prepared
+			.into_iter()
+			.map(|prepared| (prepared.commit_structure, prepared.publish_signal))
+			.unzip();
+		self.entities.commit_overlay(
+			overlay,
+			ticket,
+			move |valid| {
+				if valid {
+					for commit_structure in commit_structures {
+						commit_structure();
+					}
+				}
+			},
+			move |valid| {
+				if valid {
+					for publish_signal in publish_signals {
+						publish_signal();
+					}
+				}
+			},
+		);
+	}
+
 	fn replace_reverse_dependencies(
 		&self,
 		dependent: Rc<dyn EntityDependent>,
@@ -1630,7 +1666,7 @@ impl<T: Clone + 'static, E: Clone + 'static> QueryEntry<T, E> {
 			.cloned()
 			.collect::<HashSet<_>>();
 		if let Some(owner) = self.owner.as_ref().and_then(Weak::upgrade) {
-			owner.entities.tombstone_identities(&previous);
+			owner.commit_entity_tombstones(&previous, Some(&self.identity));
 			let dependent: Rc<dyn EntityDependent> = self.clone();
 			owner.replace_reverse_dependencies(dependent, &previous, &HashSet::new());
 		}
@@ -3341,6 +3377,10 @@ impl QueryClient {
 	pub fn remove<T, E>(&self, key: &QueryKey<T, E>) {
 		self.validate_registered_family_types(key.family_id(), key.family_types());
 		#[cfg(any(wasm, test))]
+		self.inner.hydration_table_installed.set(true);
+		#[cfg(any(wasm, test))]
+		self.inner.entities.reset_hydration();
+		#[cfg(any(wasm, test))]
 		self.inner
 			.consumed_hydration_identities
 			.borrow_mut()
@@ -3375,6 +3415,10 @@ impl QueryClient {
 		family: QueryFamily<Args, T, E>,
 	) {
 		self.validate_registered_family_types(family.id(), family.family_types());
+		#[cfg(any(wasm, test))]
+		self.inner.hydration_table_installed.set(true);
+		#[cfg(any(wasm, test))]
+		self.inner.entities.reset_hydration();
 		#[cfg(any(wasm, test))]
 		self.inner
 			.consumed_hydration_families

--- a/crates/reinhardt-pages/src/reactive/query/hook.rs
+++ b/crates/reinhardt-pages/src/reactive/query/hook.rs
@@ -205,8 +205,10 @@ where
 				.register_optional_serialized_resource_with_owner(
 					hydration_id,
 					move || async move {
-						let _ = query_for_resource.lease.result().await;
-						query_for_resource.hydration_snapshot_value()
+						match query_for_resource.lease.result().await {
+							Err(super::client::QueryResultError::Evicted) => None,
+							_ => query_for_resource.hydration_snapshot_value(),
+						}
 					},
 					owner,
 				);

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -3405,6 +3405,26 @@ mod normalized_hydration {
 	}
 
 	#[test]
+	fn reset_hydration_tombstones_installed_entities() {
+		ReactiveScope::run(|| {
+			let runtime = TestQueryRuntime::new();
+			let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+			client.install_entity_hydration_envelope(
+				serde_json::from_value(table(project(7, "server"))).unwrap(),
+			);
+
+			assert_eq!(
+				client.entity::<Project>(7).get(),
+				Some(project(7, "server"))
+			);
+
+			client.reset_hydration();
+
+			assert_eq!(client.entity::<Project>(7).get(), None);
+		});
+	}
+
+	#[test]
 	fn normalized_hydration_rejects_missing_required_entity() {
 		ReactiveScope::run(|| {
 			let runtime = TestQueryRuntime::new();

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -2185,8 +2185,18 @@ fn removal_cancels_in_flight_request() {
 		}
 	});
 	let key = descriptor.key().clone();
+	let lease = client.acquire(
+		descriptor.clone(),
+		QueryAcquireOptions {
+			consumer: QueryConsumer::Navigation(1),
+			error_policy: QueryErrorPolicy::Discard,
+		},
+	);
+	let mut result = Box::pin(lease.result());
+	let mut context = Context::from_waker(Waker::noop());
 	let query = client.observe(descriptor, QueryOptions::default());
 	runtime.run_until_stalled();
+	assert_eq!(result.as_mut().poll(&mut context), Poll::Pending);
 
 	// Act
 	client.remove(&key);
@@ -2194,6 +2204,10 @@ fn removal_cancels_in_flight_request() {
 
 	// Assert
 	assert_eq!(cancellations.get(), 1);
+	assert_eq!(
+		result.as_mut().poll(&mut context),
+		Poll::Ready(Err(QueryResultError::Evicted))
+	);
 	assert_eq!(query.snapshot().status, QueryStatus::Pending);
 	assert!(!query.snapshot().is_fetching);
 }
@@ -6248,7 +6262,7 @@ fn discarded_error_retries_on_next_acquisition() {
 		);
 		assert_eq!(
 			tokio_test::block_on(first.result()),
-			Err("route failed".to_string())
+			Err(QueryResultError::Fetch("route failed".to_string()))
 		);
 		let second = acquire_query(
 			key,
@@ -6262,7 +6276,7 @@ fn discarded_error_retries_on_next_acquisition() {
 		assert_eq!(calls.get(), 2);
 		assert_eq!(
 			tokio_test::block_on(second.result()),
-			Err("route failed".to_string())
+			Err(QueryResultError::Fetch("route failed".to_string()))
 		);
 	});
 }
@@ -6298,7 +6312,7 @@ fn discarded_error_retries_for_a_later_retaining_observer() {
 		);
 		assert_eq!(
 			tokio_test::block_on(discarded.result()),
-			Err("route failed".to_string())
+			Err(QueryResultError::Fetch("route failed".to_string()))
 		);
 		drop(discarded);
 
@@ -6734,6 +6748,70 @@ fn hydration_snapshot_is_consumed_once_after_entry_eviction() {
 
 	assert_eq!(fetch_count.get(), 1);
 	assert_eq!(remounted.data(), Some("client-value".to_string()));
+}
+
+#[test]
+fn exact_removal_consumes_an_unobserved_hydration_snapshot() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.hydration-exact-removal");
+	let key = family.key(());
+	let snapshot = serde_json::json!({
+		"state": { "Success": "server-value" },
+		"refetch_error": null,
+		"is_fetching": false,
+		"is_stale": false
+	});
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Ok::<_, String>("client-value".to_string()) }
+		}
+	});
+
+	client.remove(&key);
+	client
+		.seed_query_snapshot(key, &snapshot)
+		.expect("an auth-boundary removal should suppress the old snapshot");
+	let query = client.observe(descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query.data(), Some("client-value".to_string()));
+}
+
+#[test]
+fn family_removal_consumes_unobserved_hydration_snapshots() {
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.hydration-family-removal");
+	let key = family.key(());
+	let snapshot = serde_json::json!({
+		"state": { "Success": "server-value" },
+		"refetch_error": null,
+		"is_fetching": false,
+		"is_stale": false
+	});
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Ok::<_, String>("client-value".to_string()) }
+		}
+	});
+
+	client.remove_family(family);
+	client
+		.seed_query_snapshot(key, &snapshot)
+		.expect("a family removal should suppress old family snapshots");
+	let query = client.observe(descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+
+	assert_eq!(fetch_count.get(), 1);
+	assert_eq!(query.data(), Some("client-value".to_string()));
 }
 
 #[rstest]

--- a/crates/reinhardt-pages/src/reactive/query/tests.rs
+++ b/crates/reinhardt-pages/src/reactive/query/tests.rs
@@ -2077,6 +2077,166 @@ fn exact_invalidation_only_refetches_the_matching_active_query() {
 	assert_eq!(second_count.get(), 1);
 }
 
+#[rstest]
+fn exact_removal_clears_active_data_and_refetches_after_remount() {
+	// Arrange
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<(), String, String>::new("tests.exact-removal");
+	let fetch_count = Rc::new(Cell::new(0));
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			let fetch_count = Rc::clone(&fetch_count);
+			async move {
+				let next = fetch_count.get() + 1;
+				fetch_count.set(next);
+				Ok(format!("value-{next}"))
+			}
+		}
+	});
+	let key = descriptor.key().clone();
+	let active = client.observe(descriptor.clone(), QueryOptions::new());
+	runtime.run_until_stalled();
+	assert_eq!(active.data(), Some("value-1".to_string()));
+
+	// Act
+	client.remove(&key);
+
+	// Assert
+	let removed = active.snapshot();
+	assert_eq!(removed.status, QueryStatus::Pending);
+	assert_eq!(removed.data, None);
+	assert_eq!(removed.error, None);
+	assert_eq!(removed.refetch_error, None);
+	assert!(!removed.is_fetching);
+	assert!(!client.contains_for_test(&key));
+	active.refetch();
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+
+	let remounted = client.observe(descriptor, QueryOptions::new());
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 2);
+	assert_eq!(remounted.data(), Some("value-2".to_string()));
+}
+
+#[rstest]
+fn family_removal_evicts_only_matching_entries() {
+	// Arrange
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let family = QueryFamily::<i64, String, String>::new("tests.family-removal");
+	let other_family = QueryFamily::<i64, String, String>::new("tests.other-family-removal");
+	let target_count = Rc::new(Cell::new(0));
+	let target = |value, target_count: Rc<Cell<i32>>| {
+		family.query(value, move || {
+			target_count.set(target_count.get() + 1);
+			async move { Ok(format!("target-{value}")) }
+		})
+	};
+	let first_descriptor = target(1, Rc::clone(&target_count));
+	let second_descriptor = target(2, Rc::clone(&target_count));
+	let other_descriptor = other_family.query(1, || async { Ok("other".to_string()) });
+	let first_key = first_descriptor.key().clone();
+	let second_key = second_descriptor.key().clone();
+	let other_key = other_descriptor.key().clone();
+	let first = client.observe(first_descriptor.clone(), QueryOptions::default());
+	let second = client.observe(second_descriptor, QueryOptions::default());
+	let other = client.observe(other_descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+
+	// Act
+	client.remove_family(family);
+
+	// Assert
+	assert_eq!(first.snapshot().status, QueryStatus::Pending);
+	assert_eq!(first.data(), None);
+	assert_eq!(second.snapshot().status, QueryStatus::Pending);
+	assert_eq!(second.data(), None);
+	assert_eq!(other.data(), Some("other".to_string()));
+	assert!(!client.contains_for_test(&first_key));
+	assert!(!client.contains_for_test(&second_key));
+	assert!(client.contains_for_test(&other_key));
+
+	let remounted = client.observe(first_descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+	assert_eq!(target_count.get(), 3);
+	assert_eq!(remounted.data(), Some("target-1".to_string()));
+}
+
+#[rstest]
+fn removal_cancels_in_flight_request() {
+	// Arrange
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let cancellations = Rc::new(Cell::new(0));
+	let family = QueryFamily::<(), String, String>::new("tests.removal-cancellation");
+	let descriptor = family.query_with_cancellation((), {
+		let cancellations = Rc::clone(&cancellations);
+		move |cancellation| {
+			let cancellations = Rc::clone(&cancellations);
+			async move {
+				let _registration = cancellation.on_cancel(move || {
+					cancellations.set(cancellations.get() + 1);
+				});
+				std::future::pending::<Result<String, String>>().await
+			}
+		}
+	});
+	let key = descriptor.key().clone();
+	let query = client.observe(descriptor, QueryOptions::default());
+	runtime.run_until_stalled();
+
+	// Act
+	client.remove(&key);
+	runtime.run_until_stalled();
+
+	// Assert
+	assert_eq!(cancellations.get(), 1);
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+	assert!(!query.snapshot().is_fetching);
+}
+
+#[rstest]
+fn removal_clears_waiting_retry_without_a_follow_up_request() {
+	// Arrange
+	let runtime = TestQueryRuntime::new();
+	let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+	let fetch_count = Rc::new(Cell::new(0));
+	let family = QueryFamily::<(), String, String>::new("tests.removal-retry");
+	let descriptor = family.query((), {
+		let fetch_count = Rc::clone(&fetch_count);
+		move || {
+			fetch_count.set(fetch_count.get() + 1);
+			async { Err("offline".to_string()) }
+		}
+	});
+	let key = descriptor.key().clone();
+	let query = client.observe(
+		descriptor,
+		QueryOptions::new().retry(
+			RetryPolicy::exponential()
+				.max_attempts(2)
+				.base_delay(Duration::from_secs(1))
+				.max_delay(Duration::from_secs(1)),
+		),
+	);
+	runtime.run_until_stalled();
+	assert_eq!(fetch_count.get(), 1);
+	assert!(query.entry.retry.borrow().is_some());
+
+	// Act
+	client.remove(&key);
+	runtime.advance(Duration::from_secs(1));
+	runtime.run_due_maintenance();
+
+	// Assert
+	assert_eq!(fetch_count.get(), 1);
+	assert!(query.entry.retry.borrow().is_none());
+	assert_eq!(query.snapshot().status, QueryStatus::Pending);
+}
+
 #[test]
 fn family_invalidation_marks_inactive_entries_stale_until_remount() {
 	let runtime = TestQueryRuntime::new();
@@ -2795,6 +2955,39 @@ mod normalized {
 				Some(project(1, "normalized"))
 			);
 			assert_eq!(query.data(), Some(project(1, "normalized")));
+		});
+	}
+
+	#[rstest]
+	fn removal_releases_normalized_dependency_and_reverse_index() {
+		ReactiveScope::run(|| {
+			// Arrange
+			let runtime = TestQueryRuntime::new();
+			let client = QueryClient::with_runtime(QueryDefaults::default(), runtime.handle());
+			let descriptor = QueryFamily::<u64, Project, String>::new("tests.normalized-removal")
+				.query(1, || async { Ok(project(1, "cached")) })
+				.with_entities(EntityValue::new());
+			let key = descriptor.key().clone();
+			let query = client.observe(descriptor, QueryOptions::default());
+			runtime.run_until_stalled();
+			assert_eq!(
+				client.entity_dependency_lease_count_for_test::<Project>(&1),
+				1
+			);
+			assert_eq!(client.entity_dependency_index_len_for_test(), 1);
+
+			// Act
+			client.remove(&key);
+
+			// Assert
+			assert_eq!(query.data(), None);
+			assert_eq!(
+				client.entity_dependency_lease_count_for_test::<Project>(&1),
+				0
+			);
+			assert_eq!(client.entity_dependency_index_len_for_test(), 0);
+			client.upsert_entity(project(1, "new"));
+			assert_eq!(query.data(), None);
 		});
 	}
 

--- a/crates/reinhardt-pages/src/router/loader.rs
+++ b/crates/reinhardt-pages/src/router/loader.rs
@@ -422,6 +422,7 @@ impl PreparedLoader {
 pub(crate) struct ErasedQueryLease {
 	lease: Rc<dyn Any>,
 	promote_to_mounted_route: Rc<dyn Fn(u64)>,
+	is_evicted: Rc<dyn Fn() -> bool>,
 }
 
 impl ErasedQueryLease {
@@ -431,16 +432,22 @@ impl ErasedQueryLease {
 		E: Clone + 'static,
 	{
 		let promote_lease = lease.clone();
+		let evicted_lease = lease.clone();
 		Self {
 			lease: Rc::new(lease),
 			promote_to_mounted_route: Rc::new(move |generation| {
 				promote_lease.promote_to_mounted_route(generation);
 			}),
+			is_evicted: Rc::new(move || evicted_lease.is_evicted()),
 		}
 	}
 
 	fn promote_to_mounted_route(&self, generation: u64) {
 		(self.promote_to_mounted_route)(generation);
+	}
+
+	fn is_evicted(&self) -> bool {
+		(self.is_evicted)()
 	}
 
 	#[allow(dead_code)]
@@ -493,6 +500,16 @@ impl LoaderStore {
 	where
 		T: Clone + 'static,
 	{
+		let evicted = self
+			.values
+			.borrow()
+			.get(&id)
+			.and_then(|stored| stored.lease.as_ref())
+			.is_some_and(ErasedQueryLease::is_evicted);
+		if evicted {
+			self.values.borrow_mut().remove(&id);
+			return Err(LoaderStoreError::Missing { id });
+		}
 		let values = self.values.borrow();
 		let stored = values.get(&id).ok_or(LoaderStoreError::Missing { id })?;
 		if stored.type_id != TypeId::of::<T>() {
@@ -506,6 +523,16 @@ impl LoaderStore {
 
 	/// Returns a serialized success value for SSR/hydration transfer.
 	pub fn serialized(&self, id: RouteLoaderId) -> Result<serde_json::Value, LoaderStoreError> {
+		let evicted = self
+			.values
+			.borrow()
+			.get(&id)
+			.and_then(|stored| stored.lease.as_ref())
+			.is_some_and(ErasedQueryLease::is_evicted);
+		if evicted {
+			self.values.borrow_mut().remove(&id);
+			return Err(LoaderStoreError::Missing { id });
+		}
 		self.values
 			.borrow()
 			.get(&id)

--- a/crates/reinhardt-pages/src/router/loader.rs
+++ b/crates/reinhardt-pages/src/router/loader.rs
@@ -5,7 +5,7 @@ use crate::cancellation::CancellationHandle;
 use crate::hydration::HydrationContext;
 use crate::reactive::{
 	QueryAcquireOptions, QueryClient, QueryConsumer, QueryErrorPolicy, QueryFamily, QueryLease,
-	queries,
+	QueryResultError, queries,
 };
 use reinhardt_urls::routers::client_router::{ClientRouteTreeMatch, RouteContext, RouteLoaderId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned};
@@ -699,7 +699,12 @@ where
 		},
 	);
 	let cancellation_check = cancellation.clone();
-	let value = crate::cancellation::scope_cancellation(cancellation, lease.result()).await?;
+	let value = crate::cancellation::scope_cancellation(cancellation, lease.result())
+		.await
+		.map_err(|error| match error {
+			QueryResultError::Fetch(error) => error,
+			QueryResultError::Evicted => RouteLoaderError::new("route loader query was evicted"),
+		})?;
 	if cancellation_check.is_cancelled() {
 		return Err(RouteLoaderError::new(
 			"route loader navigation was cancelled",


### PR DESCRIPTION
## Summary

This PR addresses:

- Add exact-key and query-family eviction APIs for authentication boundaries.
- Clear active query state and release normalized query dependencies during eviction.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

invalidate preserves successful data while a refetch runs. That behavior can leak data across authentication principals when a server-function key does not include the user. This PR adds QueryClient::remove and QueryClient::remove_family to physically evict cached data, retry state, active requests, and normalized dependency edges.

Fixes #6156

Related to: kent8192/reinhardt-cloud#876

## How Was This Tested?

- cargo test -p reinhardt-pages --all-features --lib (1,055 tests)
- cargo check -p reinhardt-pages --all-features
- cargo check -p reinhardt-pages --all-features --target wasm32-unknown-unknown
- cargo doc -p reinhardt-pages --no-deps --all-features
- cargo fmt --all -- --check
- cargo make placeholder-check
- Focused Clippy passed with existing dependency dead_code warnings excluded.

## Performance Impact

Not performance-related. Family eviction performs one cache scan, then evicts the matching entries.

## Breaking Changes

Not applicable.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo make fmt-fix
- [ ] I have checked the code with cargo make clippy-check

## Related Issues

- #6156
- kent8192/reinhardt-cloud#876

## Labels to Apply

### Type Label (select one)
- [x] enhancement - New feature or improvement

### Additional Labels (apply alongside type label when applicable)
- [ ] breaking-change - Breaking change

### Scope Label (select all that apply)
- [x] auth - Authentication, authorization, sessions

### Priority Label (for maintainers)
- [ ] critical - Blocks release or major functionality
- [ ] high - Important fix or enhancement
- [ ] medium - Normal priority
- [ ] low - Minor fix or enhancement

---

Additional Context:

Evicted handles are reset to an idle/pending state and cannot restart the detached request. New observers create a fresh cache entry for the same key.