### PR TITLE
fix(pages): retain model-form responses and map structured errors

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -432,6 +432,10 @@ Async submit lifecycle callbacks re-enter the form's owning reactive scope
 after the submit future resolves, so callbacks may safely create scoped
 reactive handles even when the submit was started outside the render turn.
 
+Model-backed browser submits retain the server function's typed response;
+`submit_server_fn` exposes it through `UseFormAsyncSubmitOutcome` and routes
+structured field errors into the same runtime state.
+
 For model-derived controls, explicit field allowlists, display overrides,
 trusted server setters, and native async persistence, see
 [Model-backed Pages forms](docs/model_forms.md). Model mode submits one

--- a/crates/reinhardt-pages/docs/model_forms.md
+++ b/crates/reinhardt-pages/docs/model_forms.md
@@ -157,9 +157,10 @@ explicit `fields: [...]` and `exclude: [...]` retain their existing behavior.
 
 ## Client-side responses and validation errors
 
-Model-form submission keeps the server function's response type. Attach the
-generated form to `use_form` and use `submit_server_fn` when the client needs
-the typed success value:
+The target-stable `submit()` method returns `Result<(), ServerFnError>`. On
+WASM, `submit_response()` exposes the server function's typed success value;
+attach the generated form to `use_form` and use `submit_server_fn` with that
+method when the client needs the response:
 
 ```rust,ignore
 use reinhardt_pages::{UseFormAsyncSubmitOutcome, form, use_form};
@@ -173,7 +174,7 @@ let create_form = form! {
 };
 let runtime = use_form(&create_form).build();
 
-match runtime.submit_server_fn(|| create_form.submit()).await? {
+match runtime.submit_server_fn(|| create_form.submit_response()).await? {
     UseFormAsyncSubmitOutcome::Submitted(response) => show_one_time_value(response),
     UseFormAsyncSubmitOutcome::AlreadyPending | UseFormAsyncSubmitOutcome::ValidationFailed => {}
 }

--- a/crates/reinhardt-pages/docs/model_forms.md
+++ b/crates/reinhardt-pages/docs/model_forms.md
@@ -155,6 +155,36 @@ Model forms without `File` or `Image` fields keep the JSON payload contract
 shown above: the server function receives one generated payload, and both
 explicit `fields: [...]` and `exclude: [...]` retain their existing behavior.
 
+## Client-side responses and validation errors
+
+Model-form submission keeps the server function's response type. Attach the
+generated form to `use_form` and use `submit_server_fn` when the client needs
+the typed success value:
+
+```rust,ignore
+use reinhardt_pages::{UseFormAsyncSubmitOutcome, form, use_form};
+
+let create_form = form! {
+    name: CreateQuestionForm,
+    model: Question,
+    policy: CreateQuestionPolicy,
+    fields: [title],
+    server_fn: create_question,
+};
+let runtime = use_form(&create_form).build();
+
+match runtime.submit_server_fn(|| create_form.submit()).await? {
+    UseFormAsyncSubmitOutcome::Submitted(response) => show_one_time_value(response),
+    UseFormAsyncSubmitOutcome::AlreadyPending | UseFormAsyncSubmitOutcome::ValidationFailed => {}
+}
+```
+
+Structured `ServerFnError` field errors are routed through the same runtime:
+matching selected fields are available from `get_field_state`, while errors
+for unselected or unknown fields remain in `form_state().form_error`. Explicit
+field selections provide typed accessors such as `title_field()`; forms using
+`exclude` can resolve a selected field with `form.field("title")`.
+
 ## Excluded fields
 
 Use `exclude: [...]` when nearly every editable model field belongs in the

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -2337,6 +2337,57 @@ fn generate_model_form(
 					}
 				}
 
+				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+				fn sync_mounted_field(
+					&self,
+					field: &str,
+					value: ::core::option::Option<
+						&#pages_crate::__private::serde_json::Value,
+					>,
+				) {
+					use #pages_crate::__private::wasm_bindgen::JsCast;
+					let Some(form) = #pages_crate::__private::web_sys::window()
+						.and_then(|window| window.document())
+						.and_then(|document| document.get_element_by_id(&self.__form_id))
+						.and_then(|form| form.dyn_into::<#pages_crate::__private::web_sys::HtmlFormElement>().ok())
+					else {
+						return;
+					};
+					let Ok(elements) = form.query_selector_all("[name]") else {
+						return;
+					};
+					let text = value
+						.map(|value| match value {
+							#pages_crate::__private::serde_json::Value::Null => ::std::string::String::new(),
+							#pages_crate::__private::serde_json::Value::String(value) => value.clone(),
+							value => value.to_string(),
+						})
+						.unwrap_or_default();
+					for index in 0..elements.length() {
+						let Some(element) = elements.item(index) else {
+							continue;
+						};
+						if element.get_attribute("name").as_deref() != ::core::option::Option::Some(field) {
+							continue;
+						}
+						if let Some(input) = element.dyn_ref::<#pages_crate::__private::web_sys::HtmlInputElement>() {
+							match input.type_().as_str() {
+								"checkbox" => input.set_checked(value.and_then(|value| value.as_bool()).unwrap_or(false)),
+								"file" => {
+									if value.is_none() || value.is_some_and(#pages_crate::__private::serde_json::Value::is_null) {
+										input.set_value("");
+									}
+								}
+								_ => input.set_value(&text),
+							}
+						} else if let Some(select) = element.dyn_ref::<#pages_crate::__private::web_sys::HtmlSelectElement>() {
+							select.set_value(&text);
+						} else if let Some(textarea) = element.dyn_ref::<#pages_crate::__private::web_sys::HtmlTextAreaElement>() {
+							textarea.set_value(&text);
+						}
+					}
+				}
+
 				pub fn data(
 					&self,
 				) -> ::core::result::Result<
@@ -3173,6 +3224,16 @@ fn generate_model_form(
 						let _ = state.set_value(field, value.clone());
 					}
 					drop(state);
+					#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+					for descriptor in <#schema_path as #pages_crate::form::ModelFormSchema>::fields() {
+						if !descriptor.editable
+							|| !<#policy_ident as #pages_crate::form::ModelFormPolicy>::allows(descriptor.name)
+						{
+							continue;
+						}
+						let value = self.__model_state.borrow().value(descriptor.name).cloned();
+						self.sync_mounted_field(descriptor.name, value.as_ref());
+					}
 					self.__state_version.update(|version| *version = version.wrapping_add(1));
 				}
 
@@ -3184,6 +3245,7 @@ fn generate_model_form(
 					let previous = state.value(field.0).cloned();
 					let result = state.set_any_value(field.0, value);
 					let changed = previous != state.value(field.0).cloned();
+					let current = state.value(field.0).cloned();
 					drop(state);
 					if changed {
 						self.__state_version.update(|version| *version = version.wrapping_add(1));
@@ -3191,6 +3253,8 @@ fn generate_model_form(
 					if let ::core::result::Result::Err(error) = result {
 						panic!("model form field {:?} rejected value: {}", field.0, error);
 					}
+					#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+					self.sync_mounted_field(field.0, current.as_ref());
 				}
 
 				fn runtime_values_are_dirty(
@@ -3212,7 +3276,10 @@ fn generate_model_form(
 					{
 						let _ = state.clear_value(field.0);
 					}
+					let current = state.value(field.0).cloned();
 					drop(state);
+					#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+					self.sync_mounted_field(field.0, current.as_ref());
 					self.__state_version.update(|version| *version = version.wrapping_add(1));
 				}
 

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -2105,10 +2105,25 @@ fn generate_model_form(
 		}
 		TypedModelFieldSelection::Exclude(_) => (
 			quote! {
-				const __REINHARDT_MODEL_FORM_STATE_FIELD: __ReinhardtModelFormField =
-					__ReinhardtModelFormField("");
+				static __REINHARDT_MODEL_FORM_FIELDS: ::std::sync::OnceLock<
+					::std::boxed::Box<[__ReinhardtModelFormField]>
+				> = ::std::sync::OnceLock::new();
 			},
-			quote!(&[__REINHARDT_MODEL_FORM_STATE_FIELD]),
+			quote! {
+				__REINHARDT_MODEL_FORM_FIELDS.get_or_init(|| {
+					<#schema_path as #pages_crate::form::ModelFormSchema>::fields()
+						.iter()
+						.filter(|descriptor| {
+							descriptor.editable
+								&& <#policy_ident as #pages_crate::form::ModelFormPolicy>::allows(
+									descriptor.name,
+								)
+						})
+						.map(|descriptor| __ReinhardtModelFormField(descriptor.name))
+						.collect::<::std::vec::Vec<_>>()
+						.into_boxed_slice()
+				})
+			},
 		),
 	};
 
@@ -2351,11 +2366,18 @@ fn generate_model_form(
 				}
 
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-				pub async fn submit(
+				pub async fn submit_response(
 					&self,
 				) -> ::core::result::Result<#model_form_response_type, #pages_crate::ServerFnError> {
 					let state = self.__model_state.borrow().clone();
 					self.submit_state(state, ::core::option::Option::None).await
+				}
+
+				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+				pub async fn submit(
+					&self,
+				) -> ::core::result::Result<(), #pages_crate::ServerFnError> {
+					self.submit_response().await.map(|_| ())
 				}
 
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
@@ -3154,11 +3176,21 @@ fn generate_model_form(
 					self.__state_version.update(|version| *version = version.wrapping_add(1));
 				}
 
-				fn runtime_set_field_value<T>(&self, field: Self::Field, _value: T)
+				fn runtime_set_field_value<T>(&self, field: Self::Field, value: T)
 				where
 					T: ::core::any::Any + 'static,
 				{
-					let _ = field;
+					let mut state = self.__model_state.borrow_mut();
+					let previous = state.value(field.0).cloned();
+					let result = state.set_any_value(field.0, value);
+					let changed = previous != state.value(field.0).cloned();
+					drop(state);
+					if changed {
+						self.__state_version.update(|version| *version = version.wrapping_add(1));
+					}
+					if let ::core::result::Result::Err(error) = result {
+						panic!("model form field {:?} rejected value: {}", field.0, error);
+					}
 				}
 
 				fn runtime_values_are_dirty(
@@ -3169,8 +3201,19 @@ fn generate_model_form(
 					current != defaults
 				}
 
-				fn runtime_apply_field_value(&self, field: Self::Field, _values: &Self::Values) {
-					let _ = field;
+				fn runtime_apply_field_value(&self, field: Self::Field, values: &Self::Values) {
+					let mut state = self.__model_state.borrow_mut();
+					if let ::core::option::Option::Some(value) = values.0.get(field.0) {
+						let _ = state.set_value(field.0, value.clone());
+					} else if values
+						.0
+						.get(&format!("__reinhardt_file_{}", field.0))
+						.is_none()
+					{
+						let _ = state.clear_value(field.0);
+					}
+					drop(state);
+					self.__state_version.update(|version| *version = version.wrapping_add(1));
 				}
 
 				fn runtime_field_is_dirty(
@@ -3181,6 +3224,20 @@ fn generate_model_form(
 				) -> bool {
 					if field.0.is_empty() {
 						return current != defaults;
+					}
+					if <#schema_path as #pages_crate::form::ModelFormSchema>::fields()
+						.iter()
+						.find(|descriptor| descriptor.name == field.0)
+						.is_some_and(|descriptor| {
+							matches!(
+								descriptor.kind,
+								#pages_crate::form::ModelFormFieldKind::File
+									| #pages_crate::form::ModelFormFieldKind::Image
+							)
+						})
+					{
+						return current.0.get(&format!("__reinhardt_file_{}", field.0))
+							!= defaults.0.get(&format!("__reinhardt_file_{}", field.0));
 					}
 					current.0.get(field.0) != defaults.0.get(field.0)
 				}

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -2038,6 +2038,13 @@ fn generate_model_form(
 			>();
 		};
 	};
+	let model_form_response_type = quote! {
+		<#server_fn::marker as #pages_crate::form::ModelFormServerFn<
+			#model_form_selection_type,
+			#schema_path,
+			#policy_ident,
+		>>::Response
+	};
 	let model_form_policy_check = match &model_source.selection {
 		TypedModelFieldSelection::Fields(fields) => {
 			let names = fields.iter().map(|field| {
@@ -2063,6 +2070,46 @@ fn generate_model_form(
 			}
 		}
 		TypedModelFieldSelection::Exclude(_) => quote! {},
+	};
+	let model_form_field_accessors = match &model_source.selection {
+		TypedModelFieldSelection::Fields(fields) => fields
+			.iter()
+			.map(|field| {
+				let method = format_ident!("{}_field", field);
+				let name = field.to_string();
+				let name = name.strip_prefix("r#").unwrap_or(&name);
+				quote! {
+					pub fn #method(&self) -> __ReinhardtModelFormField {
+						__ReinhardtModelFormField(#name)
+					}
+				}
+			})
+			.collect::<Vec<_>>(),
+		TypedModelFieldSelection::Exclude(_) => Vec::new(),
+	};
+	let (model_form_runtime_fields, model_form_runtime_fields_ref) = match &model_source.selection {
+		TypedModelFieldSelection::Fields(fields) => {
+			let names = fields.iter().map(|field| {
+				let name = field.to_string();
+				let name = name.strip_prefix("r#").unwrap_or(&name);
+				quote!(__ReinhardtModelFormField(#name))
+			});
+			(
+				quote! {
+					const __REINHARDT_MODEL_FORM_FIELDS: &'static [__ReinhardtModelFormField] = &[
+						#(#names),*
+					];
+				},
+				quote!(__REINHARDT_MODEL_FORM_FIELDS),
+			)
+		}
+		TypedModelFieldSelection::Exclude(_) => (
+			quote! {
+				const __REINHARDT_MODEL_FORM_STATE_FIELD: __ReinhardtModelFormField =
+					__ReinhardtModelFormField("");
+			},
+			quote!(&[__REINHARDT_MODEL_FORM_STATE_FIELD]),
+		),
 	};
 
 	let override_arms = model_source.overrides.iter().map(|override_| {
@@ -2147,9 +2194,9 @@ fn generate_model_form(
 			);
 
 			#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-			enum __ReinhardtModelFormField {
-				State,
-			}
+			struct __ReinhardtModelFormField(&'static str);
+
+			#model_form_runtime_fields
 
 			#(#descriptor_guards)*
 
@@ -2168,6 +2215,8 @@ fn generate_model_form(
 			}
 
 			impl #form_ident {
+				#(#model_form_field_accessors)*
+
 				fn new() -> Self {
 					let __model_state = ::std::rc::Rc::new(
 						::std::cell::RefCell::new(
@@ -2211,6 +2260,13 @@ fn generate_model_form(
 					#pages_crate::__private::serde_json::Value
 				> {
 					self.__model_state.borrow().value(field).cloned()
+				}
+
+				pub fn field(
+					&self,
+					name: &str,
+				) -> ::core::option::Option<__ReinhardtModelFormField> {
+					<#form_ident as #pages_crate::FormRuntimeSource>::runtime_field_by_name(self, name)
 				}
 
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -2294,25 +2350,26 @@ fn generate_model_form(
 					&self.success
 				}
 
+				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+				pub async fn submit(
+					&self,
+				) -> ::core::result::Result<#model_form_response_type, #pages_crate::ServerFnError> {
+					let state = self.__model_state.borrow().clone();
+					self.submit_state(state, ::core::option::Option::None).await
+				}
+
+				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 				pub async fn submit(
 					&self,
 				) -> ::core::result::Result<(), #pages_crate::ServerFnError> {
-					#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-					{
-						let state = self.__model_state.borrow().clone();
-						self.submit_state(state, ::core::option::Option::None).await
+					if let ::core::result::Result::Err(error) = self.data() {
+						let error = #pages_crate::ServerFnError::validation_with_message(
+							error.to_string(),
+							::core::iter::empty::<(&str, &str)>(),
+						);
+						return ::core::result::Result::Err(error);
 					}
-					#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-					{
-						if let ::core::result::Result::Err(error) = self.data() {
-							let error = #pages_crate::ServerFnError::validation_with_message(
-								error.to_string(),
-								::core::iter::empty::<(&str, &str)>(),
-							);
-							return ::core::result::Result::Err(error);
-						}
-						::core::result::Result::Ok(())
-					}
+					::core::result::Result::Ok(())
 				}
 
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -2373,7 +2430,7 @@ fn generate_model_form(
 					form: ::core::option::Option<
 						&#pages_crate::__private::web_sys::HtmlFormElement,
 					>,
-				) -> ::core::result::Result<(), #pages_crate::ServerFnError> {
+				) -> ::core::result::Result<#model_form_response_type, #pages_crate::ServerFnError> {
 					self.loading.set(true);
 					self.error.set(::core::option::Option::None);
 					self.success.set(false);
@@ -2389,11 +2446,11 @@ fn generate_model_form(
 						});
 					self.loading.set(false);
 					match result {
-						::core::result::Result::Ok(_) => {
+						::core::result::Result::Ok(response) => {
 							self.clear_selected_files_matching(&state);
 							self.clear_mounted_file_inputs_matching(&state, form);
 							self.success.set(true);
-							::core::result::Result::Ok(())
+							::core::result::Result::Ok(response)
 						}
 						::core::result::Result::Err(error) => {
 							self.error.set(::core::option::Option::Some(error.to_string()));
@@ -3040,6 +3097,19 @@ fn generate_model_form(
 					self.runtime_current_values()
 				}
 
+				fn runtime_field_by_name(&self, name: &str) -> ::core::option::Option<Self::Field> {
+					<#schema_path as #pages_crate::form::ModelFormSchema>::fields()
+						.iter()
+						.find(|descriptor| {
+							descriptor.editable
+								&& descriptor.name == name
+								&& <#policy_ident as #pages_crate::form::ModelFormPolicy>::allows(
+									descriptor.name,
+								)
+						})
+						.map(|descriptor| __ReinhardtModelFormField(descriptor.name))
+				}
+
 				fn runtime_current_values(&self) -> Self::Values {
 					let _ = self.__state_version.get();
 					let state = self.__model_state.borrow();
@@ -3088,9 +3158,7 @@ fn generate_model_form(
 				where
 					T: ::core::any::Any + 'static,
 				{
-					match field {
-						__ReinhardtModelFormField::State => {}
-					}
+					let _ = field;
 				}
 
 				fn runtime_values_are_dirty(
@@ -3102,9 +3170,7 @@ fn generate_model_form(
 				}
 
 				fn runtime_apply_field_value(&self, field: Self::Field, _values: &Self::Values) {
-					match field {
-						__ReinhardtModelFormField::State => {}
-					}
+					let _ = field;
 				}
 
 				fn runtime_field_is_dirty(
@@ -3113,9 +3179,10 @@ fn generate_model_form(
 					current: &Self::Values,
 					defaults: &Self::Values,
 				) -> bool {
-					match field {
-						__ReinhardtModelFormField::State => current != defaults,
+					if field.0.is_empty() {
+						return current != defaults;
 					}
+					current.0.get(field.0) != defaults.0.get(field.0)
 				}
 
 				fn runtime_watch_field<T>(
@@ -3125,13 +3192,12 @@ fn generate_model_form(
 				where
 					T: Clone + 'static,
 				{
-					match field {
-						__ReinhardtModelFormField::State => ::core::option::Option::None,
-					}
+					let _ = field;
+					::core::option::Option::None
 				}
 
 				fn runtime_fields(&self) -> &'static [Self::Field] {
-					&[__ReinhardtModelFormField::State]
+					#model_form_runtime_fields_ref
 				}
 			}
 
@@ -8412,7 +8478,9 @@ mod tests {
 		assert!(output_str.contains("let _ = self . __state_version . get ()"));
 		assert!(output_str.contains("ModelFormPolicy"));
 		assert!(output_str.contains("selected_descriptors () . iter () . filter (| descriptor |"));
-		assert!(output_str.contains("__ReinhardtModelFormField :: State"));
+		assert!(output_str.contains("struct __ReinhardtModelFormField"));
+		assert!(output_str.contains("runtime_field_by_name"));
+		assert!(output_str.contains("__ReinhardtModelFormField (\"aware_at\")"));
 		assert!(output_str.contains("FormRuntimeSource for TemporalControlsForm"));
 	}
 
@@ -8522,6 +8590,7 @@ mod tests {
 		let output = parse_validate_generate(input).to_string();
 
 		assert!(output.contains("ModelFormServerFn"));
+		assert!(output.contains(":: Response"));
 		assert!(output.contains("ModelFormSelectionCount < 2usize >"));
 		assert!(output.contains("ModelFormSelectionArgument < 0usize"));
 		assert!(output.contains("ModelFormSelectionArgument < 1usize"));
@@ -8541,18 +8610,16 @@ mod tests {
 		};
 
 		let output = parse_validate_generate(input).to_string();
-		let (_, submit_and_rest) = output
-			.split_once("pub async fn submit")
-			.expect("generated model form must have a submit method");
-		let (submit, _) = submit_and_rest
-			.split_once("pub fn into_page")
-			.expect("generated submit method must precede into_page");
-		let native_cfg = "# [cfg (not (all (target_family = \"wasm\" , target_os = \"unknown\")))]";
 		let legacy_validation =
 			"if let :: core :: result :: Result :: Err (error) = self . data ()";
-		let native_validation = format!("{native_cfg} {{ {legacy_validation}");
+		let (_, native_submit) = output
+			.rsplit_once("pub async fn submit")
+			.expect("generated model form must have a native submit method");
+		let (native_submit, _) = native_submit
+			.split_once("pub fn into_page")
+			.expect("generated native submit method must precede into_page");
 
-		assert_eq!(submit.matches(&native_validation).count(), 1);
+		assert_eq!(native_submit.matches(legacy_validation).count(), 1);
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/src/form/model.rs
+++ b/crates/reinhardt-pages/src/form/model.rs
@@ -2,6 +2,7 @@
 
 use regex::Regex;
 use rust_decimal::Decimal;
+use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
 use std::marker::PhantomData;
@@ -296,6 +297,46 @@ where
 		}
 	}
 
+	/// Stores a typed runtime value after converting it to the model-form JSON representation.
+	#[doc(hidden)]
+	pub fn set_any_value<T>(&mut self, field: &str, value: T) -> Result<(), ModelFormPayloadError>
+	where
+		T: Any + 'static,
+	{
+		let value = any_value_to_json(value).ok_or_else(|| {
+			invalid_value(
+				field,
+				format!(
+					"unsupported runtime value type `{}`",
+					std::any::type_name::<T>()
+				),
+			)
+		})?;
+		self.set_value(field, value)
+	}
+
+	/// Removes one model-form value and any selected file associated with it.
+	#[doc(hidden)]
+	pub fn clear_value(&mut self, field: &str) -> Result<(), ModelFormPayloadError> {
+		let descriptor = S::fields()
+			.iter()
+			.find(|descriptor| descriptor.name == field)
+			.ok_or_else(|| ModelFormPayloadError::UnknownField {
+				field: field.to_owned(),
+			})?;
+		if !P::allows(field) {
+			return Err(ModelFormPayloadError::ForbiddenField {
+				field: field.to_owned(),
+			});
+		}
+		self.values.remove(descriptor.name);
+		#[cfg(wasm)]
+		if is_file_kind(descriptor.kind) {
+			self.selected_files.remove(descriptor.name);
+		}
+		Ok(())
+	}
+
 	/// Returns the converted value stored for a model field.
 	pub fn value(&self, field: &str) -> Option<&serde_json::Value> {
 		self.values.get(field)
@@ -537,6 +578,59 @@ where
 		}
 		Ok(descriptor)
 	}
+}
+
+fn any_value_to_json<T>(value: T) -> Option<serde_json::Value>
+where
+	T: Any + 'static,
+{
+	let mut value: Box<dyn Any> = Box::new(value);
+
+	macro_rules! downcast {
+		($type:ty, $convert:expr) => {
+			value = match value.downcast::<$type>() {
+				Ok(value) => return Some(($convert)(*value)),
+				Err(value) => value,
+			};
+		};
+	}
+
+	downcast!(serde_json::Value, |value: serde_json::Value| value);
+	downcast!(String, serde_json::Value::String);
+	downcast!(&'static str, |value: &'static str| {
+		serde_json::Value::String(value.to_owned())
+	});
+	downcast!(bool, serde_json::Value::Bool);
+	downcast!(i8, serde_json::Value::from);
+	downcast!(i16, serde_json::Value::from);
+	downcast!(i32, serde_json::Value::from);
+	downcast!(i64, serde_json::Value::from);
+	downcast!(isize, serde_json::Value::from);
+	downcast!(u8, serde_json::Value::from);
+	downcast!(u16, serde_json::Value::from);
+	downcast!(u32, serde_json::Value::from);
+	downcast!(u64, serde_json::Value::from);
+	downcast!(usize, serde_json::Value::from);
+	downcast!(f32, serde_json::Value::from);
+	downcast!(f64, serde_json::Value::from);
+	downcast!(Option<String>, |value: Option<String>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::String)
+	});
+	downcast!(Option<bool>, |value: Option<bool>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::Bool)
+	});
+	downcast!(Option<i64>, |value: Option<i64>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<u64>, |value: Option<u64>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<f64>, |value: Option<f64>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+
+	drop(value);
+	None
 }
 
 impl<S, P> Default for ModelFormState<S, P>

--- a/crates/reinhardt-pages/src/form/model.rs
+++ b/crates/reinhardt-pages/src/form/model.rs
@@ -595,6 +595,15 @@ where
 		};
 	}
 
+	macro_rules! downcast_fallible {
+		($type:ty, $convert:expr) => {
+			value = match value.downcast::<$type>() {
+				Ok(value) => return ($convert)(*value),
+				Err(value) => value,
+			};
+		};
+	}
+
 	downcast!(serde_json::Value, |value: serde_json::Value| value);
 	downcast!(String, serde_json::Value::String);
 	downcast!(&'static str, |value: &'static str| {
@@ -611,8 +620,12 @@ where
 	downcast!(u32, serde_json::Value::from);
 	downcast!(u64, serde_json::Value::from);
 	downcast!(usize, serde_json::Value::from);
-	downcast!(f32, serde_json::Value::from);
-	downcast!(f64, serde_json::Value::from);
+	downcast_fallible!(f32, |value: f32| {
+		serde_json::Number::from_f64(f64::from(value)).map(serde_json::Value::Number)
+	});
+	downcast_fallible!(f64, |value: f64| {
+		serde_json::Number::from_f64(value).map(serde_json::Value::Number)
+	});
 	downcast!(Option<String>, |value: Option<String>| {
 		value.map_or(serde_json::Value::Null, serde_json::Value::String)
 	});
@@ -649,12 +662,87 @@ where
 	downcast!(Option<usize>, |value: Option<usize>| {
 		value.map_or(serde_json::Value::Null, serde_json::Value::from)
 	});
-	downcast!(Option<f32>, |value: Option<f32>| {
-		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	downcast_fallible!(Option<f32>, |value: Option<f32>| {
+		value.map_or(Some(serde_json::Value::Null), |value| {
+			serde_json::Number::from_f64(f64::from(value)).map(serde_json::Value::Number)
+		})
 	});
-	downcast!(Option<f64>, |value: Option<f64>| {
-		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	downcast_fallible!(Option<f64>, |value: Option<f64>| {
+		value.map_or(Some(serde_json::Value::Null), |value| {
+			serde_json::Number::from_f64(value).map(serde_json::Value::Number)
+		})
 	});
+	downcast!(Option<serde_json::Value>, |value: Option<
+		serde_json::Value,
+	>| {
+		value.map_or(serde_json::Value::Null, |value| value)
+	});
+	downcast!(Decimal, |value: Decimal| {
+		serde_json::Value::String(value.to_string())
+	});
+	downcast!(Option<Decimal>, |value: Option<Decimal>| {
+		value.map_or(serde_json::Value::Null, |value| {
+			serde_json::Value::String(value.to_string())
+		})
+	});
+
+	#[cfg(feature = "chrono")]
+	{
+		downcast!(chrono::NaiveDate, |value: chrono::NaiveDate| {
+			serde_json::Value::String(value.to_string())
+		});
+		downcast!(chrono::NaiveTime, |value: chrono::NaiveTime| {
+			serde_json::Value::String(value.to_string())
+		});
+		downcast!(chrono::NaiveDateTime, |value: chrono::NaiveDateTime| {
+			serde_json::Value::String(value.to_string())
+		});
+		downcast!(chrono::DateTime<chrono::Utc>, |value: chrono::DateTime<
+			chrono::Utc,
+		>| {
+			serde_json::Value::String(value.to_rfc3339())
+		});
+		downcast!(Option<chrono::NaiveDate>, |value: Option<
+			chrono::NaiveDate,
+		>| {
+			value.map_or(serde_json::Value::Null, |value| {
+				serde_json::Value::String(value.to_string())
+			})
+		});
+		downcast!(Option<chrono::NaiveTime>, |value: Option<
+			chrono::NaiveTime,
+		>| {
+			value.map_or(serde_json::Value::Null, |value| {
+				serde_json::Value::String(value.to_string())
+			})
+		});
+		downcast!(Option<chrono::NaiveDateTime>, |value: Option<
+			chrono::NaiveDateTime,
+		>| {
+			value.map_or(serde_json::Value::Null, |value| {
+				serde_json::Value::String(value.to_string())
+			})
+		});
+		downcast!(Option<chrono::DateTime<chrono::Utc>>, |value: Option<
+			chrono::DateTime<chrono::Utc>,
+		>| {
+			value.map_or(serde_json::Value::Null, |value| {
+				serde_json::Value::String(value.to_rfc3339())
+			})
+		});
+	}
+
+	#[cfg(feature = "uuid")]
+	{
+		downcast!(uuid::Uuid, |value: uuid::Uuid| {
+			serde_json::Value::String(value.to_string())
+		});
+		downcast!(Option<uuid::Uuid>, |value: Option<uuid::Uuid>| {
+			value.map_or(serde_json::Value::Null, |value| {
+				serde_json::Value::String(value.to_string())
+			})
+		});
+	}
 
 	drop(value);
 	None
@@ -1135,6 +1223,52 @@ mod tests {
 		assert_eq!(
 			any_value_to_json(None::<i32>),
 			Some(serde_json::Value::Null)
+		);
+		assert!(any_value_to_json(f64::NAN).is_none());
+		assert!(any_value_to_json(f64::INFINITY).is_none());
+		assert!(any_value_to_json(Some(f64::NEG_INFINITY)).is_none());
+		assert_eq!(
+			any_value_to_json(Some(serde_json::json!({"enabled": true}))),
+			Some(serde_json::json!({"enabled": true}))
+		);
+		assert_eq!(
+			any_value_to_json(None::<serde_json::Value>),
+			Some(serde_json::Value::Null)
+		);
+		assert_eq!(
+			any_value_to_json(rust_decimal::Decimal::new(125, 2)),
+			Some(serde_json::json!("1.25"))
+		);
+	}
+
+	#[cfg(feature = "chrono")]
+	#[test]
+	fn native_chrono_values_convert_to_form_strings() {
+		use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+		assert_eq!(
+			any_value_to_json(NaiveDate::from_ymd_opt(2026, 8, 24).unwrap()),
+			Some(serde_json::json!("2026-08-24"))
+		);
+		assert_eq!(
+			any_value_to_json(NaiveTime::from_hms_opt(12, 34, 56).unwrap()),
+			Some(serde_json::json!("12:34:56"))
+		);
+		assert_eq!(
+			any_value_to_json(
+				NaiveDateTime::parse_from_str("2026-08-24 12:34:56", "%Y-%m-%d %H:%M:%S").unwrap()
+			),
+			Some(serde_json::json!("2026-08-24 12:34:56"))
+		);
+	}
+
+	#[cfg(feature = "uuid")]
+	#[test]
+	fn native_uuid_values_convert_to_form_strings() {
+		let uuid = uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000042").unwrap();
+		assert_eq!(
+			any_value_to_json(Some(uuid)),
+			Some(serde_json::json!("00000000-0000-0000-0000-000000000042"))
 		);
 	}
 

--- a/crates/reinhardt-pages/src/form/model.rs
+++ b/crates/reinhardt-pages/src/form/model.rs
@@ -619,10 +619,37 @@ where
 	downcast!(Option<bool>, |value: Option<bool>| {
 		value.map_or(serde_json::Value::Null, serde_json::Value::Bool)
 	});
+	downcast!(Option<i8>, |value: Option<i8>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<i16>, |value: Option<i16>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<i32>, |value: Option<i32>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
 	downcast!(Option<i64>, |value: Option<i64>| {
 		value.map_or(serde_json::Value::Null, serde_json::Value::from)
 	});
+	downcast!(Option<isize>, |value: Option<isize>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<u8>, |value: Option<u8>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<u16>, |value: Option<u16>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<u32>, |value: Option<u32>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
 	downcast!(Option<u64>, |value: Option<u64>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<usize>, |value: Option<usize>| {
+		value.map_or(serde_json::Value::Null, serde_json::Value::from)
+	});
+	downcast!(Option<f32>, |value: Option<f32>| {
 		value.map_or(serde_json::Value::Null, serde_json::Value::from)
 	});
 	downcast!(Option<f64>, |value: Option<f64>| {
@@ -1074,13 +1101,42 @@ fn normalize_datetime_local(value: &str, aware: bool) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-	use super::{ModelFormState, is_date};
+	use super::{ModelFormState, any_value_to_json, is_date};
 	use reinhardt_core::model_form::{
 		AllEditableModelFields, ModelFormFieldDescriptor, ModelFormFieldKind, ModelFormPayload,
 		ModelFormPayloadError, ModelFormSchema,
 	};
 
 	struct NullableBooleanSchema;
+
+	#[test]
+	fn nullable_numeric_values_convert_to_json() {
+		assert_eq!(any_value_to_json(Some(1_i8)), Some(serde_json::json!(1)));
+		assert_eq!(any_value_to_json(Some(2_i16)), Some(serde_json::json!(2)));
+		assert_eq!(any_value_to_json(Some(3_i32)), Some(serde_json::json!(3)));
+		assert_eq!(any_value_to_json(Some(4_i64)), Some(serde_json::json!(4)));
+		assert_eq!(any_value_to_json(Some(5_isize)), Some(serde_json::json!(5)));
+		assert_eq!(any_value_to_json(Some(6_u8)), Some(serde_json::json!(6)));
+		assert_eq!(any_value_to_json(Some(7_u16)), Some(serde_json::json!(7)));
+		assert_eq!(any_value_to_json(Some(8_u32)), Some(serde_json::json!(8)));
+		assert_eq!(any_value_to_json(Some(9_u64)), Some(serde_json::json!(9)));
+		assert_eq!(
+			any_value_to_json(Some(10_usize)),
+			Some(serde_json::json!(10))
+		);
+		assert_eq!(
+			any_value_to_json(Some(1.5_f32)),
+			Some(serde_json::json!(1.5))
+		);
+		assert_eq!(
+			any_value_to_json(Some(2.5_f64)),
+			Some(serde_json::json!(2.5))
+		);
+		assert_eq!(
+			any_value_to_json(None::<i32>),
+			Some(serde_json::Value::Null)
+		);
+	}
 
 	impl ModelFormSchema for NullableBooleanSchema {
 		type Model = ();

--- a/crates/reinhardt-pages/tests/model_form_file_upload_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/model_form_file_upload_wasm_test.rs
@@ -6,9 +6,9 @@ use gloo_timers::future::TimeoutFuture;
 use js_sys::{Function, Reflect};
 use reinhardt_pages::component::{PageExt, cleanup_reactive_nodes};
 use reinhardt_pages::dom::Element;
-use reinhardt_pages::form;
 use reinhardt_pages::prelude::defer_yield;
 use reinhardt_pages::reactive::ReactiveScope;
+use reinhardt_pages::{form, use_form};
 use serial_test::serial;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::*;
@@ -325,7 +325,7 @@ async fn model_form_files_clear_only_after_success_or_reset() {
 	let avatar_file = browser_file("avatar.png");
 	let fetch = MultipartFetchGuard::install(&document_file, &avatar_file);
 	let scope = ReactiveScope::new();
-	let form = scope.enter(|| {
+	let (form, runtime) = scope.enter(|| {
 		let form = form! {
 			name: UploadForm,
 			model: Upload,
@@ -337,7 +337,8 @@ async fn model_form_files_clear_only_after_success_or_reset() {
 			.into_page()
 			.mount(&Element::new(root.0.clone()))
 			.expect("model form mounts");
-		form
+		let runtime = use_form(&form).build();
+		(form, runtime)
 	});
 
 	let title = query_input(&root.0, "upload-form-title");
@@ -353,6 +354,9 @@ async fn model_form_files_clear_only_after_success_or_reset() {
 		.expect("dispatch title input");
 	select_file(&document, &document_file);
 	select_file(&avatar, &avatar_file);
+	defer_yield().await;
+	assert!(runtime.get_field_state(form.document_field()).is_dirty);
+	assert!(runtime.get_field_state(form.avatar_field()).is_dirty);
 
 	submit(&query_form(&root.0));
 	wait_for_requests(&fetch, 1).await;
@@ -384,6 +388,9 @@ async fn model_form_files_clear_only_after_success_or_reset() {
 	);
 	select_file(&query_input(&root.0, "upload-form-avatar"), &avatar_file);
 	clear_selected_file(&query_input(&root.0, "upload-form-document"));
+	defer_yield().await;
+	assert!(!runtime.get_field_state(form.document_field()).is_dirty);
+	assert!(runtime.get_field_state(form.avatar_field()).is_dirty);
 	submit(&query_form(&root.0));
 	defer_yield().await;
 	assert_eq!(fetch.requests(), 2);

--- a/crates/reinhardt-pages/tests/model_form_multipart_wasm_compile.rs
+++ b/crates/reinhardt-pages/tests/model_form_multipart_wasm_compile.rs
@@ -21,27 +21,37 @@ mod multipart {
 mod json {
 	include!("ui/form/model_json_support.rs");
 
-	use reinhardt_pages::form;
+	use reinhardt_pages::{UseFormAsyncSubmitOutcome, form, use_form};
 
 	#[test]
 	fn model_form_json_explicit_fields_compile() {
-		let _form = form! {
+		let form = form! {
 			name: QuestionFieldsForm,
 			model: Question,
 			policy: QuestionPolicy,
 			fields: [title],
 			server_fn: save_question,
 		};
+		let runtime = use_form(&form).build();
+		let _ = runtime.get_field_state(form.title_field());
+		let _typed_submit = async {
+			if let Ok(UseFormAsyncSubmitOutcome::Submitted(response)) =
+				runtime.submit_server_fn(|| form.submit()).await
+			{
+				let _: QuestionResponse = response;
+			}
+		};
 	}
 
 	#[test]
 	fn model_form_json_exclude_compiles() {
-		let _form = form! {
+		let form = form! {
 			name: QuestionExcludeForm,
 			model: Question,
 			policy: QuestionPolicy,
 			exclude: [owner_id],
 			server_fn: save_question,
 		};
+		let _ = form.field("title");
 	}
 }

--- a/crates/reinhardt-pages/tests/model_form_multipart_wasm_compile.rs
+++ b/crates/reinhardt-pages/tests/model_form_multipart_wasm_compile.rs
@@ -36,7 +36,7 @@ mod json {
 		let _ = runtime.get_field_state(form.title_field());
 		let _typed_submit = async {
 			if let Ok(UseFormAsyncSubmitOutcome::Submitted(response)) =
-				runtime.submit_server_fn(|| form.submit()).await
+				runtime.submit_server_fn(|| form.submit_response()).await
 			{
 				let _: QuestionResponse = response;
 			}

--- a/crates/reinhardt-pages/tests/model_form_native_submit.rs
+++ b/crates/reinhardt-pages/tests/model_form_native_submit.rs
@@ -2,7 +2,7 @@
 
 include!("ui/form/model_json_support.rs");
 
-use reinhardt_pages::{form, server_fn::ServerFnErrorKind};
+use reinhardt_pages::{FieldError, form, server_fn::ServerFnErrorKind, use_form};
 
 #[test]
 fn native_submit_maps_payload_errors_to_validation() {
@@ -31,5 +31,41 @@ fn native_submit_maps_payload_errors_to_validation() {
 		assert_eq!(submit_error.status(), Some(422));
 		assert_eq!(submit_error.message(), payload_error.to_string());
 		assert_eq!(submit_error.field_errors(), []);
+	});
+}
+
+#[test]
+fn model_form_routes_structured_server_errors_to_selected_fields() {
+	reinhardt_core::reactive::ReactiveScope::run(|| {
+		let form = form! {
+			name: QuestionForm,
+			model: Question,
+			policy: QuestionPolicy,
+			fields: [title],
+			server_fn: save_question,
+		};
+		let runtime = use_form(&form).build();
+		let error = reinhardt_pages::ServerFnError::validation_with_message(
+			"Please correct the submitted values",
+			[
+				("title", "Title is already used"),
+				("owner_id", "Owner is required"),
+			],
+		);
+
+		runtime.apply_server_error(&error);
+
+		assert_eq!(
+			runtime
+				.get_field_state(form.title_field())
+				.error
+				.as_ref()
+				.map(FieldError::message),
+			Some("Title is already used")
+		);
+		assert_eq!(
+			runtime.form_state().form_error.get(),
+			Some("Please correct the submitted values\nowner_id: Owner is required".to_owned())
+		);
 	});
 }

--- a/crates/reinhardt-pages/tests/model_form_native_submit.rs
+++ b/crates/reinhardt-pages/tests/model_form_native_submit.rs
@@ -69,3 +69,50 @@ fn model_form_routes_structured_server_errors_to_selected_fields() {
 		);
 	});
 }
+
+#[test]
+fn model_form_runtime_mutations_track_explicit_and_excluded_fields() {
+	reinhardt_core::reactive::ReactiveScope::run(|| {
+		let explicit_form = form! {
+			name: QuestionExplicitRuntimeForm,
+			model: Question,
+			policy: QuestionPolicy,
+			fields: [title],
+			server_fn: save_question,
+		};
+		let explicit_runtime = use_form(&explicit_form).build();
+		explicit_runtime.set_value(explicit_form.title_field(), "changed".to_owned());
+		assert!(
+			explicit_runtime
+				.get_field_state(explicit_form.title_field())
+				.is_touched
+		);
+		assert!(
+			explicit_runtime
+				.get_field_state(explicit_form.title_field())
+				.is_dirty
+		);
+		explicit_runtime.reset_field(explicit_form.title_field());
+		assert!(
+			!explicit_runtime
+				.get_field_state(explicit_form.title_field())
+				.is_dirty
+		);
+
+		let excluded_form = form! {
+			name: QuestionExcludedRuntimeForm,
+			model: Question,
+			policy: QuestionPolicy,
+			exclude: [owner_id],
+			server_fn: save_question,
+		};
+		let excluded_field = excluded_form
+			.field("title")
+			.expect("policy-allowed excluded-form fields resolve by name");
+		assert!(excluded_form.field("owner_id").is_none());
+		let excluded_runtime = use_form(&excluded_form).build();
+		excluded_runtime.set_value(excluded_field, "changed".to_owned());
+		assert!(excluded_runtime.get_field_state(excluded_field).is_touched);
+		assert!(excluded_runtime.get_field_state(excluded_field).is_dirty);
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/form/model_json_support.rs
+++ b/crates/reinhardt-pages/tests/ui/form/model_json_support.rs
@@ -65,7 +65,6 @@ impl QuestionFormSchema {
 		&QUESTION_FIELDS[0]
 	}
 
-	#[cfg(wasm)]
 	const fn owner_id() -> &'static ModelFormFieldDescriptor {
 		&QUESTION_FIELDS[1]
 	}

--- a/crates/reinhardt-pages/tests/ui/form/model_json_support.rs
+++ b/crates/reinhardt-pages/tests/ui/form/model_json_support.rs
@@ -8,6 +8,11 @@ use reinhardt_pages::server_fn::{ServerFnError, server_fn};
 
 struct Question;
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct QuestionResponse {
+	token: String,
+}
+
 #[derive(Debug)]
 struct QuestionPolicy;
 
@@ -130,7 +135,11 @@ impl<P: ModelFormPolicy> NativeModelFormPayload for QuestionModelFormData<P> {
 #[server_fn(model_form = true)]
 async fn save_question(
 	payload: QuestionModelFormData<QuestionPolicy>,
-) -> Result<(), ServerFnError> {
+) -> Result<QuestionResponse, ServerFnError> {
 	let _ = payload;
-	Ok(())
+	let response = QuestionResponse {
+		token: "one-time-token".to_owned(),
+	};
+	let _ = &response.token;
+	Ok(response)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Retain typed successful responses from model-backed server functions in browser form submits.
- Map structured `ServerFnError` field errors into selected model-form controls while retaining unmatched errors at form level.
- Document the `use_form` response and error-handling contract.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code that causes existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Model-backed forms previously discarded the typed server response and exposed only a string error signal. Their generated runtime field token also could not resolve structured field names, so `use_form` could not display field-level validation details.

Fixes #6153

## How Was This Tested?

- `cargo test -p reinhardt-pages --test model_form_native_submit`
- `cargo test -p reinhardt-pages-macros test_generate_model_`
- `cargo test -p reinhardt-pages --test ui test_form_macro_pass -- --nocapture`
- `cargo check -p reinhardt-pages --target wasm32-unknown-unknown --test model_form_multipart_wasm_compile`
- `cargo clippy -p reinhardt-pages-macros --lib -- -D warnings`
- `cargo clippy -p reinhardt-pages --test model_form_native_submit -- -D warnings`
- `cargo clippy -p reinhardt-pages --target wasm32-unknown-unknown --test model_form_multipart_wasm_compile -- -D warnings`
- `cargo doc -p reinhardt-pages --no-deps`

## Performance Impact

-

## Checklist

- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [x] I have checked the code with targeted clippy commands

## Related Issues

- kent8192/reinhardt-cloud#875 tracks the downstream dashboard response/error handling gap.

**Additional Context:**

- The generated form continues to use the existing `use_form(...).submit_server_fn(...)` lifecycle; no callback or redirect API was added.
