### PR TITLE
fix(db): avoid duplicate single-column unique constraints

### DIFF
--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -4278,20 +4278,33 @@ impl MigrationAutodetector {
 		from_field: &FieldState,
 		to_field: &FieldState,
 	) -> bool {
-		let constraint_managed =
-			Self::single_field_unique_constraint_present(from_model, field_name)
-				|| Self::single_field_unique_constraint_present(to_model, field_name);
+		let from_constraint_managed =
+			Self::single_field_unique_constraint_present(from_model, field_name);
+		let to_constraint_managed =
+			Self::single_field_unique_constraint_present(to_model, field_name);
+		let constraint_managed = from_constraint_managed || to_constraint_managed;
+		let from_inline_unique = Self::field_has_inline_unique(from_model, field_name);
+		let to_inline_unique = Self::field_has_inline_unique(to_model, field_name);
 		let from_unique = Some(if constraint_managed {
-			false
+			from_inline_unique && !to_constraint_managed
 		} else {
 			Self::single_field_unique_column_already_present(from_model, field_name)
 		});
 		let to_unique = Some(if constraint_managed {
-			false
+			to_inline_unique && !from_constraint_managed
 		} else {
 			Self::single_field_unique_column_already_present(to_model, field_name)
 		});
 		self.has_field_changed_with_unique(field_name, from_field, to_field, from_unique, to_unique)
+	}
+
+	fn field_has_inline_unique(model: &ModelState, field_name: &str) -> bool {
+		model
+			.fields
+			.get(field_name)
+			.and_then(|field| field.params.get("unique"))
+			.map(String::as_str)
+			== Some("true")
 	}
 
 	fn has_field_changed_with_unique(
@@ -10048,6 +10061,70 @@ mod tests {
 			"expected NO Operation::AddConstraint, got: {:?}",
 			operations
 		);
+	}
+
+	#[test]
+	fn legacy_inline_and_named_unique_removal_changes_the_field_definition() {
+		// Arrange
+		let id_field = FieldState::new("id", super::super::FieldType::Integer, false);
+		let mut legacy_username =
+			FieldState::new("username", super::super::FieldType::VarChar(150), false);
+		legacy_username
+			.params
+			.insert("unique".to_string(), "true".to_string());
+		let named_constraint = ConstraintDefinition {
+			name: "users_username_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["username".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		};
+		let from_model = build_model_state(
+			"users",
+			"User",
+			vec![id_field.clone(), legacy_username],
+			Vec::new(),
+			vec![named_constraint],
+		);
+		let to_model = build_model_state(
+			"users",
+			"User",
+			vec![
+				id_field,
+				FieldState::new("username", super::super::FieldType::VarChar(150), false),
+			],
+			Vec::new(),
+			Vec::new(),
+		);
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(
+				("users".to_string(), "User".to_string()),
+				from_model,
+			)]),
+			build_project_state(vec![(("users".to_string(), "User".to_string()), to_model)]),
+		);
+
+		// Act
+		let operations = detector.generate_operations();
+
+		// Assert
+		assert!(operations.iter().any(|operation| {
+			matches!(
+				operation,
+				super::super::Operation::AlterColumn {
+					new_definition,
+					column,
+					..
+				} if column == "username" && !new_definition.unique
+			)
+		}));
+		assert!(operations.iter().any(|operation| {
+			matches!(
+				operation,
+				super::super::Operation::DropConstraint { constraint_name, .. }
+					if constraint_name == "users_username_uniq"
+			)
+		}));
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -4272,15 +4272,20 @@ impl MigrationAutodetector {
 		from_field: &FieldState,
 		to_field: &FieldState,
 	) -> bool {
-		let from_unique = Self::single_field_unique_column_already_present(from_model, field_name);
-		let to_unique = Self::single_field_unique_column_already_present(to_model, field_name);
-		self.has_field_changed_with_unique(
-			field_name,
-			from_field,
-			to_field,
-			Some(from_unique),
-			Some(to_unique),
-		)
+		let constraint_managed =
+			Self::single_field_unique_constraint_present(from_model, field_name)
+				|| Self::single_field_unique_constraint_present(to_model, field_name);
+		let from_unique = Some(if constraint_managed {
+			false
+		} else {
+			Self::single_field_unique_column_already_present(from_model, field_name)
+		});
+		let to_unique = Some(if constraint_managed {
+			false
+		} else {
+			Self::single_field_unique_column_already_present(to_model, field_name)
+		});
+		self.has_field_changed_with_unique(field_name, from_field, to_field, from_unique, to_unique)
 	}
 
 	fn has_field_changed_with_unique(
@@ -5101,11 +5106,7 @@ impl MigrationAutodetector {
 	}
 
 	fn single_field_unique_column_already_present(model: &ModelState, column: &str) -> bool {
-		let covered_by_constraint = model
-			.constraints
-			.iter()
-			.any(|c| is_single_field_unique(c) && c.fields[0] == column);
-		if covered_by_constraint {
+		if Self::single_field_unique_constraint_present(model, column) {
 			return true;
 		}
 		model
@@ -5114,6 +5115,13 @@ impl MigrationAutodetector {
 			.and_then(|f| f.params.get("unique"))
 			.map(String::as_str)
 			== Some("true")
+	}
+
+	fn single_field_unique_constraint_present(model: &ModelState, column: &str) -> bool {
+		model
+			.constraints
+			.iter()
+			.any(|constraint| is_single_field_unique(constraint) && constraint.fields[0] == column)
 	}
 
 	fn added_single_field_unique_preserved_by_rename(
@@ -5919,6 +5927,32 @@ impl MigrationAutodetector {
 			}
 		}
 
+		// DropConstraint for non-PK constraints removed from existing tables.
+		//
+		// Emit these before DropColumn: databases remove a column's dependent
+		// UNIQUE constraint together with the column, so dropping the constraint
+		// afterward would target an object that no longer exists.
+		for (app_label, model_name, constraint_name) in &changes.removed_constraints {
+			let Some(from_model) = self.from_state.get_model(app_label, model_name) else {
+				continue;
+			};
+			let is_composite_pk = from_model
+				.constraints
+				.iter()
+				.find(|c| &c.name == constraint_name)
+				.is_some_and(|c| c.constraint_type == "primary_key" && c.fields.len() >= 2);
+			if is_composite_pk {
+				continue;
+			}
+			by_app
+				.entry(app_label.clone())
+				.or_default()
+				.push(super::Operation::DropConstraint {
+					table: from_model.table_name.clone(),
+					constraint_name: constraint_name.clone(),
+				});
+		}
+
 		// DropColumn for removed fields.
 		for (app_label, model_name, field_name) in &changes.removed_fields {
 			if let Some(model) = self.from_state.get_model(app_label, model_name) {
@@ -5967,32 +6001,6 @@ impl MigrationAutodetector {
 					},
 				);
 			}
-		}
-
-		// DropConstraint for non-PK constraints removed from existing tables.
-		//
-		// Composite primary keys (constraint_type == "primary_key" with 2+
-		// fields) are handled by `removed_composite_primary_keys` above and
-		// must be skipped here to avoid emitting a duplicate DropConstraint.
-		for (app_label, model_name, constraint_name) in &changes.removed_constraints {
-			let Some(from_model) = self.from_state.get_model(app_label, model_name) else {
-				continue;
-			};
-			let is_composite_pk = from_model
-				.constraints
-				.iter()
-				.find(|c| &c.name == constraint_name)
-				.is_some_and(|c| c.constraint_type == "primary_key" && c.fields.len() >= 2);
-			if is_composite_pk {
-				continue;
-			}
-			by_app
-				.entry(app_label.clone())
-				.or_default()
-				.push(super::Operation::DropConstraint {
-					table: from_model.table_name.clone(),
-					constraint_name: constraint_name.clone(),
-				});
 		}
 
 		// AddConstraint for non-PK constraints added to existing tables.
@@ -10022,6 +10030,52 @@ mod tests {
 				.all(|op| !matches!(op, super::super::Operation::AddConstraint { .. })),
 			"expected NO Operation::AddConstraint, got: {:?}",
 			operations
+		);
+	}
+
+	#[test]
+	fn removed_unique_constraint_precedes_removed_column_without_alter_column() {
+		let id_field = FieldState::new("id", super::super::FieldType::Integer, false);
+		let username_field =
+			FieldState::new("username", super::super::FieldType::VarChar(150), false);
+		let unique_constraint = ConstraintDefinition {
+			name: "users_username_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["username".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		};
+		let from_model = build_model_state(
+			"users",
+			"User",
+			vec![id_field.clone(), username_field],
+			Vec::new(),
+			vec![unique_constraint],
+		);
+		let to_model = build_model_state("users", "User", vec![id_field], Vec::new(), Vec::new());
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(
+				("users".to_string(), "User".to_string()),
+				from_model,
+			)]),
+			build_project_state(vec![(("users".to_string(), "User".to_string()), to_model)]),
+		);
+
+		let operations = detector.generate_operations();
+		assert_eq!(operations.len(), 2, "unexpected operations: {operations:?}");
+		assert!(matches!(
+			&operations[0],
+			super::super::Operation::DropConstraint { constraint_name, .. }
+				if constraint_name == "users_username_uniq"
+		));
+		assert!(matches!(
+			&operations[1],
+			super::super::Operation::DropColumn { column, .. } if column == "username"
+		));
+		assert!(
+			operations
+				.iter()
+				.all(|operation| !matches!(operation, super::super::Operation::AlterColumn { .. }))
 		);
 	}
 

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -4540,6 +4540,8 @@ impl MigrationAutodetector {
 						removed_field,
 						added_name,
 						added_field,
+						Self::single_field_unique_column_already_present(from_model, removed_name),
+						Self::single_field_unique_column_already_present(to_model, added_name),
 					) {
 						old_to_new
 							.entry((*removed_name).clone())
@@ -4646,6 +4648,8 @@ impl MigrationAutodetector {
 		from_field: &FieldState,
 		to_name: &str,
 		to_field: &FieldState,
+		from_unique: bool,
+		to_unique: bool,
 	) -> bool {
 		if from_field.field_type != to_field.field_type
 			|| from_field.nullable != to_field.nullable
@@ -4658,6 +4662,8 @@ impl MigrationAutodetector {
 		let mut to_def = super::ColumnDefinition::from_field_state(to_name, to_field);
 		from_def.name = "__renamed_field__".to_string();
 		to_def.name = "__renamed_field__".to_string();
+		from_def.unique = from_unique;
+		to_def.unique = to_unique;
 		from_def == to_def
 	}
 
@@ -7027,6 +7033,68 @@ mod tests {
 			}),
 			"expected no AddConstraint/DropConstraint for unique rename, got: {operations:?}"
 		);
+	}
+
+	#[rstest]
+	fn generate_operations_renames_unique_column_from_inline_to_model_constraint() {
+		// Arrange
+		let id_field = FieldState::new("id", super::super::FieldType::Integer, false);
+		let mut old_email_field =
+			FieldState::new("old_email", super::super::FieldType::VarChar(255), false);
+		old_email_field
+			.params
+			.insert("unique".to_string(), "true".to_string());
+		let new_email_field =
+			FieldState::new("email", super::super::FieldType::VarChar(255), false);
+		let new_unique = ConstraintDefinition {
+			name: "accounts_account_email_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["email".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		};
+		let from_model = build_model_state(
+			"accounts",
+			"Account",
+			vec![id_field.clone(), old_email_field],
+			Vec::new(),
+			Vec::new(),
+		);
+		let to_model = build_model_state(
+			"accounts",
+			"Account",
+			vec![id_field, new_email_field],
+			Vec::new(),
+			vec![new_unique],
+		);
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(
+				("accounts".to_string(), "Account".to_string()),
+				from_model,
+			)]),
+			build_project_state(vec![(
+				("accounts".to_string(), "Account".to_string()),
+				to_model,
+			)]),
+		);
+
+		// Act
+		let operations = detector
+			.try_generate_operations()
+			.expect("unique field rename should generate operations");
+
+		// Assert
+		assert_eq!(operations.len(), 1, "unexpected operations: {operations:?}");
+		assert!(matches!(
+			&operations[0],
+			super::super::Operation::RenameColumn {
+				table,
+				old_name,
+				new_name
+			} if table == "accounts_account"
+				&& old_name == "old_email"
+				&& new_name == "email"
+		));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1805,11 +1805,91 @@ impl ProjectState {
 	}
 
 	fn parse_constraint_identifier_list(identifier_list: &str) -> Vec<String> {
-		identifier_list
-			.split(',')
-			.map(Self::trim_sql_identifier)
-			.filter(|identifier| !identifier.is_empty())
-			.collect()
+		let mut identifiers = Vec::new();
+		let mut current = String::new();
+		let mut quote = None;
+		let mut depth = 0usize;
+		let mut chars = identifier_list.chars().peekable();
+
+		while let Some(character) = chars.next() {
+			if let Some(quote_char) = quote {
+				current.push(character);
+				if character == quote_char {
+					if chars.peek() == Some(&quote_char) {
+						current.push(chars.next().expect("peeked quote must exist"));
+					} else {
+						quote = None;
+					}
+				}
+				continue;
+			}
+
+			match character {
+				'\'' | '"' | '`' => {
+					quote = Some(character);
+					current.push(character);
+				}
+				'(' => {
+					depth += 1;
+					current.push(character);
+				}
+				')' => {
+					depth = depth.saturating_sub(1);
+					current.push(character);
+				}
+				',' if depth == 0 => {
+					let identifier = Self::trim_sql_identifier(&current);
+					if !identifier.is_empty() {
+						identifiers.push(identifier);
+					}
+					current.clear();
+				}
+				_ => current.push(character),
+			}
+		}
+
+		let identifier = Self::trim_sql_identifier(&current);
+		if !identifier.is_empty() {
+			identifiers.push(identifier);
+		}
+		identifiers
+	}
+
+	fn extract_sql_parenthesized_expression(sql: &str, open: usize) -> Option<(&str, usize)> {
+		if !sql.is_char_boundary(open) || sql[open..].chars().next()? != '(' {
+			return None;
+		}
+
+		let mut depth = 0usize;
+		let mut quote = None;
+		let mut chars = sql[open..].char_indices().peekable();
+		while let Some((relative_index, character)) = chars.next() {
+			let index = open + relative_index;
+			if let Some(quote_char) = quote {
+				if character == quote_char {
+					if chars.peek().is_some_and(|(_, next)| *next == quote_char) {
+						chars.next();
+					} else {
+						quote = None;
+					}
+				}
+				continue;
+			}
+
+			match character {
+				'\'' | '"' | '`' => quote = Some(character),
+				'(' => depth += 1,
+				')' => {
+					depth = depth.checked_sub(1)?;
+					if depth == 0 {
+						return Some((&sql[open + 1..index], index));
+					}
+				}
+				_ => {}
+			}
+		}
+
+		None
 	}
 
 	fn foreign_key_action_from_clause(clauses: &str, clause: &str) -> Option<ForeignKeyAction> {
@@ -1837,12 +1917,8 @@ impl ProjectState {
 		let upper_body = body.to_ascii_uppercase();
 		if upper_body.starts_with("UNIQUE (") {
 			let open = body.find('(')?;
-			let close = body[open + 1..].find(')')? + open + 1;
-			let fields = body[open + 1..close]
-				.split(',')
-				.map(|field| field.trim().trim_matches('"').to_string())
-				.filter(|field| !field.is_empty())
-				.collect::<Vec<_>>();
+			let (identifier_list, _) = Self::extract_sql_parenthesized_expression(body, open)?;
+			let fields = Self::parse_constraint_identifier_list(identifier_list);
 			if fields.is_empty() {
 				return None;
 			}
@@ -1867,8 +1943,8 @@ impl ProjectState {
 		}
 		if upper_body.starts_with("FOREIGN KEY") {
 			let open = body.find('(')?;
-			let close = body[open + 1..].find(')')? + open + 1;
-			let fields = Self::parse_constraint_identifier_list(&body[open + 1..close]);
+			let (identifier_list, close) = Self::extract_sql_parenthesized_expression(body, open)?;
+			let fields = Self::parse_constraint_identifier_list(identifier_list);
 			if fields.is_empty() {
 				return None;
 			}
@@ -1884,11 +1960,10 @@ impl ProjectState {
 				return None;
 			}
 
-			let referenced_close =
-				after_references[referenced_open + 1..].find(')')? + referenced_open + 1;
-			let referenced_columns = Self::parse_constraint_identifier_list(
-				&after_references[referenced_open + 1..referenced_close],
-			);
+			let (referenced_identifier_list, referenced_close) =
+				Self::extract_sql_parenthesized_expression(after_references, referenced_open)?;
+			let referenced_columns =
+				Self::parse_constraint_identifier_list(referenced_identifier_list);
 			if referenced_columns.is_empty() {
 				return None;
 			}
@@ -11527,6 +11602,20 @@ mod tests {
 					if constraint_name == "users_username_uniq"
 			)
 		}));
+	}
+
+	#[test]
+	fn constraint_definition_parser_handles_quoted_unique_identifiers() {
+		// Arrange
+		let sql = "CONSTRAINT uq_profile UNIQUE (\"profile,id\", \"name)\")";
+
+		// Act
+		let constraint = ProjectState::constraint_definition_from_sql(sql)
+			.expect("quoted UNIQUE columns should parse");
+
+		// Assert
+		assert_eq!(constraint.name, "uq_profile");
+		assert_eq!(constraint.fields, vec!["profile,id", "name)"]);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -4974,7 +4974,7 @@ impl MigrationAutodetector {
 	///    column — same semantics, different name. This handles the
 	///    DB-introspection case where SQLite auto-generates names like
 	///    `sqlite_autoindex_users_1`, which never match the to-state's
-	///    `{app}_{model}_{field}_uniq`.
+	///    `{table}_{field}_uniq`.
 	/// 3. From-state has a `FieldState` for that column with
 	///    `params["unique"] == "true"`. This handles the file-based
 	///    reconstruction path: `apply_migration_operations` translates
@@ -5159,7 +5159,7 @@ impl MigrationAutodetector {
 	/// any future codepath that produces both an `AddColumn { column.unique
 	/// = true }` and a peer `AddConstraint` for the same single column —
 	/// for example, a column being added in the same migration as the
-	/// model registry synthesises its `{app}_{model}_{field}_uniq`
+	/// model registry synthesises its `{table}_{field}_uniq`
 	/// constraint.
 	///
 	/// Coverage rules (per `(table, column)`):
@@ -9913,12 +9913,12 @@ mod tests {
 			Vec::new(),
 		);
 
-		// `to_state` mimics what `ModelMetadata::to_model_state()` produces:
-		// the same inline-unique param PLUS a synthesised single-field
-		// UNIQUE `ConstraintDefinition` named per the
-		// `{app}_{model.to_lowercase()}_{field}_uniq` convention.
+		// `to_state` mimics what `ModelMetadata::to_model_state()` produces
+		// after the fix: a single-field UNIQUE `ConstraintDefinition` named
+		// per the `{table}_{field}_uniq` convention, without a duplicate
+		// inline field flag.
 		let synthesised = ConstraintDefinition {
-			name: "users_user_username_uniq".to_string(),
+			name: "users_username_uniq".to_string(),
 			constraint_type: "unique".to_string(),
 			fields: vec!["username".to_string()],
 			expression: None,
@@ -9927,7 +9927,10 @@ mod tests {
 		let to_model = build_model_state(
 			"users",
 			"User",
-			vec![id_field, username_field],
+			vec![
+				id_field,
+				FieldState::new("username", super::super::FieldType::VarChar(150), false),
+			],
 			Vec::new(),
 			vec![synthesised],
 		);
@@ -9958,8 +9961,8 @@ mod tests {
 	/// `from_state` carries a single-field UNIQUE constraint with a
 	/// dialect-specific auto-name (e.g. SQLite's
 	/// `sqlite_autoindex_users_1`), and `to_state` declares the same
-	/// column's UNIQUE with the model-derived name
-	/// (`users_user_username_uniq`). The names differ but the semantics
+	/// column's UNIQUE with the table-derived name
+	/// (`users_username_uniq`). The names differ but the semantics
 	/// are identical — no `AddConstraint` must be emitted.
 	#[rstest]
 	fn single_field_unique_constraint_renames_do_not_emit_redundant_add_constraint() {
@@ -9975,7 +9978,7 @@ mod tests {
 			foreign_key_info: None,
 		};
 		let model_named = ConstraintDefinition {
-			name: "users_user_username_uniq".to_string(),
+			name: "users_username_uniq".to_string(),
 			constraint_type: "unique".to_string(),
 			fields: vec!["username".to_string()],
 			expression: None,
@@ -10044,7 +10047,7 @@ mod tests {
 			.params
 			.insert("unique".to_string(), "true".to_string());
 		let unique_constraint = ConstraintDefinition {
-			name: "users_user_username_uniq".to_string(),
+			name: "users_username_uniq".to_string(),
 			constraint_type: "unique".to_string(),
 			fields: vec!["username".to_string()],
 			expression: None,
@@ -10117,7 +10120,7 @@ mod tests {
 			},
 			super::super::Operation::AddConstraint {
 				table: "users".to_string(),
-				constraint_sql: "CONSTRAINT users_user_username_uniq UNIQUE (username)".to_string(),
+				constraint_sql: "CONSTRAINT users_username_uniq UNIQUE (username)".to_string(),
 			},
 		];
 		let mut by_app: std::collections::BTreeMap<String, Vec<super::super::Operation>> =

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -269,17 +269,23 @@ fn parse_single_column_unique(constraint_sql: &str) -> Option<&str> {
 	if body.contains(',') || body.is_empty() {
 		return None;
 	}
-	Some(body)
+	Some(
+		body.strip_prefix('"')
+			.and_then(|body| body.strip_suffix('"'))
+			.unwrap_or(body),
+	)
 }
 
 impl ConstraintDefinition {
 	/// Convert ConstraintDefinition to operations::Constraint
 	pub fn to_constraint(&self) -> super::operations::Constraint {
 		match self.constraint_type.as_str() {
-			"unique" => super::operations::Constraint::Unique {
-				name: self.name.clone(),
-				columns: self.fields.clone(),
-			},
+			unique if unique.eq_ignore_ascii_case("unique") => {
+				super::operations::Constraint::Unique {
+					name: self.name.clone(),
+					columns: self.fields.clone(),
+				}
+			}
 			"check" => super::operations::Constraint::Check {
 				name: self.name.clone(),
 				expression: self.expression.clone().unwrap_or_default(),
@@ -5005,11 +5011,10 @@ impl MigrationAutodetector {
 				self.matching_from_model_for_to_model(app_label, model_name, to_model, changes)
 			{
 				for to_constraint in &to_model.constraints {
-					if from_model
-						.constraints
-						.iter()
-						.any(|c| c.name == to_constraint.name)
-					{
+					if from_model.constraints.iter().any(|c| {
+						c.name == to_constraint.name
+							&& Self::constraint_definitions_match(c, to_constraint)
+					}) {
 						continue;
 					}
 					if Self::single_field_unique_already_present(to_constraint, from_model) {
@@ -5055,11 +5060,10 @@ impl MigrationAutodetector {
 				self.matching_to_model_for_from_model(app_label, model_name, from_model, changes)
 			{
 				for from_constraint in &from_model.constraints {
-					if to_model
-						.constraints
-						.iter()
-						.any(|c| c.name == from_constraint.name)
-					{
+					if to_model.constraints.iter().any(|c| {
+						c.name == from_constraint.name
+							&& Self::constraint_definitions_match(c, from_constraint)
+					}) {
 						continue;
 					}
 					if Self::single_field_unique_already_present(from_constraint, to_model) {
@@ -5082,6 +5086,17 @@ impl MigrationAutodetector {
 				}
 			}
 		}
+	}
+
+	fn constraint_definitions_match(
+		left: &ConstraintDefinition,
+		right: &ConstraintDefinition,
+	) -> bool {
+		left.constraint_type
+			.eq_ignore_ascii_case(&right.constraint_type)
+			&& left.fields == right.fields
+			&& left.expression == right.expression
+			&& left.foreign_key_info == right.foreign_key_info
 	}
 
 	/// Returns true when `candidate` is a single-field UNIQUE constraint and

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -5154,6 +5154,7 @@ impl MigrationAutodetector {
 			app == app_label
 				&& model == model_name
 				&& new == new_column
+				&& !Self::single_field_unique_constraint_present(from_model, old)
 				&& Self::single_field_unique_column_already_present(from_model, old)
 		})
 	}
@@ -5173,6 +5174,7 @@ impl MigrationAutodetector {
 			app == app_label
 				&& (model == from_model_name || model == &to_model.name)
 				&& old == old_column
+				&& !Self::single_field_unique_constraint_present(to_model, new)
 				&& Self::single_field_unique_column_already_present(to_model, new)
 		})
 	}
@@ -6987,7 +6989,7 @@ mod tests {
 	}
 
 	#[rstest]
-	fn generate_operations_renames_unique_column_without_constraint_churn() {
+	fn generate_operations_renames_unique_column_with_constraint_name_change() {
 		let id_field = FieldState::new("id", super::super::FieldType::Integer, false);
 		let old_slug_field =
 			FieldState::new("old_slug", super::super::FieldType::VarChar(255), false);
@@ -7035,7 +7037,7 @@ mod tests {
 			.try_generate_operations()
 			.expect("unique column rename should generate operations");
 
-		assert_eq!(operations.len(), 1, "unexpected operations: {operations:?}");
+		assert_eq!(operations.len(), 3, "unexpected operations: {operations:?}");
 		assert!(matches!(
 			&operations[0],
 			super::super::Operation::RenameColumn {
@@ -7046,16 +7048,16 @@ mod tests {
 				&& old_name == "old_slug"
 				&& new_name == "slug"
 		));
-		assert!(
-			operations.iter().all(|op| {
-				!matches!(
-					op,
-					super::super::Operation::AddConstraint { .. }
-						| super::super::Operation::DropConstraint { .. }
-				)
-			}),
-			"expected no AddConstraint/DropConstraint for unique rename, got: {operations:?}"
-		);
+		assert!(matches!(
+			&operations[1],
+			super::super::Operation::DropConstraint { constraint_name, .. }
+				if constraint_name == "deployments_deployment_old_slug_uniq"
+		));
+		assert!(matches!(
+			&operations[2],
+			super::super::Operation::AddConstraint { constraint_sql, .. }
+				if constraint_sql == "CONSTRAINT deployments_deployment_slug_uniq UNIQUE (slug)"
+		));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-db/src/migrations/executor.rs
+++ b/crates/reinhardt-db/src/migrations/executor.rs
@@ -11,6 +11,8 @@ use super::{
 };
 use crate::backends::{connection::DatabaseConnection, types::DatabaseType};
 use indexmap::IndexMap;
+#[cfg(feature = "sqlite")]
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 #[cfg(feature = "sqlite")]
@@ -818,7 +820,11 @@ impl DatabaseMigrationExecutor {
 	async fn read_sqlite_table_via_editor(
 		editor: &mut SchemaEditor,
 		table_name: &str,
-	) -> Result<(Vec<super::ColumnDefinition>, Vec<super::Constraint>)> {
+	) -> Result<(
+		Vec<super::ColumnDefinition>,
+		Vec<super::Constraint>,
+		HashMap<String, String>,
+	)> {
 		// 1. PRAGMA table_info(<table>) → columns. Identifier interpolation
 		//    via the shared `sqlite_pragma` helper. See issue #4454.
 		// nosemgrep: rust.actix.sql.sqlx-taint.sqlx-taint
@@ -970,6 +976,7 @@ impl DatabaseMigrationExecutor {
 		}
 
 		let mut constraints: Vec<super::Constraint> = Vec::new();
+		let mut sqlite_constraint_aliases = HashMap::new();
 		for (fk_id, mut group) in fk_groups {
 			group.sort_by_key(|r| r.seq);
 			let referenced_table = group[0].table.clone();
@@ -1018,11 +1025,14 @@ impl DatabaseMigrationExecutor {
 				.iter()
 				.filter_map(|r| r.get::<String>("name").ok())
 				.collect();
+			let declared_name = named_unique_constraints.get(&cols).cloned();
+			if let Some(declared_name) = &declared_name
+				&& declared_name != &idx_name
+			{
+				sqlite_constraint_aliases.insert(idx_name.clone(), declared_name.clone());
+			}
 			constraints.push(super::Constraint::Unique {
-				name: named_unique_constraints
-					.get(&cols)
-					.cloned()
-					.unwrap_or(idx_name),
+				name: declared_name.unwrap_or(idx_name),
 				columns: cols,
 			});
 		}
@@ -1041,7 +1051,18 @@ impl DatabaseMigrationExecutor {
 			}
 		}
 
-		Ok((columns, constraints))
+		Ok((columns, constraints, sqlite_constraint_aliases))
+	}
+
+	#[cfg(feature = "sqlite")]
+	fn resolve_sqlite_constraint_name<'a>(
+		aliases: &'a HashMap<String, String>,
+		requested_name: &'a str,
+	) -> &'a str {
+		aliases
+			.get(requested_name)
+			.map(String::as_str)
+			.unwrap_or(requested_name)
 	}
 
 	/// Handle SQLite table recreation for operations that require it
@@ -1081,7 +1102,7 @@ impl DatabaseMigrationExecutor {
 					table,
 					column
 				);
-				let (columns, constraints) =
+				let (columns, constraints, _) =
 					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_drop_column(table, columns, column, constraints)
 			}
@@ -1096,7 +1117,7 @@ impl DatabaseMigrationExecutor {
 					table,
 					column
 				);
-				let (columns, constraints) =
+				let (columns, constraints, _) =
 					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_alter_column(
 					table,
@@ -1114,7 +1135,7 @@ impl DatabaseMigrationExecutor {
 					"Handling SQLite table recreation for AddConstraint: table={}",
 					table
 				);
-				let (columns, constraints) =
+				let (columns, constraints, _) =
 					Self::read_sqlite_table_via_editor(editor, table).await?;
 				SqliteTableRecreation::for_add_constraint(
 					table,
@@ -1132,13 +1153,14 @@ impl DatabaseMigrationExecutor {
 					table,
 					constraint_name
 				);
-				let (columns, constraints) =
+				let (columns, constraints, aliases) =
 					Self::read_sqlite_table_via_editor(editor, table).await?;
+				let resolved_name = Self::resolve_sqlite_constraint_name(&aliases, constraint_name);
 				SqliteTableRecreation::for_drop_constraint(
 					table,
 					columns,
 					constraints,
-					constraint_name,
+					resolved_name,
 				)
 			}
 			_ => {
@@ -1780,6 +1802,27 @@ mod optimizer_tests {
 
 		let optimized = optimizer.optimize(ops);
 		assert_eq!(optimized.len(), 3);
+	}
+
+	#[cfg(feature = "sqlite")]
+	#[test]
+	fn sqlite_autoindex_alias_resolves_to_declared_constraint_name() {
+		let aliases = std::collections::HashMap::from([(
+			"sqlite_autoindex_users_1".to_string(),
+			"users_email_uniq".to_string(),
+		)]);
+
+		assert_eq!(
+			DatabaseMigrationExecutor::resolve_sqlite_constraint_name(
+				&aliases,
+				"sqlite_autoindex_users_1"
+			),
+			"users_email_uniq"
+		);
+		assert_eq!(
+			DatabaseMigrationExecutor::resolve_sqlite_constraint_name(&aliases, "users_email_uniq"),
+			"users_email_uniq"
+		);
 	}
 
 	#[cfg(test)]

--- a/crates/reinhardt-db/src/migrations/executor.rs
+++ b/crates/reinhardt-db/src/migrations/executor.rs
@@ -948,6 +948,10 @@ impl DatabaseMigrationExecutor {
 			.as_ref()
 			.map(|sql| SQLiteIntrospector::parse_fk_constraint_names(sql))
 			.unwrap_or_default();
+		let named_unique_constraints = create_sql
+			.as_ref()
+			.map(|sql| SQLiteIntrospector::parse_unique_constraint_names(sql))
+			.unwrap_or_default();
 
 		let mut fk_groups: std::collections::HashMap<i64, Vec<FkRow>> =
 			std::collections::HashMap::new();
@@ -1015,7 +1019,10 @@ impl DatabaseMigrationExecutor {
 				.filter_map(|r| r.get::<String>("name").ok())
 				.collect();
 			constraints.push(super::Constraint::Unique {
-				name: idx_name,
+				name: named_unique_constraints
+					.get(&cols)
+					.cloned()
+					.unwrap_or(idx_name),
 				columns: cols,
 			});
 		}

--- a/crates/reinhardt-db/src/migrations/introspection.rs
+++ b/crates/reinhardt-db/src/migrations/introspection.rs
@@ -1548,6 +1548,10 @@ impl SQLiteIntrospector {
 			.fetch_all(&self.pool)
 			.await
 			.map_err(|e| MigrationError::IntrospectionError(e.to_string()))?;
+		let named_unique_constraints = Self::get_create_table_sql(&self.pool, table_name)
+			.await?
+			.map(|sql| Self::parse_unique_constraint_names(&sql))
+			.unwrap_or_default();
 
 		let mut constraints = Vec::new();
 		for index_row in index_list {
@@ -1568,7 +1572,10 @@ impl SQLiteIntrospector {
 					.collect();
 
 				constraints.push(UniqueConstraintInfo {
-					name: index_row.name,
+					name: named_unique_constraints
+						.get(&columns)
+						.cloned()
+						.unwrap_or(index_row.name),
 					columns,
 				});
 			}

--- a/crates/reinhardt-db/src/migrations/introspection.rs
+++ b/crates/reinhardt-db/src/migrations/introspection.rs
@@ -1465,6 +1465,42 @@ impl SQLiteIntrospector {
 		result
 	}
 
+	/// Parses named UNIQUE constraint names from a CREATE TABLE SQL statement.
+	///
+	/// SQLite exposes named table UNIQUE constraints through `PRAGMA index_list`
+	/// as `sqlite_autoindex_*`; matching by columns preserves the declared name
+	/// for later `DropConstraint` operations.
+	pub(crate) fn parse_unique_constraint_names(create_sql: &str) -> HashMap<Vec<String>, String> {
+		let mut result = HashMap::new();
+		let Ok(re) = regex::Regex::new(
+			r#"(?i)CONSTRAINT\s+["'`]?([^\s"'`]+)["'`]?[\s]+UNIQUE\s*\(([^)]+)\)"#,
+		) else {
+			return result;
+		};
+
+		for cap in re.captures_iter(create_sql) {
+			let (Some(name), Some(columns)) = (cap.get(1), cap.get(2)) else {
+				continue;
+			};
+			let columns = columns
+				.as_str()
+				.split(',')
+				.map(|column| {
+					column
+						.trim()
+						.trim_matches('"')
+						.trim_matches('\'')
+						.trim_matches('`')
+						.to_owned()
+				})
+				.collect::<Vec<_>>();
+			if !columns.is_empty() {
+				result.insert(columns, name.as_str().to_owned());
+			}
+		}
+		result
+	}
+
 	/// Extracts unique constraints from PRAGMA index_list where origin = 'u'.
 	async fn extract_unique_constraints(
 		&self,
@@ -2276,5 +2312,14 @@ mod tests {
 			Some(&"fk_owner".to_string())
 		);
 		assert!(SQLiteIntrospector::parse_fk_constraint_names("FOREIGN KEY (owner_id)").is_empty());
+
+		let unique_names = SQLiteIntrospector::parse_unique_constraint_names(
+			"CREATE TABLE t (CONSTRAINT \"uq_group\" UNIQUE (\"group\", email), UNIQUE (name))",
+		);
+		assert_eq!(
+			unique_names.get(&vec!["group".to_string(), "email".to_string()]),
+			Some(&"uq_group".to_string())
+		);
+		assert!(!unique_names.contains_key(&vec!["name".to_string()]));
 	}
 }

--- a/crates/reinhardt-db/src/migrations/introspection.rs
+++ b/crates/reinhardt-db/src/migrations/introspection.rs
@@ -1397,26 +1397,44 @@ impl SQLiteIntrospector {
 	/// `start_pos` should be the position of the opening parenthesis.
 	fn extract_parenthesized_expression(sql: &str, start_pos: usize) -> Option<String> {
 		let chars: Vec<char> = sql.chars().collect();
+		let start_pos = sql.get(..start_pos)?.chars().count();
 		if start_pos >= chars.len() || chars[start_pos] != '(' {
 			return None;
 		}
 
-		let mut depth = 0;
+		let mut depth: usize = 0;
 		let expr_start = start_pos + 1;
 		let mut expr_end = start_pos + 1;
+		let mut quote = None;
+		let mut index = start_pos;
 
-		for (i, &c) in chars.iter().enumerate().skip(start_pos) {
+		while index < chars.len() {
+			let c = chars[index];
+			if let Some(quote_char) = quote {
+				if c == quote_char {
+					if chars.get(index + 1) == Some(&quote_char) {
+						index += 2;
+						continue;
+					}
+					quote = None;
+				}
+				index += 1;
+				continue;
+			}
+
 			match c {
+				'\'' | '"' | '`' => quote = Some(c),
 				'(' => depth += 1,
 				')' => {
 					depth -= 1;
 					if depth == 0 {
-						expr_end = i;
+						expr_end = index;
 						break;
 					}
 				}
 				_ => {}
 			}
+			index += 1;
 		}
 
 		if depth == 0 && expr_end > expr_start {
@@ -1472,33 +1490,91 @@ impl SQLiteIntrospector {
 	/// for later `DropConstraint` operations.
 	pub(crate) fn parse_unique_constraint_names(create_sql: &str) -> HashMap<Vec<String>, String> {
 		let mut result = HashMap::new();
-		let Ok(re) = regex::Regex::new(
-			r#"(?i)CONSTRAINT\s+["'`]?([^\s"'`]+)["'`]?[\s]+UNIQUE\s*\(([^)]+)\)"#,
-		) else {
+		let Ok(re) = regex::Regex::new(r#"(?i)CONSTRAINT\s+["'`]?([^\s"'`]+)["'`]?\s+UNIQUE\s*\("#)
+		else {
 			return result;
 		};
 
 		for cap in re.captures_iter(create_sql) {
-			let (Some(name), Some(columns)) = (cap.get(1), cap.get(2)) else {
+			let Some(name) = cap.get(1) else {
 				continue;
 			};
-			let columns = columns
-				.as_str()
-				.split(',')
-				.map(|column| {
-					column
-						.trim()
-						.trim_matches('"')
-						.trim_matches('\'')
-						.trim_matches('`')
-						.to_owned()
-				})
-				.collect::<Vec<_>>();
+			let opening = cap.get(0).map(|matched| matched.end() - 1);
+			let Some(columns) = opening
+				.and_then(|position| Self::extract_parenthesized_expression(create_sql, position))
+			else {
+				continue;
+			};
+			let columns = Self::split_sql_identifier_list(&columns);
 			if !columns.is_empty() {
 				result.insert(columns, name.as_str().to_owned());
 			}
 		}
 		result
+	}
+
+	fn split_sql_identifier_list(value: &str) -> Vec<String> {
+		let mut identifiers = Vec::new();
+		let mut current = String::new();
+		let mut quote = None;
+		let mut depth: usize = 0;
+		let mut chars = value.chars().peekable();
+
+		while let Some(character) = chars.next() {
+			if let Some(quote_char) = quote {
+				current.push(character);
+				if character == quote_char {
+					if chars.peek() == Some(&quote_char) {
+						current.push(chars.next().expect("peeked quote must exist"));
+					} else {
+						quote = None;
+					}
+				}
+				continue;
+			}
+
+			match character {
+				'\'' | '"' | '`' => {
+					quote = Some(character);
+					current.push(character);
+				}
+				'(' => {
+					depth += 1;
+					current.push(character);
+				}
+				')' => {
+					depth = depth.saturating_sub(1);
+					current.push(character);
+				}
+				',' if depth == 0 => {
+					let identifier = Self::normalize_sql_identifier(&current);
+					if !identifier.is_empty() {
+						identifiers.push(identifier);
+					}
+					current.clear();
+				}
+				_ => current.push(character),
+			}
+		}
+
+		let identifier = Self::normalize_sql_identifier(&current);
+		if !identifier.is_empty() {
+			identifiers.push(identifier);
+		}
+		identifiers
+	}
+
+	fn normalize_sql_identifier(value: &str) -> String {
+		let value = value.trim();
+		let Some(first) = value.chars().next() else {
+			return String::new();
+		};
+		let is_quoted = matches!(first, '\'' | '"' | '`') && value.ends_with(first);
+		if is_quoted {
+			let inner = &value[first.len_utf8()..value.len() - first.len_utf8()];
+			return inner.replace(&format!("{first}{first}"), &first.to_string());
+		}
+		value.to_owned()
 	}
 
 	/// Extracts unique constraints from PRAGMA index_list where origin = 'u'.
@@ -2328,5 +2404,17 @@ mod tests {
 			Some(&"uq_group".to_string())
 		);
 		assert!(!unique_names.contains_key(&vec!["name".to_string()]));
+
+		let quoted_names = SQLiteIntrospector::parse_unique_constraint_names(
+			"CREATE TABLE t (CONSTRAINT uq_quoted UNIQUE (\"profile,id\", \"name)\", \"display\"\"name\"))",
+		);
+		assert_eq!(
+			quoted_names.get(&vec![
+				"profile,id".to_string(),
+				"name)".to_string(),
+				"display\"name".to_string(),
+			]),
+			Some(&"uq_quoted".to_string())
+		);
 	}
 }

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -113,7 +113,7 @@ impl ModelMetadata {
 	) -> String {
 		let base_name = format!(
 			"{}_{}_uniq",
-			safe_constraint_name_fragment(&self.table_name),
+			safe_constraint_table_fragment(&self.table_name),
 			safe_constraint_name_fragment(field_name)
 		);
 		let is_taken = |candidate: &str| {
@@ -210,7 +210,15 @@ impl ModelMetadata {
 		// `unique` flag is consumed above so the same declaration cannot be
 		// emitted both inline and as a table constraint.
 		let mut generated_unique_constraint_names = HashSet::new();
-		for (field_name, field_meta) in &self.fields {
+		let mut unique_fields = self
+			.fields
+			.iter()
+			.filter(|(_, field_meta)| {
+				field_meta.params.get("unique").map(String::as_str) == Some("true")
+			})
+			.collect::<Vec<_>>();
+		unique_fields.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+		for (field_name, field_meta) in unique_fields {
 			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
 				// Prefer a model-level declaration when it explicitly names the
 				// single-column constraint. This keeps one physical constraint and
@@ -268,6 +276,23 @@ fn safe_constraint_name_fragment(value: &str) -> String {
 		fragment.insert_str(0, "table_");
 	}
 	fragment
+}
+
+fn safe_constraint_table_fragment(value: &str) -> String {
+	let fragment = safe_constraint_name_fragment(value);
+	if fragment == value {
+		return fragment;
+	}
+	format!("{fragment}_{:08x}", stable_constraint_name_hash(value))
+}
+
+fn stable_constraint_name_hash(value: &str) -> u32 {
+	let mut hash = 0x811c9dc5_u32;
+	for byte in value.bytes() {
+		hash ^= u32::from(byte);
+		hash = hash.wrapping_mul(0x01000193);
+	}
+	hash
 }
 
 /// Field metadata for registration
@@ -1028,6 +1053,10 @@ mod tests {
 		// Act
 		let model_state = metadata.to_model_state();
 		let constraint_name = model_state.constraints[0].name.clone();
+		let expected_constraint_name = format!(
+			"user_events_{:08x}_token_uniq",
+			stable_constraint_name_hash("User-Events")
+		);
 		let mut to_state = ProjectState::new();
 		to_state.add_model(model_state);
 		let migrations =
@@ -1035,10 +1064,31 @@ mod tests {
 		let sql = migrations[0].operations[0].to_sql(&SqlDialect::Postgres);
 
 		// Assert
-		assert_eq!(constraint_name, "user_events_token_uniq");
+		assert_eq!(constraint_name, expected_constraint_name);
 		assert_eq!(
 			sql,
-			"CREATE TABLE \"User-Events\" (\n  token VARCHAR(255) NOT NULL,\n  CONSTRAINT user_events_token_uniq UNIQUE (token)\n);"
+			format!(
+				"CREATE TABLE \"User-Events\" (\n  token VARCHAR(255) NOT NULL,\n  CONSTRAINT {expected_constraint_name} UNIQUE (token)\n);"
+			)
+		);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_names_are_distinct_for_normalized_tables() {
+		let mut dashed = ModelMetadata::new("accounts", "Dashed", "User-Events");
+		dashed.add_field(
+			"token".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		let mut underscored = ModelMetadata::new("accounts", "Underscored", "user_events");
+		underscored.add_field(
+			"token".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		assert_ne!(
+			dashed.to_model_state().constraints[0].name,
+			underscored.to_model_state().constraints[0].name
 		);
 	}
 

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -106,6 +106,33 @@ impl ModelMetadata {
 		self.constraints.push(constraint);
 	}
 
+	fn synthesized_unique_constraint_name(&self, field_name: &str) -> String {
+		let base_name = format!(
+			"{}_{}_uniq",
+			safe_constraint_name_fragment(&self.table_name),
+			safe_constraint_name_fragment(field_name)
+		);
+		if !self
+			.constraints
+			.iter()
+			.any(|constraint| constraint.name.eq_ignore_ascii_case(&base_name))
+		{
+			return base_name;
+		}
+
+		let mut candidate = format!("{base_name}_field");
+		let mut suffix = 2;
+		while self
+			.constraints
+			.iter()
+			.any(|constraint| constraint.name.eq_ignore_ascii_case(&candidate))
+		{
+			candidate = format!("{base_name}_field_{suffix}");
+			suffix += 1;
+		}
+		candidate
+	}
+
 	/// Returns model-level constraints registered by the `#[model(...)]`
 	/// macro (currently composite UNIQUE from `unique_together`).
 	///
@@ -191,7 +218,7 @@ impl ModelMetadata {
 					continue;
 				}
 				let constraint = ConstraintDefinition {
-					name: format!("{}_{}_uniq", self.table_name, field_name),
+					name: self.synthesized_unique_constraint_name(field_name),
 					constraint_type: "unique".to_string(),
 					fields: vec![field_name.clone()],
 					expression: None,
@@ -210,6 +237,28 @@ impl ModelMetadata {
 
 		model_state
 	}
+}
+
+fn safe_constraint_name_fragment(value: &str) -> String {
+	let mut fragment = String::with_capacity(value.len());
+	for character in value.chars() {
+		if character.is_ascii_alphanumeric() || character == '_' {
+			fragment.push(character.to_ascii_lowercase());
+		} else {
+			fragment.push('_');
+		}
+	}
+
+	if fragment.is_empty() {
+		fragment.push_str("table");
+	} else if fragment
+		.as_bytes()
+		.first()
+		.is_some_and(|character| character.is_ascii_digit())
+	{
+		fragment.insert_str(0, "table_");
+	}
+	fragment
 }
 
 /// Field metadata for registration
@@ -899,6 +948,61 @@ mod tests {
 		);
 		assert_eq!(model_state.constraints.len(), 1);
 		assert_eq!(model_state.constraints[0].name, "auth_evt_token_hash_uniq");
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_avoids_model_constraint_name_collision() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("accounts", "Account", "accounts");
+		metadata.add_field(
+			"a_b".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		metadata.add_field("a".to_string(), FieldMetadata::new(FieldType::VarChar(255)));
+		metadata.add_field("b".to_string(), FieldMetadata::new(FieldType::VarChar(255)));
+		metadata.add_constraint(ConstraintDefinition {
+			name: "accounts_a_b_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["a".to_string(), "b".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		});
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		let mut names: Vec<_> = model_state
+			.constraints
+			.iter()
+			.map(|constraint| constraint.name.as_str())
+			.collect();
+		names.sort_unstable();
+		assert_eq!(names, vec!["accounts_a_b_uniq", "accounts_a_b_uniq_field"]);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_name_is_safe_for_custom_table_names() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("accounts", "Account", "User-Events");
+		metadata.add_field(
+			"token".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+		let constraint_name = model_state.constraints[0].name.clone();
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_state);
+		let migrations =
+			MigrationAutodetector::new(ProjectState::new(), to_state).generate_migrations();
+		let sql = migrations[0].operations[0].to_sql(&SqlDialect::Postgres);
+
+		// Assert
+		assert_eq!(constraint_name, "user_events_token_uniq");
+		assert!(sql.contains("CONSTRAINT user_events_token_uniq UNIQUE (token)"));
+		assert!(!sql.contains("CONSTRAINT User-Events_token_uniq"));
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -123,8 +123,13 @@ impl ModelMetadata {
 		generated_names: &HashSet<String>,
 		existing_constraints: &[ConstraintDefinition],
 	) -> String {
+		// The raw tuple digest is required because concatenated safe fragments do
+		// not preserve table/field boundaries and normalized field names can
+		// collide. It also makes the name independent of field iteration order.
+		let tuple_digest =
+			stable_constraint_name_hash(&format!("{}\0{}", self.table_name, field_name));
 		let base_name = bounded_constraint_identifier(&format!(
-			"{}_{}_uniq",
+			"{}_{}_uniq_{tuple_digest:08x}",
 			safe_constraint_table_fragment(&self.table_name),
 			safe_constraint_name_fragment(field_name)
 		));
@@ -143,10 +148,14 @@ impl ModelMetadata {
 			return base_name;
 		}
 
-		let mut candidate = bounded_constraint_identifier(&format!("{base_name}_field"));
+		let field_digest = stable_constraint_name_hash(field_name);
+		let mut candidate =
+			bounded_constraint_identifier(&format!("{base_name}_field_{field_digest:08x}"));
 		let mut suffix = 2;
 		while is_taken(&candidate) {
-			candidate = bounded_constraint_identifier(&format!("{base_name}_field_{suffix}"));
+			candidate = bounded_constraint_identifier(&format!(
+				"{base_name}_field_{field_digest:08x}_{suffix}"
+			));
 			suffix += 1;
 		}
 		candidate
@@ -1011,6 +1020,10 @@ mod tests {
 		else {
 			panic!("expected an initial CreateTable operation");
 		};
+		let expected_constraint_name = format!(
+			"auth_evt_token_hash_uniq_{:08x}",
+			stable_constraint_name_hash("auth_evt\0token_hash")
+		);
 		assert_eq!(
 			columns
 				.iter()
@@ -1022,7 +1035,7 @@ mod tests {
 		assert_eq!(
 			constraints,
 			&vec![Constraint::Unique {
-				name: "auth_evt_token_hash_uniq".to_string(),
+				name: expected_constraint_name,
 				columns: vec!["token_hash".to_string()],
 			}],
 			"the physical constraint name must derive from the stable table name"
@@ -1091,10 +1104,14 @@ mod tests {
 		let mut names: Vec<_> = model_state
 			.constraints
 			.iter()
-			.map(|constraint| constraint.name.as_str())
+			.map(|constraint| constraint.name.clone())
 			.collect();
 		names.sort_unstable();
-		assert_eq!(names, vec!["accounts_a_b_uniq", "accounts_a_b_uniq_field"]);
+		let generated_name = format!(
+			"accounts_a_b_uniq_{:08x}",
+			stable_constraint_name_hash("accounts\0a_b")
+		);
+		assert_eq!(names, vec!["accounts_a_b_uniq".to_string(), generated_name]);
 	}
 
 	#[test]
@@ -1122,10 +1139,14 @@ mod tests {
 		let mut names: Vec<_> = model_state
 			.constraints
 			.iter()
-			.map(|constraint| constraint.name.as_str())
+			.map(|constraint| constraint.name.clone())
 			.collect();
 		names.sort_unstable();
-		assert_eq!(names, vec!["fk_fk_x_uniq", "fk_fk_x_uniq_field"]);
+		let generated_name = format!(
+			"fk_fk_x_uniq_{:08x}",
+			stable_constraint_name_hash("fk\0fk_x")
+		);
+		assert_eq!(names, vec!["fk_fk_x_uniq".to_string(), generated_name]);
 	}
 
 	#[test]
@@ -1148,10 +1169,76 @@ mod tests {
 		let mut names: Vec<_> = model_state
 			.constraints
 			.iter()
-			.map(|constraint| constraint.name.as_str())
+			.map(|constraint| constraint.name.clone())
 			.collect();
 		names.sort_unstable();
-		assert_eq!(names, vec!["accounts___uniq", "accounts___uniq_field"]);
+		let mut expected_names = ["é", "ü"]
+			.into_iter()
+			.map(|field| {
+				format!(
+					"accounts___uniq_{:08x}",
+					stable_constraint_name_hash(&format!("accounts\0{field}"))
+				)
+			})
+			.collect::<Vec<_>>();
+		expected_names.sort_unstable();
+		assert_eq!(names, expected_names);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_name_is_stable_when_normalized_field_is_added() {
+		// Arrange
+		let mut existing = ModelMetadata::new("accounts", "Account", "accounts");
+		existing.add_field(
+			"ü".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		let existing_name = existing.to_model_state().constraints[0].name.clone();
+
+		let mut expanded = ModelMetadata::new("accounts", "Account", "accounts");
+		expanded.add_field(
+			"é".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		expanded.add_field(
+			"ü".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		// Act
+		let expanded_state = expanded.to_model_state();
+		let expanded_name = expanded_state
+			.constraints
+			.iter()
+			.find(|constraint| constraint.fields == vec!["ü".to_string()])
+			.expect("expanded model must retain the existing unique field")
+			.name
+			.clone();
+
+		// Assert
+		assert_eq!(existing_name, expanded_name);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_names_encode_table_field_boundaries() {
+		// Arrange
+		let mut first = ModelMetadata::new("accounts", "First", "a_b");
+		first.add_field(
+			"c".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		let mut second = ModelMetadata::new("accounts", "Second", "a");
+		second.add_field(
+			"b_c".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		// Act
+		let first_name = first.to_model_state().constraints[0].name.clone();
+		let second_name = second.to_model_state().constraints[0].name.clone();
+
+		// Assert
+		assert_ne!(first_name, second_name);
 	}
 
 	#[test]
@@ -1167,8 +1254,9 @@ mod tests {
 		let model_state = metadata.to_model_state();
 		let constraint_name = model_state.constraints[0].name.clone();
 		let expected_constraint_name = format!(
-			"user_events_{:08x}_token_uniq",
-			stable_constraint_name_hash("User-Events")
+			"user_events_{:08x}_token_uniq_{:08x}",
+			stable_constraint_name_hash("User-Events"),
+			stable_constraint_name_hash("User-Events\0token")
 		);
 		let mut to_state = ProjectState::new();
 		to_state.add_model(model_state);

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -13,7 +13,7 @@
 
 use super::ConstraintDefinition;
 use super::autodetector::{FieldState, ModelState};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -106,27 +106,31 @@ impl ModelMetadata {
 		self.constraints.push(constraint);
 	}
 
-	fn synthesized_unique_constraint_name(&self, field_name: &str) -> String {
+	fn synthesized_unique_constraint_name(
+		&self,
+		field_name: &str,
+		generated_names: &HashSet<String>,
+	) -> String {
 		let base_name = format!(
 			"{}_{}_uniq",
 			safe_constraint_name_fragment(&self.table_name),
 			safe_constraint_name_fragment(field_name)
 		);
-		if !self
-			.constraints
-			.iter()
-			.any(|constraint| constraint.name.eq_ignore_ascii_case(&base_name))
-		{
+		let is_taken = |candidate: &str| {
+			self.constraints
+				.iter()
+				.any(|constraint| constraint.name.eq_ignore_ascii_case(candidate))
+				|| generated_names
+					.iter()
+					.any(|name| name.eq_ignore_ascii_case(candidate))
+		};
+		if !is_taken(&base_name) {
 			return base_name;
 		}
 
 		let mut candidate = format!("{base_name}_field");
 		let mut suffix = 2;
-		while self
-			.constraints
-			.iter()
-			.any(|constraint| constraint.name.eq_ignore_ascii_case(&candidate))
-		{
+		while is_taken(&candidate) {
 			candidate = format!("{base_name}_field_{suffix}");
 			suffix += 1;
 		}
@@ -205,6 +209,7 @@ impl ModelMetadata {
 		// Generate named Unique constraints from field params. The field-level
 		// `unique` flag is consumed above so the same declaration cannot be
 		// emitted both inline and as a table constraint.
+		let mut generated_unique_constraint_names = HashSet::new();
 		for (field_name, field_meta) in &self.fields {
 			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
 				// Prefer a model-level declaration when it explicitly names the
@@ -218,12 +223,16 @@ impl ModelMetadata {
 					continue;
 				}
 				let constraint = ConstraintDefinition {
-					name: self.synthesized_unique_constraint_name(field_name),
+					name: self.synthesized_unique_constraint_name(
+						field_name,
+						&generated_unique_constraint_names,
+					),
 					constraint_type: "unique".to_string(),
 					fields: vec![field_name.clone()],
 					expression: None,
 					foreign_key_info: None,
 				};
+				generated_unique_constraint_names.insert(constraint.name.clone());
 				model_state.constraints.push(constraint);
 			}
 		}
@@ -982,6 +991,32 @@ mod tests {
 	}
 
 	#[test]
+	fn test_synthesized_unique_constraint_names_avoid_normalized_field_collisions() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("accounts", "Account", "accounts");
+		metadata.add_field(
+			"é".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		metadata.add_field(
+			"ü".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		let mut names: Vec<_> = model_state
+			.constraints
+			.iter()
+			.map(|constraint| constraint.name.as_str())
+			.collect();
+		names.sort_unstable();
+		assert_eq!(names, vec!["accounts___uniq", "accounts___uniq_field"]);
+	}
+
+	#[test]
 	fn test_synthesized_unique_constraint_name_is_safe_for_custom_table_names() {
 		// Arrange
 		let mut metadata = ModelMetadata::new("accounts", "Account", "User-Events");
@@ -1001,8 +1036,10 @@ mod tests {
 
 		// Assert
 		assert_eq!(constraint_name, "user_events_token_uniq");
-		assert!(sql.contains("CONSTRAINT user_events_token_uniq UNIQUE (token)"));
-		assert!(!sql.contains("CONSTRAINT User-Events_token_uniq"));
+		assert_eq!(
+			sql,
+			"CREATE TABLE \"User-Events\" (\n  token VARCHAR(255) NOT NULL,\n  CONSTRAINT user_events_token_uniq UNIQUE (token)\n);"
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -68,6 +68,8 @@ pub struct ModelMetadata {
 }
 
 impl ModelMetadata {
+	const MAX_CONSTRAINT_IDENTIFIER_BYTES: usize = 63;
+
 	/// Creates a new instance.
 	pub fn new(
 		app_label: impl Into<String>,
@@ -111,11 +113,11 @@ impl ModelMetadata {
 		field_name: &str,
 		generated_names: &HashSet<String>,
 	) -> String {
-		let base_name = format!(
+		let base_name = bounded_constraint_identifier(&format!(
 			"{}_{}_uniq",
 			safe_constraint_table_fragment(&self.table_name),
 			safe_constraint_name_fragment(field_name)
-		);
+		));
 		let is_taken = |candidate: &str| {
 			self.constraints
 				.iter()
@@ -128,10 +130,10 @@ impl ModelMetadata {
 			return base_name;
 		}
 
-		let mut candidate = format!("{base_name}_field");
+		let mut candidate = bounded_constraint_identifier(&format!("{base_name}_field"));
 		let mut suffix = 2;
 		while is_taken(&candidate) {
-			candidate = format!("{base_name}_field_{suffix}");
+			candidate = bounded_constraint_identifier(&format!("{base_name}_field_{suffix}"));
 			suffix += 1;
 		}
 		candidate
@@ -293,6 +295,20 @@ fn stable_constraint_name_hash(value: &str) -> u32 {
 		hash = hash.wrapping_mul(0x01000193);
 	}
 	hash
+}
+
+fn bounded_constraint_identifier(value: &str) -> String {
+	if value.len() <= ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES {
+		return value.to_owned();
+	}
+
+	let suffix = format!("_{:08x}", stable_constraint_name_hash(value));
+	let prefix_len = ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES - suffix.len();
+	let mut end = prefix_len;
+	while !value.is_char_boundary(end) {
+		end -= 1;
+	}
+	format!("{}{}", &value[..end], suffix)
 }
 
 /// Field metadata for registration
@@ -1090,6 +1106,29 @@ mod tests {
 			dashed.to_model_state().constraints[0].name,
 			underscored.to_model_state().constraints[0].name
 		);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_names_are_bounded_and_distinct() {
+		let long_table = "t".repeat(40);
+		let long_field = "f".repeat(40);
+		let other_field = format!("{}g", "f".repeat(39));
+		let mut metadata = ModelMetadata::new("accounts", "Account", long_table);
+		metadata.add_field(
+			long_field,
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		metadata.add_field(
+			other_field,
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		let constraints = metadata.to_model_state().constraints;
+		assert_eq!(constraints.len(), 2);
+		assert!(constraints.iter().all(|constraint| {
+			constraint.name.len() <= ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES
+		}));
+		assert_ne!(constraints[0].name, constraints[1].name);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -143,13 +143,14 @@ impl ModelMetadata {
 
 		// Convert fields
 		for (name, field_meta) in &self.fields {
+			let is_unique = field_meta.params.get("unique").map(String::as_str) == Some("true");
 			let mut field_state = FieldState::new(
 				name.clone(),
 				field_meta.field_type.clone(),
 				field_meta.nullable,
 			);
 			for (key, value) in &field_meta.params {
-				if key == "null" {
+				if key == "null" || (is_unique && key == "unique") {
 					continue;
 				}
 				field_state.params.insert(key.clone(), value.clone());
@@ -174,16 +175,23 @@ impl ModelMetadata {
 		// Copy ManyToMany relationship metadata
 		model_state.many_to_many_fields = self.many_to_many_fields.clone();
 
-		// Generate Unique constraints from field params
+		// Generate named Unique constraints from field params. The field-level
+		// `unique` flag is consumed above so the same declaration cannot be
+		// emitted both inline and as a table constraint.
 		for (field_name, field_meta) in &self.fields {
 			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
+				// Prefer a model-level declaration when it explicitly names the
+				// single-column constraint. This keeps one physical constraint and
+				// preserves the declared name.
+				if self.constraints.iter().any(|constraint| {
+					constraint.constraint_type.eq_ignore_ascii_case("unique")
+						&& constraint.fields.len() == 1
+						&& constraint.fields[0] == *field_name
+				}) {
+					continue;
+				}
 				let constraint = ConstraintDefinition {
-					name: format!(
-						"{}_{}_{}_uniq",
-						self.app_label,
-						self.model_name.to_lowercase(),
-						field_name
-					),
+					name: format!("{}_{}_uniq", self.table_name, field_name),
 					constraint_type: "unique".to_string(),
 					fields: vec![field_name.clone()],
 					expression: None,
@@ -654,6 +662,8 @@ pub fn global_registry() -> &'static ModelRegistry {
 mod tests {
 	use super::*;
 	use crate::migrations::FieldType;
+	use crate::migrations::autodetector::{MigrationAutodetector, ProjectState};
+	use crate::migrations::operations::{Constraint, Operation, SqlDialect};
 	use rstest::rstest;
 
 	#[test]
@@ -808,6 +818,87 @@ mod tests {
 		assert_eq!(model_state.name, "Post");
 		assert_eq!(model_state.fields.len(), 1);
 		assert!(model_state.fields.contains_key("title"));
+	}
+
+	#[test]
+	fn test_unique_field_uses_stable_table_constraint_without_inline_duplicate() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("auth", "RenamedEmailVerificationToken", "auth_evt");
+		metadata.add_field(
+			"token_hash".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+		let mut to_state = ProjectState::new();
+		to_state.add_model(model_state);
+		let migrations =
+			MigrationAutodetector::new(ProjectState::new(), to_state).generate_migrations();
+
+		// Assert
+		let model_state = &migrations[0].operations;
+		let Operation::CreateTable {
+			columns,
+			constraints,
+			..
+		} = &model_state[0]
+		else {
+			panic!("expected an initial CreateTable operation");
+		};
+		assert_eq!(
+			columns
+				.iter()
+				.filter(|column| column.name == "token_hash" && column.unique)
+				.count(),
+			0,
+			"single-column uniqueness must not be emitted inline"
+		);
+		assert_eq!(
+			constraints,
+			&vec![Constraint::Unique {
+				name: "auth_evt_token_hash_uniq".to_string(),
+				columns: vec!["token_hash".to_string()],
+			}],
+			"the physical constraint name must derive from the stable table name"
+		);
+		assert_eq!(
+			model_state[0]
+				.to_sql(&SqlDialect::Postgres)
+				.matches("UNIQUE")
+				.count(),
+			1,
+			"the generated PostgreSQL DDL must contain one UNIQUE representation"
+		);
+	}
+
+	#[test]
+	fn test_explicit_single_field_unique_constraint_name_is_preserved() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("auth", "Token", "auth_evt");
+		metadata.add_field(
+			"token_hash".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		metadata.add_constraint(ConstraintDefinition {
+			name: "auth_evt_token_hash_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["token_hash".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		});
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		assert!(
+			!model_state.fields["token_hash"]
+				.params
+				.contains_key("unique")
+		);
+		assert_eq!(model_state.constraints.len(), 1);
+		assert_eq!(model_state.constraints[0].name, "auth_evt_token_hash_uniq");
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -112,6 +112,7 @@ impl ModelMetadata {
 		&self,
 		field_name: &str,
 		generated_names: &HashSet<String>,
+		existing_constraints: &[ConstraintDefinition],
 	) -> String {
 		let base_name = bounded_constraint_identifier(&format!(
 			"{}_{}_uniq",
@@ -122,6 +123,9 @@ impl ModelMetadata {
 			self.constraints
 				.iter()
 				.any(|constraint| constraint.name.eq_ignore_ascii_case(candidate))
+				|| existing_constraints
+					.iter()
+					.any(|constraint| constraint.name.eq_ignore_ascii_case(candidate))
 				|| generated_names
 					.iter()
 					.any(|name| name.eq_ignore_ascii_case(candidate))
@@ -236,6 +240,7 @@ impl ModelMetadata {
 					name: self.synthesized_unique_constraint_name(
 						field_name,
 						&generated_unique_constraint_names,
+						&model_state.constraints,
 					),
 					constraint_type: "unique".to_string(),
 					fields: vec![field_name.clone()],
@@ -761,7 +766,7 @@ pub fn global_registry() -> &'static ModelRegistry {
 mod tests {
 	use super::*;
 	use crate::migrations::FieldType;
-	use crate::migrations::autodetector::{MigrationAutodetector, ProjectState};
+	use crate::migrations::autodetector::{ForeignKeyInfo, MigrationAutodetector, ProjectState};
 	use crate::migrations::operations::{Constraint, Operation, SqlDialect};
 	use rstest::rstest;
 
@@ -1029,6 +1034,37 @@ mod tests {
 			.collect();
 		names.sort_unstable();
 		assert_eq!(names, vec!["accounts_a_b_uniq", "accounts_a_b_uniq_field"]);
+	}
+
+	#[test]
+	fn test_synthesized_unique_constraint_avoids_foreign_key_name_collision() {
+		// Arrange
+		let mut metadata = ModelMetadata::new("billing", "Account", "fk");
+		metadata.add_field(
+			"fk_x".to_string(),
+			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
+		);
+		metadata.add_field(
+			"x_uniq".to_string(),
+			FieldMetadata::new(FieldType::Integer).with_foreign_key(ForeignKeyInfo {
+				referenced_table: "users".to_string(),
+				referenced_column: "id".to_string(),
+				on_delete: crate::migrations::ForeignKeyAction::Cascade,
+				on_update: crate::migrations::ForeignKeyAction::NoAction,
+			}),
+		);
+
+		// Act
+		let model_state = metadata.to_model_state();
+
+		// Assert
+		let mut names: Vec<_> = model_state
+			.constraints
+			.iter()
+			.map(|constraint| constraint.name.as_str())
+			.collect();
+		names.sort_unstable();
+		assert_eq!(names, vec!["fk_fk_x_uniq", "fk_fk_x_uniq_field"]);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -1091,6 +1091,7 @@ mod tests {
 
 	#[test]
 	fn test_synthesized_unique_constraint_names_are_distinct_for_normalized_tables() {
+		// Arrange
 		let mut dashed = ModelMetadata::new("accounts", "Dashed", "User-Events");
 		dashed.add_field(
 			"token".to_string(),
@@ -1102,14 +1103,17 @@ mod tests {
 			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
 		);
 
-		assert_ne!(
-			dashed.to_model_state().constraints[0].name,
-			underscored.to_model_state().constraints[0].name
-		);
+		// Act
+		let dashed_name = dashed.to_model_state().constraints[0].name.clone();
+		let underscored_name = underscored.to_model_state().constraints[0].name.clone();
+
+		// Assert
+		assert_ne!(dashed_name, underscored_name);
 	}
 
 	#[test]
 	fn test_synthesized_unique_constraint_names_are_bounded_and_distinct() {
+		// Arrange
 		let long_table = "t".repeat(40);
 		let long_field = "f".repeat(40);
 		let other_field = format!("{}g", "f".repeat(39));
@@ -1123,7 +1127,10 @@ mod tests {
 			FieldMetadata::new(FieldType::VarChar(255)).with_param("unique", "true"),
 		);
 
+		// Act
 		let constraints = metadata.to_model_state().constraints;
+
+		// Assert
 		assert_eq!(constraints.len(), 2);
 		assert!(constraints.iter().all(|constraint| {
 			constraint.name.len() <= ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -223,7 +223,7 @@ impl ModelMetadata {
 				field_meta.params.get("unique").map(String::as_str) == Some("true")
 			})
 			.collect::<Vec<_>>();
-		unique_fields.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+		unique_fields.sort_unstable_by_key(|(left, _)| *left);
 		for (field_name, field_meta) in unique_fields {
 			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
 				// Prefer a model-level declaration when it explicitly names the

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -582,7 +582,12 @@ impl std::fmt::Display for Constraint {
 				Ok(())
 			}
 			Constraint::Unique { name, columns } => {
-				write!(f, "CONSTRAINT {} UNIQUE ({})", name, columns.join(", "))
+				let columns = columns
+					.iter()
+					.map(|column| quote_identifier(column))
+					.collect::<Vec<_>>()
+					.join(", ");
+				write!(f, "CONSTRAINT {} UNIQUE ({})", name, columns)
 			}
 			Constraint::Check { name, expression } => {
 				write!(f, "CONSTRAINT {} CHECK ({})", name, expression)
@@ -609,7 +614,12 @@ impl std::fmt::Display for Constraint {
 				if let Some(defer_opt) = deferrable {
 					write!(f, " {}", defer_opt)?;
 				}
-				write!(f, ", CONSTRAINT {}_unique UNIQUE ({})", name, column)
+				write!(
+					f,
+					", CONSTRAINT {}_unique UNIQUE ({})",
+					name,
+					quote_identifier(column)
+				)
 			}
 			Constraint::ManyToMany { through_table, .. } => {
 				write!(f, "-- ManyToMany via {}", through_table)


### PR DESCRIPTION
## Summary

This PR addresses:

- Normalize field-level `unique = true` into one named table-level UNIQUE constraint during model-state generation.
- Derive generated constraint names from the physical table name and preserve explicit single-column constraint names.
- Add regressions proving that generated PostgreSQL DDL contains only one UNIQUE representation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`ModelMetadata::to_model_state()` copied a field `unique` flag into the column and also synthesized a table-level UNIQUE constraint. Initial migrations therefore emitted duplicate physical uniqueness constraints. Generated names also depended on the Rust model name, so renaming a model could change the constraint name even when the table stayed the same.

Fixes #6160

## How Was This Tested?

- `cargo test -p reinhardt-db --lib --all-features` (2773 passed)
- `cargo test -p reinhardt-integration-tests --test migrations macro_unique_together` (3 passed)
- `cargo make fmt-fix` and `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo check -p reinhardt-db --all-features --all-targets`

## Performance Impact

Not performance-related.

## Breaking Changes

Not a breaking change. Existing uniqueness semantics are retained with a single stable table constraint.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- #6160

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

The fix is confined to migration model-state generation; generated migration files are not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)