### PR TITLE
fix(db): close post-merge migration review findings

### DIFF
--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -1785,20 +1785,23 @@ impl ProjectState {
 
 	fn trim_sql_identifier(identifier: &str) -> String {
 		let trimmed = identifier.trim();
-		if let Some(stripped) = trimmed
-			.strip_prefix('"')
-			.and_then(|value| value.strip_suffix('"'))
-			.or_else(|| {
-				trimmed
-					.strip_prefix('`')
-					.and_then(|value| value.strip_suffix('`'))
-			})
-			.or_else(|| {
-				trimmed
-					.strip_prefix('\'')
-					.and_then(|value| value.strip_suffix('\''))
-			}) {
-			stripped.to_string()
+		let Some(quote) = trimmed.chars().next() else {
+			return String::new();
+		};
+		let stripped = match quote {
+			'"' => trimmed
+				.strip_prefix('"')
+				.and_then(|value| value.strip_suffix('"')),
+			'`' => trimmed
+				.strip_prefix('`')
+				.and_then(|value| value.strip_suffix('`')),
+			'\'' => trimmed
+				.strip_prefix('\'')
+				.and_then(|value| value.strip_suffix('\'')),
+			_ => None,
+		};
+		if let Some(stripped) = stripped {
+			stripped.replace(&format!("{quote}{quote}"), &quote.to_string())
 		} else {
 			trimmed.to_string()
 		}
@@ -5539,6 +5542,28 @@ impl MigrationAutodetector {
 			&& left.foreign_key_info == right.foreign_key_info
 	}
 
+	fn renamed_single_field_unique_constraints(
+		from_model: &ModelState,
+		to_model: &ModelState,
+	) -> Vec<(ConstraintDefinition, ConstraintDefinition)> {
+		from_model
+			.constraints
+			.iter()
+			.filter(|from_constraint| is_single_field_unique(from_constraint))
+			.filter_map(|from_constraint| {
+				to_model
+					.constraints
+					.iter()
+					.find(|to_constraint| {
+						to_constraint.name != from_constraint.name
+							&& is_single_field_unique(to_constraint)
+							&& Self::constraint_definitions_match(from_constraint, to_constraint)
+					})
+					.map(|to_constraint| (from_constraint.clone(), to_constraint.clone()))
+			})
+			.collect()
+	}
+
 	/// Returns true when `candidate` is a single-field UNIQUE constraint and
 	/// the same column on `other_side` is already covered by either:
 	/// - any single-field UNIQUE constraint over the same column, or
@@ -6866,6 +6891,8 @@ impl MigrationAutodetector {
 
 				// Defense-in-depth: skip no-op renames where table name is unchanged
 				if old_table_name != model.table_name {
+					let renamed_constraints =
+						Self::renamed_single_field_unique_constraints(old_model, model);
 					let renamed_indexes = old_model
 						.indexes
 						.iter()
@@ -6883,6 +6910,12 @@ impl MigrationAutodetector {
 						})
 						.collect::<Vec<_>>();
 					let operations = migrations_by_app.entry(app_label.clone()).or_default();
+					for (old_constraint, _) in &renamed_constraints {
+						operations.push(super::Operation::DropConstraint {
+							table: old_table_name.clone(),
+							constraint_name: old_constraint.name.clone(),
+						});
+					}
 					for (old_index, _) in &renamed_indexes {
 						operations.push(old_index.drop_operation(&old_table_name));
 					}
@@ -6890,6 +6923,12 @@ impl MigrationAutodetector {
 						old_name: old_table_name,
 						new_name: model.table_name.clone(),
 					});
+					for (_, new_constraint) in renamed_constraints {
+						operations.push(super::Operation::AddConstraint {
+							table: model.table_name.clone(),
+							constraint_sql: new_constraint.to_constraint().to_string(),
+						});
+					}
 					for (_, new_index) in renamed_indexes {
 						operations.push(new_index.create_operation(&model.table_name));
 					}
@@ -6924,33 +6963,42 @@ impl MigrationAutodetector {
 					.unwrap_or_else(|| format!("{}_{}", to_app, to_model_name.to_lowercase()))
 			});
 
-			let renamed_indexes = if *rename_table {
+			let (renamed_constraints, renamed_indexes) = if *rename_table {
 				match (
 					self.from_state.get_model(from_app, from_model_name),
 					self.to_state.get_model(to_app, to_model_name),
 				) {
-					(Some(old_model), Some(new_model)) => old_model
-						.indexes
-						.iter()
-						.filter_map(|old_index| {
-							new_model
-								.indexes
-								.iter()
-								.find(|new_index| {
-									model_index_definitions_equivalent(
-										old_model, old_index, new_model, new_index,
-									)
-								})
-								.filter(|new_index| old_index.name != new_index.name)
-								.map(|new_index| (old_index.clone(), new_index.clone()))
-						})
-						.collect::<Vec<_>>(),
-					_ => Vec::new(),
+					(Some(old_model), Some(new_model)) => (
+						Self::renamed_single_field_unique_constraints(old_model, new_model),
+						old_model
+							.indexes
+							.iter()
+							.filter_map(|old_index| {
+								new_model
+									.indexes
+									.iter()
+									.find(|new_index| {
+										model_index_definitions_equivalent(
+											old_model, old_index, new_model, new_index,
+										)
+									})
+									.filter(|new_index| old_index.name != new_index.name)
+									.map(|new_index| (old_index.clone(), new_index.clone()))
+							})
+							.collect::<Vec<_>>(),
+					),
+					_ => (Vec::new(), Vec::new()),
 				}
 			} else {
-				Vec::new()
+				(Vec::new(), Vec::new())
 			};
 			let operations = migrations_by_app.entry(to_app.clone()).or_default();
+			for (old_constraint, _) in &renamed_constraints {
+				operations.push(super::Operation::DropConstraint {
+					table: old_table_name.clone(),
+					constraint_name: old_constraint.name.clone(),
+				});
+			}
 			for (old_index, _) in &renamed_indexes {
 				operations.push(old_index.drop_operation(&old_table_name));
 			}
@@ -6971,6 +7019,12 @@ impl MigrationAutodetector {
 					None
 				},
 			});
+			for (_, new_constraint) in renamed_constraints {
+				operations.push(super::Operation::AddConstraint {
+					table: new_table_name.clone(),
+					constraint_sql: new_constraint.to_constraint().to_string(),
+				});
+			}
 			for (_, new_index) in renamed_indexes {
 				operations.push(new_index.create_operation(&new_table_name));
 			}
@@ -9800,6 +9854,66 @@ mod tests {
 	}
 
 	#[rstest]
+	fn table_rename_recreates_single_field_unique_constraint_with_new_name() {
+		// Arrange
+		let email = FieldState::new("email", super::super::FieldType::VarChar(255), false);
+		let old_constraint = ConstraintDefinition {
+			name: "old_table_email_uniq".to_string(),
+			constraint_type: "unique".to_string(),
+			fields: vec!["email".to_string()],
+			expression: None,
+			foreign_key_info: None,
+		};
+		let new_constraint = ConstraintDefinition {
+			name: "new_table_email_uniq".to_string(),
+			..old_constraint.clone()
+		};
+		let mut from_model = build_model_state_with_table_name(
+			"myapp",
+			"OldModel",
+			"old_table",
+			vec![email.clone()],
+		);
+		from_model.constraints.push(old_constraint);
+		let mut to_model =
+			build_model_state_with_table_name("myapp", "NewModel", "new_table", vec![email]);
+		to_model.constraints.push(new_constraint.clone());
+		let detector = MigrationAutodetector::new(
+			build_project_state(vec![(
+				("myapp".to_string(), "OldModel".to_string()),
+				from_model,
+			)]),
+			build_project_state(vec![(
+				("myapp".to_string(), "NewModel".to_string()),
+				to_model,
+			)]),
+		);
+
+		// Act
+		let migrations = detector.generate_migrations();
+
+		// Assert
+		assert_eq!(migrations.len(), 1);
+		assert_eq!(
+			migrations[0].operations,
+			vec![
+				super::super::Operation::DropConstraint {
+					table: "old_table".to_string(),
+					constraint_name: "old_table_email_uniq".to_string(),
+				},
+				super::super::Operation::RenameTable {
+					old_name: "old_table".to_string(),
+					new_name: "new_table".to_string(),
+				},
+				super::super::Operation::AddConstraint {
+					table: "new_table".to_string(),
+					constraint_sql: new_constraint.to_constraint().to_string(),
+				},
+			]
+		);
+	}
+
+	#[rstest]
 	fn has_field_changed_ignores_non_schema_params() {
 		// Arrange: same schema, but to_field has extra non-schema params
 		let from_field = FieldState {
@@ -11607,7 +11721,7 @@ mod tests {
 	#[test]
 	fn constraint_definition_parser_handles_quoted_unique_identifiers() {
 		// Arrange
-		let sql = "CONSTRAINT uq_profile UNIQUE (\"profile,id\", \"name)\")";
+		let sql = "CONSTRAINT uq_profile UNIQUE (\"profile,id\", \"name)\", \"display\"\"name\")";
 
 		// Act
 		let constraint = ProjectState::constraint_definition_from_sql(sql)
@@ -11615,7 +11729,10 @@ mod tests {
 
 		// Assert
 		assert_eq!(constraint.name, "uq_profile");
-		assert_eq!(constraint.fields, vec!["profile,id", "name)"]);
+		assert_eq!(
+			constraint.fields,
+			vec!["profile,id", "name)", "display\"name"]
+		);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/migrations/executor.rs
+++ b/crates/reinhardt-db/src/migrations/executor.rs
@@ -1807,22 +1807,23 @@ mod optimizer_tests {
 	#[cfg(feature = "sqlite")]
 	#[test]
 	fn sqlite_autoindex_alias_resolves_to_declared_constraint_name() {
+		// Arrange
 		let aliases = std::collections::HashMap::from([(
 			"sqlite_autoindex_users_1".to_string(),
 			"users_email_uniq".to_string(),
 		)]);
 
-		assert_eq!(
-			DatabaseMigrationExecutor::resolve_sqlite_constraint_name(
-				&aliases,
-				"sqlite_autoindex_users_1"
-			),
-			"users_email_uniq"
+		// Act
+		let resolved_alias = DatabaseMigrationExecutor::resolve_sqlite_constraint_name(
+			&aliases,
+			"sqlite_autoindex_users_1",
 		);
-		assert_eq!(
-			DatabaseMigrationExecutor::resolve_sqlite_constraint_name(&aliases, "users_email_uniq"),
-			"users_email_uniq"
-		);
+		let resolved_declared =
+			DatabaseMigrationExecutor::resolve_sqlite_constraint_name(&aliases, "users_email_uniq");
+
+		// Assert
+		assert_eq!(resolved_alias, "users_email_uniq");
+		assert_eq!(resolved_declared, "users_email_uniq");
 	}
 
 	#[cfg(test)]

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -1244,6 +1244,138 @@ pub enum Operation {
 	},
 }
 
+fn mysql_quote_identifier(identifier: &str) -> String {
+	format!("`{}`", identifier.replace('`', "``"))
+}
+
+fn unquote_sql_identifier(identifier: &str) -> String {
+	let trimmed = identifier.trim();
+	let Some(quote) = trimmed.chars().next() else {
+		return String::new();
+	};
+	let stripped = match quote {
+		'"' => trimmed
+			.strip_prefix('"')
+			.and_then(|value| value.strip_suffix('"')),
+		'`' => trimmed
+			.strip_prefix('`')
+			.and_then(|value| value.strip_suffix('`')),
+		'\'' => trimmed
+			.strip_prefix('\'')
+			.and_then(|value| value.strip_suffix('\'')),
+		_ => None,
+	};
+	stripped.map_or_else(
+		|| trimmed.to_string(),
+		|value| value.replace(&format!("{quote}{quote}"), &quote.to_string()),
+	)
+}
+
+fn split_sql_identifier_list(identifier_list: &str) -> Option<Vec<String>> {
+	let mut identifiers = Vec::new();
+	let mut current = String::new();
+	let mut quote = None;
+	let mut chars = identifier_list.chars().peekable();
+
+	while let Some(character) = chars.next() {
+		if let Some(quote_char) = quote {
+			current.push(character);
+			if character == quote_char {
+				if chars.peek() == Some(&quote_char) {
+					current.push(chars.next().expect("peeked quote must exist"));
+				} else {
+					quote = None;
+				}
+			}
+			continue;
+		}
+
+		match character {
+			'"' | '`' | '\'' => {
+				quote = Some(character);
+				current.push(character);
+			}
+			',' => {
+				let identifier = unquote_sql_identifier(&current);
+				if identifier.is_empty() {
+					return None;
+				}
+				identifiers.push(identifier);
+				current.clear();
+			}
+			_ => current.push(character),
+		}
+	}
+
+	if quote.is_some() {
+		return None;
+	}
+	let identifier = unquote_sql_identifier(&current);
+	if identifier.is_empty() {
+		return None;
+	}
+	identifiers.push(identifier);
+	Some(identifiers)
+}
+
+fn mysql_quote_unique_constraint_columns(constraint_sql: &str) -> String {
+	let Some(unique_start) = constraint_sql.find(" UNIQUE") else {
+		return constraint_sql.to_string();
+	};
+	let Some(open_offset) = constraint_sql[unique_start..].find('(') else {
+		return constraint_sql.to_string();
+	};
+	let open = unique_start + open_offset;
+	let mut depth = 0usize;
+	let mut quote = None;
+	let mut close = None;
+	let mut chars = constraint_sql[open..].char_indices().peekable();
+
+	while let Some((offset, character)) = chars.next() {
+		if let Some(quote_char) = quote {
+			if character == quote_char {
+				if chars.peek().is_some_and(|(_, next)| *next == quote_char) {
+					chars.next();
+				} else {
+					quote = None;
+				}
+			}
+			continue;
+		}
+
+		match character {
+			'"' | '`' | '\'' => quote = Some(character),
+			'(' => depth += 1,
+			')' => {
+				depth = depth.saturating_sub(1);
+				if depth == 0 {
+					close = Some(open + offset);
+					break;
+				}
+			}
+			_ => {}
+		}
+	}
+
+	let Some(close) = close else {
+		return constraint_sql.to_string();
+	};
+	let Some(columns) = split_sql_identifier_list(&constraint_sql[open + 1..close]) else {
+		return constraint_sql.to_string();
+	};
+	let quoted_columns = columns
+		.iter()
+		.map(|column| mysql_quote_identifier(column))
+		.collect::<Vec<_>>()
+		.join(", ");
+	format!(
+		"{}{}{}",
+		&constraint_sql[..open + 1],
+		quoted_columns,
+		&constraint_sql[close..]
+	)
+}
+
 /// Default value provider for serde (returns true)
 const fn default_true() -> bool {
 	true
@@ -1812,6 +1944,11 @@ impl Operation {
 				table,
 				constraint_sql,
 			} => {
+				let constraint_sql = if matches!(dialect, SqlDialect::Mysql) {
+					mysql_quote_unique_constraint_columns(constraint_sql)
+				} else {
+					constraint_sql.clone()
+				};
 				format!(
 					"ALTER TABLE {} ADD {};",
 					quote_identifier(table),
@@ -5262,6 +5399,29 @@ mod tests {
 			sql.contains("age_check"),
 			"SQL should contain constraint name 'age_check', got: {}",
 			sql
+		);
+	}
+
+	#[test]
+	fn test_add_unique_constraint_to_sql_uses_mysql_identifier_quotes() {
+		// Arrange
+		let op = Operation::AddConstraint {
+			table: "users".to_string(),
+			constraint_sql: "CONSTRAINT users_group_uniq UNIQUE (\"group\")".to_string(),
+		};
+
+		// Act
+		let mysql_sql = op.to_sql(&SqlDialect::Mysql);
+		let postgres_sql = op.to_sql(&SqlDialect::Postgres);
+
+		// Assert
+		assert_eq!(
+			mysql_sql,
+			"ALTER TABLE users ADD CONSTRAINT users_group_uniq UNIQUE (`group`);"
+		);
+		assert_eq!(
+			postgres_sql,
+			"ALTER TABLE users ADD CONSTRAINT users_group_uniq UNIQUE (\"group\");"
 		);
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Replays quoted constraint identifiers with doubled delimiters decoded.
- Recreates single-field UNIQUE constraints when a table rename changes their synthesized names.
- Uses MySQL backtick quoting for incremental UNIQUE constraints.
- Adds explicit Arrange/Act/Assert phases to the SQLite alias regression test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a feature nor adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] No - This change is backward compatible
- [ ] Yes - This change breaks existing public API or behavior

## Motivation and Context

These fixes address the post-merge actionable review findings from #6163 without modifying the already-merged branch.

Fixes #
Related to: #6163

## How Was This Tested?

- cargo fmt --all
- cargo test -p reinhardt-db --all-features migrations::autodetector::tests
- cargo test -p reinhardt-db --all-features model_registry::tests::test_
- cargo test -p reinhardt-db --all-features migrations::executor::optimizer_tests
- cargo clippy -p reinhardt-db --all-features --lib -- -D warnings
- git diff --check

## Performance Impact

Not applicable.

## Breaking Changes

Not applicable.

## Screenshots

Not applicable.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (SQL generation)
- [x] I have formatted the code with cargo fmt --all
- [x] I have checked the code with cargo clippy -p reinhardt-db --all-features --lib -- -D warnings
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Pull request #6163 review follow-up

## Labels to Apply

### Type Label
- [x] bug - Bug fix

### Scope Label
- [x] database - Database layer, schema, migrations

### Priority Label
- [ ] critical - Blocks release or major functionality
- [ ] high - Important fix or feature
- [ ] medium - Normal priority
- [ ] low - Minor fix or enhancement

---

**Additional Context:**

This is a follow-up for actionable review comments that arrived after #6163 merged.