### PR TITLE
fix(views): apply custom lookup fields to detail queries

### DIFF
--- a/crates/reinhardt-views/src/viewsets.rs
+++ b/crates/reinhardt-views/src/viewsets.rs
@@ -48,9 +48,8 @@
 //! dispatch. The hook itself is synchronous and fallible, requires
 //! `with_pool`, and scopes list, retrieve, update, and destroy. Create is
 //! excluded, so serializers, permissions, or database constraints must assign
-//! ownership. Scoped-out objects and malformed detail primary keys are 404.
-//! Static `Vec` querysets are separate from database scoping, and custom lookup
-//! fields are the separate #6091 boundary.
+//! ownership. Scoped-out objects and malformed detail lookup values are 404.
+//! Static `Vec` querysets are separate from database scoping.
 //!
 //! ```rust,no_run
 //! # #![allow(unexpected_cfgs)]

--- a/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
+++ b/crates/reinhardt-views/src/viewsets/handler/model_view_set_handler.rs
@@ -634,6 +634,44 @@ fn primary_key_filter_for_model<T: Model>(
 	))
 }
 
+fn lookup_value(value: &serde_json::Value) -> std::result::Result<String, ViewError> {
+	let value = value
+		.as_str()
+		.map(str::to_owned)
+		.unwrap_or_else(|| value.to_string());
+	urlencoding::decode(&value)
+		.map(|value| value.into_owned())
+		.map_err(|_| ViewError::NotFound(format!("Object with lookup={value} not found")))
+}
+
+fn lookup_filter_for_model<T: Model>(
+	lookup_field: Option<&str>,
+	value: &serde_json::Value,
+) -> std::result::Result<FilterCondition, ViewError> {
+	let Some(lookup_field) = lookup_field else {
+		return primary_key_filter_for_model::<T>(value);
+	};
+	if lookup_field == T::primary_key_field() {
+		return primary_key_filter_for_model::<T>(value);
+	}
+
+	let value = lookup_value(value)?;
+	let field = T::field_metadata()
+		.into_iter()
+		.find(|field| field.name == lookup_field);
+	let filter_value = field
+		.as_ref()
+		.map(|field| filter_value_from_field_type(&field.field_type, &value))
+		.transpose()
+		.map_err(|_| ViewError::NotFound(format!("Object with lookup={value} not found")))?
+		.unwrap_or(FilterValue::String(value));
+	let column = field
+		.as_ref()
+		.map(|field| field.db_column_name())
+		.unwrap_or(lookup_field);
+	Ok(Filter::new(column, FilterOperator::Eq, filter_value).into())
+}
+
 fn assigned_primary_key_filter<T: Model>(item: &T) -> Option<FilterCondition> {
 	let metadata = T::field_metadata();
 	if let Some(composite) = T::composite_primary_key() {
@@ -734,6 +772,7 @@ where
 	filter_backends: Vec<Arc<dyn FilterBackend>>,
 	pagination_class: Option<reinhardt_core::pagination::PaginatorImpl>,
 	pool: Option<Arc<sqlx::AnyPool>>,
+	lookup_field: Option<String>,
 	/// Database backend type (default: PostgreSQL)
 	db_backend: DbBackend,
 	_phantom: PhantomData<T>,
@@ -785,6 +824,7 @@ where
 			filter_backends: Vec::new(),
 			pagination_class: None,
 			pool: None,
+			lookup_field: None,
 			db_backend: DbBackend::Postgres, // Default to PostgreSQL
 			_phantom: PhantomData,
 		}
@@ -833,6 +873,11 @@ where
 		self
 	}
 
+	pub(crate) fn with_lookup_field(mut self, lookup_field: String) -> Self {
+		self.lookup_field = Some(lookup_field);
+		self
+	}
+
 	/// Scope database queries using the current request.
 	///
 	/// The synchronous, fallible hook returns one [`FilterCondition`] and requires
@@ -842,9 +887,7 @@ where
 	/// in middleware before dispatch and read its application-defined identity
 	/// from request extensions in this hook. Static `Vec` data supplied through
 	/// [`Self::with_queryset`] is separate and is never filtered by this hook.
-	/// A scoped-out object or a malformed detail primary key is reported as 404.
-	/// Custom lookup fields are outside this primary-key scope boundary and are
-	/// tracked by #6091.
+	/// A scoped-out object or malformed detail lookup value is reported as 404.
 	pub fn with_queryset_fn<F>(mut self, queryset_fn: F) -> Self
 	where
 		F: Fn(&Request) -> std::result::Result<FilterCondition, ViewError> + Send + Sync + 'static,
@@ -1161,6 +1204,34 @@ where
 		primary_key_filter_for_model::<T>(pk)
 	}
 
+	fn lookup_filter(
+		&self,
+		value: &serde_json::Value,
+	) -> std::result::Result<FilterCondition, ViewError> {
+		lookup_filter_for_model::<T>(self.lookup_field.as_deref(), value)
+	}
+
+	fn matches_lookup(&self, item: &T, value: &serde_json::Value) -> bool {
+		let Some(lookup_field) = self.lookup_field.as_deref() else {
+			let value = value.to_string();
+			return item
+				.primary_key()
+				.is_some_and(|primary_key| primary_key.to_string() == value.trim_matches('"'));
+		};
+		let Ok(value) = lookup_value(value) else {
+			return false;
+		};
+		serde_json::to_value(item)
+			.ok()
+			.and_then(|item| item.get(lookup_field).cloned())
+			.is_some_and(|field_value| match field_value {
+				serde_json::Value::String(field_value) => field_value == value,
+				serde_json::Value::Number(field_value) => field_value.to_string() == value,
+				serde_json::Value::Bool(field_value) => field_value.to_string() == value,
+				_ => false,
+			})
+	}
+
 	async fn get_object(
 		&self,
 		request: &Request,
@@ -1176,7 +1247,7 @@ where
 			})?;
 		let queryset = self
 			.scoped_queryset(request)?
-			.filter(Self::primary_key_filter(pk)?)
+			.filter(self.lookup_filter(pk)?)
 			.without_slicing();
 		session
 			.list(&queryset)
@@ -1399,17 +1470,9 @@ where
 			));
 		} else {
 			let queryset = self.get_queryset();
-			let pk_str = pk.to_string();
-			let pk_str = pk_str.trim_matches('"');
 			queryset
 				.iter()
-				.find(|item| {
-					if let Some(item_pk) = item.primary_key() {
-						item_pk.to_string() == pk_str
-					} else {
-						false
-					}
-				})
+				.find(|item| self.matches_lookup(item, &pk))
 				.cloned()
 				.ok_or_else(|| ViewError::NotFound(format!("Object with pk={} not found", pk)))?
 		};
@@ -1634,22 +1697,11 @@ where
 			));
 		} else {
 			// Fall back to queryset for non-database mode
-			// Normalize pk: strip surrounding quotes only (consistent with retrieve()).
-			let pk_str_owned = pk.to_string();
-			let pk_str = pk_str_owned.trim_matches('"');
 			self.get_queryset()
 				.iter()
-				.find(|item| {
-					if let Some(item_pk) = item.primary_key() {
-						item_pk.to_string() == pk_str
-					} else {
-						false
-					}
-				})
+				.find(|item| self.matches_lookup(item, &pk))
 				.cloned()
-				.ok_or_else(|| {
-					ViewError::NotFound(format!("Object with pk {} not found", pk_str))
-				})?
+				.ok_or_else(|| ViewError::NotFound(format!("Object with lookup={pk} not found")))?
 		};
 
 		// Parse request body as JSON for partial update (PATCH semantics)
@@ -1702,7 +1754,7 @@ where
 			// Recheck the request-scoped predicate and lock the row before writing.
 			let mutation_queryset = self
 				.scoped_queryset(request)?
-				.filter(Self::primary_key_filter(&pk)?)
+				.filter(self.lookup_filter(&pk)?)
 				.without_slicing()
 				.without_distinct();
 			if session
@@ -1806,19 +1858,11 @@ where
 					"with_queryset_fn requires a database pool".to_owned(),
 				));
 			}
-			let pk_str_owned = pk.to_string();
-			let pk_str = pk_str_owned.trim_matches('"');
 			self.get_queryset()
 				.iter()
-				.find(|item| {
-					item.primary_key()
-						.map(|item_pk| item_pk.to_string() == pk_str)
-						.unwrap_or(false)
-				})
+				.find(|item| self.matches_lookup(item, &pk))
 				.cloned()
-				.ok_or_else(|| {
-					ViewError::NotFound(format!("Object with pk {} not found", pk_str))
-				})?;
+				.ok_or_else(|| ViewError::NotFound(format!("Object with lookup={pk} not found")))?;
 		}
 
 		// Delete from database if pool is available
@@ -1838,7 +1882,7 @@ where
 			// Recheck the request-scoped predicate and lock the row before deleting.
 			let mutation_queryset = self
 				.scoped_queryset(request)?
-				.filter(Self::primary_key_filter(&pk)?)
+				.filter(self.lookup_filter(&pk)?)
 				.without_slicing()
 				.without_distinct();
 			let item = session
@@ -2301,6 +2345,25 @@ mod tests {
 
 		assert_eq!(filter.field, "id");
 		assert!(matches!(filter.value, FilterValue::Integer(42)));
+	}
+
+	#[test]
+	fn custom_lookup_filter_maps_declared_database_column() {
+		let handler =
+			ModelViewSetHandler::<TestItem>::new().with_lookup_field("organization".to_owned());
+
+		let FilterCondition::Single(filter) = handler
+			.lookup_filter(&serde_json::json!("tenant-a"))
+			.unwrap()
+		else {
+			panic!("a custom lookup should produce one filter");
+		};
+
+		assert_eq!(filter.field, "organization_id");
+		assert!(matches!(
+			filter.value,
+			FilterValue::String(value) if value == "tenant-a"
+		));
 	}
 
 	#[test]

--- a/crates/reinhardt-views/src/viewsets/viewset.rs
+++ b/crates/reinhardt-views/src/viewsets/viewset.rs
@@ -302,7 +302,7 @@ where
 		}
 	}
 
-	/// Set custom lookup field for this ViewSet
+	/// Set the model field used by detail routes and object queries.
 	///
 	/// # Examples
 	///
@@ -340,6 +340,8 @@ where
 	/// ```
 	pub fn with_lookup_field(mut self, field: impl Into<String>) -> Self {
 		self.lookup_field = field.into();
+		self.handler =
+			std::mem::take(&mut self.handler).with_lookup_field(self.lookup_field.clone());
 		self
 	}
 
@@ -510,8 +512,7 @@ where
 	/// or database. Middleware must resolve asynchronous scope data before
 	/// dispatch, and the hook reads application-defined request extensions.
 	/// [`Self::with_queryset`] static `Vec` data is separate and is not filtered.
-	/// Scoped-out objects and malformed detail primary keys produce 404. Custom
-	/// lookup fields remain the #6091 boundary.
+	/// Scoped-out objects and malformed detail lookup values produce 404.
 	pub fn with_queryset_fn<F>(mut self, queryset_fn: F) -> Self
 	where
 		F: Fn(&Request) -> std::result::Result<FilterCondition, ViewError> + Send + Sync + 'static,
@@ -661,9 +662,11 @@ where
 		}
 	}
 
-	/// Set custom lookup field for this ViewSet
+	/// Set the model field used by detail routes and object queries.
 	pub fn with_lookup_field(mut self, field: impl Into<String>) -> Self {
 		self.lookup_field = field.into();
+		self.handler =
+			std::mem::take(&mut self.handler).with_lookup_field(self.lookup_field.clone());
 		self
 	}
 
@@ -751,8 +754,7 @@ where
 	/// asynchronous scope data before dispatch, and the hook reads
 	/// application-defined request extensions. [`Self::with_queryset`] static
 	/// `Vec` data is separate and is not filtered. Scoped-out objects and malformed
-	/// detail primary keys produce 404; custom lookup fields remain the #6091
-	/// boundary.
+	/// detail lookup values produce 404.
 	pub fn with_queryset_fn<F>(mut self, queryset_fn: F) -> Self
 	where
 		F: Fn(&Request) -> std::result::Result<FilterCondition, ViewError> + Send + Sync + 'static,

--- a/tests/integration/tests/routing/router_viewset_integration.rs
+++ b/tests/integration/tests/routing/router_viewset_integration.rs
@@ -249,14 +249,9 @@ async fn test_nested_viewset_routes() {
 #[tokio::test]
 async fn test_viewset_custom_lookup_field() {
 	let mut router = DefaultRouter::new();
-	// Note: TestModel.primary_key() returns id, not name. We seed with id == 1
-	// and use lookup_field = "username" — the ModelViewSet's lookup_field only
-	// affects URL parameter resolution, not how the handler matches the pk.
-	// For this test we just need the request to reach the dispatch with the
-	// expected path param populated.
 	let viewset: Arc<ModelViewSet<TestModel, TestSerializer>> = Arc::new(
 		ModelViewSet::new("users")
-			.with_lookup_field("username")
+			.with_lookup_field("name")
 			.with_queryset(vec![TestModel {
 				id: 1,
 				name: "alice".into(),
@@ -265,15 +260,11 @@ async fn test_viewset_custom_lookup_field() {
 
 	router.register_viewset("users", viewset);
 
-	// Verify that the route uses 'username' instead of 'id'
+	// Verify that the route uses 'name' instead of 'id'
 	let routes = router.get_routes();
 	assert_eq!(routes.len(), 2);
-	assert_eq!(routes[1].path, "/users/{username}/");
+	assert_eq!(routes[1].path, "/users/{name}/");
 
-	// Test that the lookup field parameter is correctly populated by the router.
-	// The handler will treat "alice" as a primary key and not find a match in
-	// the queryset (which keys items by their `id`), so this confirms routing
-	// reaches dispatch, not that the data is found.
 	let request = Request::builder()
 		.method(Method::GET)
 		.uri("/users/alice/")
@@ -283,21 +274,11 @@ async fn test_viewset_custom_lookup_field() {
 		.build()
 		.unwrap();
 
-	let response = router.route(request).await;
-	match response {
-		Ok(resp) => assert_ne!(
-			resp.status,
-			StatusCode::OK,
-			"REGRESSION GUARD (#3985): retrieve must not return placeholder 200 OK with empty body"
-		),
-		Err(e) => {
-			let s = e.to_string();
-			assert!(
-				s.contains("Not found") || s.contains("not found"),
-				"expected NotFound-style error, got: {s}"
-			);
-		}
-	}
+	let response = router.route(request).await.unwrap();
+	assert_eq!(response.status, StatusCode::OK);
+	let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+	assert_eq!(body["id"], 1);
+	assert_eq!(body["name"], "alice");
 }
 
 // Test: Multiple HTTP methods on same ViewSet route.

--- a/tests/integration/tests/viewsets/model_viewset_crud_e2e.rs
+++ b/tests/integration/tests/viewsets/model_viewset_crud_e2e.rs
@@ -454,6 +454,111 @@ async fn model_and_readonly_viewsets_queryset_fn_scope_list_and_detail_in_databa
 
 #[rstest]
 #[tokio::test]
+async fn model_and_readonly_viewsets_apply_custom_lookup_to_scoped_database_queries(
+	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
+) {
+	let (_container, _pg_pool, _port, pg_url) = postgres_container.await;
+	let pool = pool_with_scoped_items_table(&pg_url).await;
+	sqlx::query(
+		"INSERT INTO scoped_items (id, organization_id, is_archived, name) VALUES \
+			(4, 1, FALSE, 'own-delete'), \
+			(5, 2, FALSE, 'foreign')",
+	)
+	.execute(pool.as_ref())
+	.await
+	.unwrap();
+
+	let mut readonly_router = DefaultRouter::new();
+	readonly_router.register_viewset(
+		"scoped-items",
+		Arc::new(
+			ReadOnlyModelViewSet::<ScopedItem, JsonSerializer<ScopedItem>>::new("scoped-items")
+				.with_lookup_field("name")
+				.with_queryset_fn(organization_filter)
+				.with_pool(pool.clone())
+				.with_db_backend(DbBackend::Postgres),
+		),
+	);
+	let readonly_response = readonly_router
+		.route(scoped_request(
+			Method::GET,
+			"/scoped-items/own/",
+			"",
+			Some(1),
+		))
+		.await
+		.unwrap();
+	assert_eq!(readonly_response.status, StatusCode::OK);
+	let readonly_foreign = readonly_router
+		.route(scoped_request(
+			Method::GET,
+			"/scoped-items/foreign/",
+			"",
+			Some(1),
+		))
+		.await
+		.unwrap_err();
+	assert!(matches!(
+		readonly_foreign,
+		reinhardt_core::exception::Error::NotFound(_)
+	));
+
+	let mut model_router = DefaultRouter::new();
+	model_router.register_viewset(
+		"scoped-items",
+		Arc::new(
+			ModelViewSet::<ScopedItem, JsonSerializer<ScopedItem>>::new("scoped-items")
+				.with_lookup_field("name")
+				.with_queryset_fn(organization_filter)
+				.with_pool(pool.clone())
+				.with_db_backend(DbBackend::Postgres),
+		),
+	);
+	let retrieved = model_router
+		.route(scoped_request(
+			Method::GET,
+			"/scoped-items/own/",
+			"",
+			Some(1),
+		))
+		.await
+		.unwrap();
+	let updated = model_router
+		.route(scoped_request(
+			Method::PATCH,
+			"/scoped-items/own/",
+			r#"{"name":"renamed"}"#,
+			Some(1),
+		))
+		.await
+		.unwrap();
+	let destroyed = model_router
+		.route(scoped_request(
+			Method::DELETE,
+			"/scoped-items/own-delete/",
+			"",
+			Some(1),
+		))
+		.await
+		.unwrap();
+
+	assert_eq!(retrieved.status, StatusCode::OK);
+	assert_eq!(updated.status, StatusCode::OK);
+	assert_eq!(destroyed.status, StatusCode::NO_CONTENT);
+	let renamed = sqlx::query_scalar::<_, String>("SELECT name FROM scoped_items WHERE id = 1")
+		.fetch_one(pool.as_ref())
+		.await
+		.unwrap();
+	assert_eq!(renamed, "renamed");
+	let deleted = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM scoped_items WHERE id = 4")
+		.fetch_one(pool.as_ref())
+		.await
+		.unwrap();
+	assert_eq!(deleted, 0);
+}
+
+#[rstest]
+#[tokio::test]
 async fn modelviewset_queryset_fn_blocks_cross_scope_update_and_destroy(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<sqlx::PgPool>, u16, String),
 ) {


### PR DESCRIPTION
## Summary

This PR addresses:

- Applies `ModelViewSet::with_lookup_field` to in-memory and database detail predicates, not only route parameter names.
- Maps custom lookup values through model field metadata for typed bindings and physical database columns.
- Preserves manager and request scopes for retrieve, update, destroy, and `ReadOnlyModelViewSet` retrieve, including mutation-time row-lock rechecks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Custom lookup fields previously changed only the detail route placeholder. The handler still interpreted the extracted value as a primary key, so custom-field retrieve, update, and destroy returned `NotFound`.

Fixes #6091

Related to: #6085

## How Was This Tested?

- `cargo check -p reinhardt-views`
- `cargo nextest run -p reinhardt-views` — 274 passed
- `cargo test --doc -p reinhardt-views` — 115 passed, 20 ignored
- Focused router custom-lookup integration test — passed
- Focused PostgreSQL scoped retrieve/update/destroy and read-only retrieve regression — passed
- `cargo clippy -p reinhardt-views --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo make fmt-check` remains blocked by an unrelated baseline formatter disagreement in `crates/reinhardt-admin/src/pages/components/features.rs`; its check-mode artifact was restored.

## Performance Impact

No additional query is introduced. Detail actions replace the primary-key predicate with one typed equality predicate for the configured lookup field.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #6091
- Related to #6085

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [x] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The in-memory compatibility path matches custom lookup fields through serialized model values. Database-backed paths retain type and column metadata.

🤖 Generated with [Codex](https://openai.com/codex)