### PR TITLE
feat(pages): support optional query extractors

### DIFF
--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(pages)* support optional typed query extraction across route components, layouts, loaders, page props, and manual request props; optional loader cache identity distinguishes missing and present values
+
 ## [0.4.0-alpha.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.4.0-alpha.8...reinhardt-pages@v0.4.0-alpha.9) - 2026-08-23
 
 ### Documentation

--- a/crates/reinhardt-pages/docs/route_loaders.md
+++ b/crates/reinhardt-pages/docs/route_loaders.md
@@ -47,6 +47,10 @@ async fn deployment_loader(
 }
 ```
 
+Optional lowering recognizes only `Option<T>`, `std::option::Option<T>`, and
+`core::option::Option<T>`; type aliases are not lowered as optional query
+extractors.
+
 For optional loader queries, missing, empty, and ordinary present values have
 different cache keys:
 

--- a/crates/reinhardt-pages/docs/route_loaders.md
+++ b/crates/reinhardt-pages/docs/route_loaders.md
@@ -36,6 +36,29 @@ the same `loader = ...` option and receive their value before the leaf route is
 rendered. A persistent layout is remounted when one of its declared loader
 inputs changes, even if its route path parameters are unchanged.
 
+An optional query extractor uses an explicit outer `Option<T>`:
+
+```rust,ignore
+#[loader]
+async fn deployment_loader(
+    Query(logs): Query<Option<i64>>,
+) -> Result<DeploymentData, String> {
+    load_deployments(logs).await
+}
+```
+
+For optional loader queries, missing, empty, and ordinary present values have
+different cache keys:
+
+```json
+{"path":[],"query":[["logs",null]]}
+{"path":[],"query":[["logs",""]]}
+{"path":[],"query":[["logs","42"]]}
+```
+
+These shapes identify distinct loader cache entries across SSR, hydration,
+prefetch, and navigation.
+
 ## Navigation and cancellation
 
 `ClientLauncher` installs a pages-owned `NavigationCoordinator`. It performs

--- a/crates/reinhardt-pages/macros/CHANGELOG.md
+++ b/crates/reinhardt-pages/macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(pages-macros)* support optional typed query extraction across route components, layouts, loaders, and page props
+
 ## [0.4.0-alpha.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-macros@v0.4.0-alpha.6...reinhardt-pages-macros@v0.4.0-alpha.7) - 2026-08-19
 
 ### Added

--- a/crates/reinhardt-pages/macros/src/component.rs
+++ b/crates/reinhardt-pages/macros/src/component.rs
@@ -12,6 +12,7 @@ use syn::{
 };
 
 use crate::crate_paths::get_reinhardt_pages_crate;
+use crate::type_utils::option_inner_type;
 
 struct ComponentArgs {
 	path: LitStr,
@@ -275,9 +276,17 @@ fn expand_component(args: ComponentArgs, input: ItemFn) -> syn::Result<proc_macr
 				Source::Path => quote! {
 					#name: #pages_crate::router::request::PathParam::<#ty>::extract(ctx, #key)?.into_inner()
 				},
-				Source::Query => quote! {
-					#name: #pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
-				},
+				Source::Query => {
+					if let Some(inner) = option_inner_type(ty) {
+						quote! {
+							#name: #pages_crate::router::request::OptionalQueryParam::<#inner>::extract(ctx, #key)?.into_inner()
+						}
+					} else {
+						quote! {
+							#name: #pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
+						}
+					}
+				}
 				Source::Loader => unreachable!("loader inputs are not props fields"),
 			}
 		});
@@ -484,9 +493,17 @@ fn expand_layout(args: LayoutArgs, input: ItemFn) -> syn::Result<proc_macro2::To
 				Source::Path => quote! {
 					#name: #pages_crate::router::request::PathParam::<#ty>::extract(ctx, #key)?.into_inner()
 				},
-				Source::Query => quote! {
-					#name: #pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
-				},
+				Source::Query => {
+					if let Some(inner) = option_inner_type(ty) {
+						quote! {
+							#name: #pages_crate::router::request::OptionalQueryParam::<#inner>::extract(ctx, #key)?.into_inner()
+						}
+					} else {
+						quote! {
+							#name: #pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
+						}
+					}
+				}
 				Source::Loader => unreachable!("loader inputs are not props fields"),
 			}
 		});

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -180,18 +180,56 @@ pub fn derive_client_form(input: TokenStream) -> TokenStream {
 }
 
 /// Adds builder support and `FromRequest` extraction to a named props struct.
+///
+/// ```ignore
+/// use reinhardt_pages::page_props;
+///
+/// #[page_props]
+/// struct DeploymentPageProps {
+///     #[from_request(query)]
+///     logs: Option<i64>,
+/// }
+/// ```
+///
+/// The optional form recognizes only `Option<T>`, `std::option::Option<T>`,
+/// and `core::option::Option<T>`; aliases remain required query fields.
 #[proc_macro_attribute]
 pub fn page_props(args: TokenStream, input: TokenStream) -> TokenStream {
 	page_props::page_props_impl(args, input)
 }
 
 /// Declares a route-backed page component.
+///
+/// A query extractor may use an explicit outer `Option<T>` to accept a missing
+/// query key:
+///
+/// ```ignore
+/// use reinhardt_pages::{Page, Query, component};
+///
+/// #[component("/deployments/", name = "deployment-list")]
+/// fn deployment_list(Query(logs): Query<Option<i64>>) -> Page {
+///     render_deployments(logs)
+/// }
+/// ```
+///
+/// The optional form recognizes only `Option<T>`, `std::option::Option<T>`,
+/// and `core::option::Option<T>`. Type aliases are not lowered as optional
+/// query extractors.
 #[proc_macro_attribute]
 pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
 	component::component_impl(args, input)
 }
 
 /// Declares a route-backed layout component.
+///
+/// ```ignore
+/// use reinhardt_pages::{Outlet, Page, Query, layout};
+///
+/// #[layout("/deployments/", name = "deployment-shell")]
+/// fn deployment_shell(Query(logs): Query<Option<i64>>, outlet: Outlet) -> Page {
+///     render_shell(logs, outlet)
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn layout(args: TokenStream, input: TokenStream) -> TokenStream {
 	component::layout_impl(args, input)
@@ -202,6 +240,17 @@ pub fn layout(args: TokenStream, input: TokenStream) -> TokenStream {
 /// The original function remains directly callable. The generated marker is
 /// used by `#[component(loader = ...)]`/`#[layout(loader = ...)]`, the shared
 /// query-cache executor, and SSR hydration deserialization.
+///
+/// ```ignore
+/// use reinhardt_pages::{Query, loader};
+///
+/// #[loader]
+/// async fn deployment_loader(
+///     Query(logs): Query<Option<i64>>,
+/// ) -> Result<DeploymentData, String> {
+///     load_deployments(logs).await
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn loader(args: TokenStream, input: TokenStream) -> TokenStream {
 	loader::loader_impl(args, input)

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -91,6 +91,7 @@ mod page_props;
 mod server_fn;
 mod server_fnset;
 mod style;
+mod type_utils;
 mod wasm_server_api;
 
 /// Defines one component-scoped style API from a canonical static item.

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -230,6 +230,10 @@ pub fn component(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     render_shell(logs, outlet)
 /// }
 /// ```
+///
+/// The optional form recognizes only `Option<T>`, `std::option::Option<T>`,
+/// and `core::option::Option<T>`. Type aliases are not lowered as optional
+/// query extractors.
 #[proc_macro_attribute]
 pub fn layout(args: TokenStream, input: TokenStream) -> TokenStream {
 	component::layout_impl(args, input)
@@ -251,6 +255,10 @@ pub fn layout(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     load_deployments(logs).await
 /// }
 /// ```
+///
+/// The optional form recognizes only `Option<T>`, `std::option::Option<T>`,
+/// and `core::option::Option<T>`. Type aliases are not lowered as optional
+/// query extractors.
 #[proc_macro_attribute]
 pub fn loader(args: TokenStream, input: TokenStream) -> TokenStream {
 	loader::loader_impl(args, input)

--- a/crates/reinhardt-pages/macros/src/loader.rs
+++ b/crates/reinhardt-pages/macros/src/loader.rs
@@ -6,6 +6,7 @@ use syn::{
 };
 
 use crate::crate_paths::get_reinhardt_pages_crate;
+use crate::type_utils::option_inner_type;
 
 #[derive(Clone, Copy)]
 enum LoaderInputKind {
@@ -17,6 +18,15 @@ struct LoaderArg {
 	kind: Option<LoaderInputKind>,
 	name: Option<Ident>,
 	value_type: Option<Type>,
+}
+
+impl LoaderArg {
+	fn optional_query_inner(&self) -> Option<&Type> {
+		if !matches!(self.kind, Some(LoaderInputKind::Query)) {
+			return None;
+		}
+		self.value_type.as_ref().and_then(option_inner_type)
+	}
 }
 
 struct LoaderSignature {
@@ -83,6 +93,15 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 			}
 		})
 	});
+	let optional_query_inputs = signature.args.iter().filter_map(|arg| {
+		arg.optional_query_inner()?;
+		Some(
+			arg.name
+				.as_ref()
+				.expect("loader extractor has a name")
+				.to_string(),
+		)
+	});
 	let extraction = signature.args.iter().map(|arg| {
 		let Some(kind) = arg.kind else {
 			return quote! {};
@@ -94,9 +113,17 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 			LoaderInputKind::Path => quote! {
 				#pages_crate::router::request::PathParam::<#value_type>::extract(&__context, #key)
 			},
-			LoaderInputKind::Query => quote! {
-				#pages_crate::router::request::QueryParam::<#value_type>::extract(&__context, #key)
-			},
+			LoaderInputKind::Query => {
+				if let Some(inner) = arg.optional_query_inner() {
+					quote! {
+						#pages_crate::router::request::OptionalQueryParam::<#inner>::extract(&__context, #key)
+					}
+				} else {
+					quote! {
+						#pages_crate::router::request::QueryParam::<#value_type>::extract(&__context, #key)
+					}
+				}
+			}
 		};
 		quote! {
 			let #name = #extractor
@@ -136,6 +163,11 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 				#(#input_specs,)*
 			];
 
+			#[doc(hidden)]
+			pub const OPTIONAL_QUERY_INPUTS: &'static [&'static str] = &[
+				#(#optional_query_inputs,)*
+			];
+
 			impl #pages_crate::RouteLoader for marker {
 				type Data = #data;
 				type Error = #error;
@@ -165,10 +197,11 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 							#fetcher_name(__fetch_context.clone(), __query_cancellation)
 						}
 					};
-					#pages_crate::router::loader::acquire_loader_query::<#data>(
+					#pages_crate::router::loader::acquire_loader_query_with_optional_queries::<#data>(
 						<marker as #pages_crate::RouteLoader>::ID,
 						&__context,
 						INPUTS,
+						OPTIONAL_QUERY_INPUTS,
 						__cancellation,
 						__consumer,
 						__fetcher,
@@ -192,11 +225,12 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 						#fetcher_name(__fetch_context.clone(), __query_cancellation)
 					}
 				};
-				#pages_crate::router::loader::seed_loader_query::<#data>(
+				#pages_crate::router::loader::seed_loader_query_with_optional_queries::<#data>(
 					__client,
 					<marker as #pages_crate::RouteLoader>::ID,
 					&__context,
 					INPUTS,
+					OPTIONAL_QUERY_INPUTS,
 					__hydration,
 					__fetcher,
 				)
@@ -214,6 +248,13 @@ fn expand_loader(input: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
 				#pages_crate::router::loader_registry::LoaderQueryHydrationRegistration::new(
 					<marker as #pages_crate::RouteLoader>::ID,
 					#query_seeder_name,
+				)
+			}
+
+			#pages_crate::__private::inventory::submit! {
+				#pages_crate::router::loader_registry::LoaderOptionalQueryRegistration::new(
+					<marker as #pages_crate::RouteLoader>::ID,
+					OPTIONAL_QUERY_INPUTS,
 				)
 			}
 		}

--- a/crates/reinhardt-pages/macros/src/page_props.rs
+++ b/crates/reinhardt-pages/macros/src/page_props.rs
@@ -5,6 +5,7 @@ use quote::quote;
 use syn::{Error, Field, Fields, ItemStruct, Result, parse_macro_input};
 
 use crate::crate_paths::get_reinhardt_pages_crate;
+use crate::type_utils::option_inner_type;
 
 pub(crate) fn page_props_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 	if !args.is_empty() {
@@ -56,9 +57,17 @@ fn expand_page_props(mut item: ItemStruct) -> Result<proc_macro2::TokenStream> {
 			SourceKind::Path => quote! {
 				#pages_crate::router::request::PathParam::<#ty>::extract(ctx, #key)?.into_inner()
 			},
-			SourceKind::Query => quote! {
-				#pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
-			},
+			SourceKind::Query => {
+				if let Some(inner) = option_inner_type(ty) {
+					quote! {
+						#pages_crate::router::request::OptionalQueryParam::<#inner>::extract(ctx, #key)?.into_inner()
+					}
+				} else {
+					quote! {
+						#pages_crate::router::request::QueryParam::<#ty>::extract(ctx, #key)?.into_inner()
+					}
+				}
+			}
 		};
 		initializers.push(quote! { #field_ident: #extractor });
 	}

--- a/crates/reinhardt-pages/macros/src/type_utils.rs
+++ b/crates/reinhardt-pages/macros/src/type_utils.rs
@@ -1,0 +1,33 @@
+use syn::{GenericArgument, PathArguments, Type};
+
+pub(crate) fn option_inner_type(ty: &Type) -> Option<&Type> {
+	let Type::Path(type_path) = ty else {
+		return None;
+	};
+	if type_path.qself.is_some() {
+		return None;
+	}
+	let segments = type_path.path.segments.iter().collect::<Vec<_>>();
+	let supported = match segments.as_slice() {
+		[option] => option.ident == "Option",
+		[root, module, option] => {
+			(root.ident == "std" || root.ident == "core")
+				&& module.ident == "option"
+				&& option.ident == "Option"
+		}
+		_ => false,
+	};
+	if !supported {
+		return None;
+	}
+	let PathArguments::AngleBracketed(arguments) = &segments.last()?.arguments else {
+		return None;
+	};
+	if arguments.args.len() != 1 {
+		return None;
+	}
+	match arguments.args.first()? {
+		GenericArgument::Type(inner) => Some(inner),
+		_ => None,
+	}
+}

--- a/crates/reinhardt-pages/src/app/launcher.rs
+++ b/crates/reinhardt-pages/src/app/launcher.rs
@@ -35,7 +35,8 @@ use crate::document_head::{
 use crate::router::loader::RouteLoaderError;
 #[cfg(wasm)]
 use crate::router::loader::{
-	LoaderStore, active_loader_store, loader_cache_id, route_context, with_loader_store,
+	LoaderStore, active_loader_store, loader_cache_id_with_optional_queries, route_context,
+	with_loader_store,
 };
 #[cfg(wasm)]
 use crate::router::loader_registry::LoaderRegistry;
@@ -143,12 +144,17 @@ impl PersistentLayoutRenderer {
 					route_match.query().unwrap_or_default()
 				);
 				if let Some(id) = layout.metadata().loader_id() {
-					let cache_key = registry
-						.as_ref()
-						.and_then(|registry| registry.get(id).ok())
-						.and_then(|registration| {
-							loader_cache_id(id, &loader_context, registration.inputs).ok()
-						});
+					let cache_key = registry.as_ref().and_then(|registry| {
+						registry.get(id).ok().and_then(|registration| {
+							loader_cache_id_with_optional_queries(
+								id,
+								&loader_context,
+								registration.inputs,
+								registry.optional_query_inputs(id),
+							)
+							.ok()
+						})
+					});
 					let cache_key = cache_key.unwrap_or_else(|| {
 						format!(
 							"route-loader:{}:{}?{}",

--- a/crates/reinhardt-pages/src/router.rs
+++ b/crates/reinhardt-pages/src/router.rs
@@ -127,15 +127,18 @@ pub mod loader_store;
 ///
 /// ```ignore
 /// use reinhardt_pages::router::request::{
-///     ExtractError, FromRequest, PathParam, RouteContext,
+///     ExtractError, FromRequest, OptionalQueryParam, RouteContext,
 /// };
-/// use reinhardt_urls::routers::ClientRouter;
 ///
-/// struct UserPageProps { id: PathParam<i32> }
+/// struct DeploymentRequest {
+///     logs: OptionalQueryParam<i64>,
+/// }
 ///
-/// impl FromRequest for UserPageProps {
+/// impl FromRequest for DeploymentRequest {
 ///     fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
-///         Ok(Self { id: PathParam::extract(ctx, "id")? })
+///         Ok(Self {
+///             logs: OptionalQueryParam::extract(ctx, "logs")?,
+///         })
 ///     }
 /// }
 /// ```

--- a/crates/reinhardt-pages/src/router.rs
+++ b/crates/reinhardt-pages/src/router.rs
@@ -146,7 +146,7 @@ pub mod loader_store;
 /// this submodule.
 pub mod request {
 	pub use reinhardt_urls::routers::client_router::from_request::{
-		ExtractError, FromRequest, PathParam, QueryParam, RouteContext,
+		ExtractError, FromRequest, OptionalQueryParam, PathParam, QueryParam, RouteContext,
 	};
 }
 

--- a/crates/reinhardt-pages/src/router/loader.rs
+++ b/crates/reinhardt-pages/src/router/loader.rs
@@ -241,20 +241,38 @@ pub fn canonical_loader_inputs(
 	context: &RouteContext,
 	specs: &[LoaderInputSpec],
 ) -> Result<String, LoaderInputError> {
+	canonical_loader_inputs_with_optional_queries(context, specs, &[])
+}
+
+#[doc(hidden)]
+pub fn canonical_loader_inputs_with_optional_queries(
+	context: &RouteContext,
+	specs: &[LoaderInputSpec],
+	optional_query_inputs: &[&str],
+) -> Result<String, LoaderInputError> {
 	let mut path_values = Vec::new();
 	let mut query_values = Vec::new();
 	for spec in specs {
 		let value = match spec.kind {
 			LoaderInputKind::Path => context.path_param(spec.name),
 			LoaderInputKind::Query => query_value(context.query(), spec.name),
-		}
-		.ok_or_else(|| LoaderInputError::Missing {
-			kind: spec.kind,
-			name: spec.name.to_string(),
-		})?;
+		};
+		let encoded_value = match value {
+			Some(value) => serde_json::to_string(&value).expect("loader input values serialize"),
+			None if spec.kind == LoaderInputKind::Query
+				&& optional_query_inputs.contains(&spec.name) =>
+			{
+				"null".to_owned()
+			}
+			None => {
+				return Err(LoaderInputError::Missing {
+					kind: spec.kind,
+					name: spec.name.to_string(),
+				});
+			}
+		};
 		let encoded_name =
 			serde_json::to_string(spec.name).expect("static loader input names serialize");
-		let encoded_value = serde_json::to_string(&value).expect("loader input values serialize");
 		let pair = format!("[{encoded_name},{encoded_value}]");
 		match spec.kind {
 			LoaderInputKind::Path => path_values.push(pair),
@@ -274,7 +292,18 @@ pub fn loader_cache_id(
 	context: &RouteContext,
 	specs: &[LoaderInputSpec],
 ) -> Result<String, LoaderInputError> {
-	let shape = canonical_loader_inputs(context, specs)?;
+	loader_cache_id_with_optional_queries(id, context, specs, &[])
+}
+
+#[doc(hidden)]
+pub fn loader_cache_id_with_optional_queries(
+	id: RouteLoaderId,
+	context: &RouteContext,
+	specs: &[LoaderInputSpec],
+	optional_query_inputs: &[&str],
+) -> Result<String, LoaderInputError> {
+	let shape =
+		canonical_loader_inputs_with_optional_queries(context, specs, optional_query_inputs)?;
 	let mut digest = Sha256::new();
 	digest.update(id.as_str().as_bytes());
 	digest.update([0]);
@@ -648,7 +677,28 @@ pub fn seed_loader_query<T>(
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 {
-	let cache_id = loader_cache_id(id, context, specs)
+	seed_loader_query_with_optional_queries(client, id, context, specs, &[], hydration, fetcher)
+}
+
+/// Seeds the typed query cache entry that backs a hydrated route loader.
+#[doc(hidden)]
+pub fn seed_loader_query_with_optional_queries<T>(
+	client: &QueryClient,
+	id: RouteLoaderId,
+	context: &RouteContext,
+	specs: &[LoaderInputSpec],
+	optional_query_inputs: &[&str],
+	hydration: &HydrationContext,
+	fetcher: impl Fn(
+		CancellationHandle,
+	) -> std::pin::Pin<
+		Box<dyn std::future::Future<Output = Result<T, RouteLoaderError>> + 'static>,
+	> + 'static,
+) -> Result<PreparedLoader, RouteLoaderError>
+where
+	T: Clone + Serialize + DeserializeOwned + 'static,
+{
+	let cache_id = loader_cache_id_with_optional_queries(id, context, specs, optional_query_inputs)
 		.map_err(|error| RouteLoaderError::with_status(error.to_string(), 400))?;
 	let query_state = hydration.get_resource_state(&cache_id).ok_or_else(|| {
 		RouteLoaderError::with_status(
@@ -698,6 +748,7 @@ where
 /// Acquires a registered loader using the shared query cache.
 // Generated `#[loader]` executors call this function so route preparation uses
 // the same query client as `use_query`.
+#[doc(hidden)]
 pub async fn acquire_loader_query<T>(
 	id: RouteLoaderId,
 	context: &RouteContext,
@@ -713,7 +764,37 @@ pub async fn acquire_loader_query<T>(
 where
 	T: Clone + Serialize + DeserializeOwned + 'static,
 {
-	let cache_id = loader_cache_id(id, context, specs)
+	acquire_loader_query_with_optional_queries(
+		id,
+		context,
+		specs,
+		&[],
+		cancellation,
+		consumer,
+		fetcher,
+	)
+	.await
+}
+
+/// Acquires a registered loader using the shared query cache.
+#[doc(hidden)]
+pub async fn acquire_loader_query_with_optional_queries<T>(
+	id: RouteLoaderId,
+	context: &RouteContext,
+	specs: &'static [LoaderInputSpec],
+	optional_query_inputs: &'static [&'static str],
+	cancellation: CancellationHandle,
+	consumer: LoaderConsumer,
+	fetcher: impl Fn(
+		CancellationHandle,
+	) -> std::pin::Pin<
+		Box<dyn std::future::Future<Output = Result<T, RouteLoaderError>> + 'static>,
+	> + 'static,
+) -> Result<PreparedLoader, RouteLoaderError>
+where
+	T: Clone + Serialize + DeserializeOwned + 'static,
+{
+	let cache_id = loader_cache_id_with_optional_queries(id, context, specs, optional_query_inputs)
 		.map_err(|error| RouteLoaderError::with_status(error.to_string(), 400))?;
 	let client = queries();
 	let descriptor = QueryFamily::<String, T, RouteLoaderError>::new(id.as_str())
@@ -835,6 +916,75 @@ mod tests {
 		assert_ne!(
 			loader_cache_id(RouteLoaderId::new("jobs"), &first, &specs).unwrap(),
 			loader_cache_id(RouteLoaderId::new("jobs"), &second, &specs).unwrap()
+		);
+	}
+
+	#[test]
+	fn required_query_input_is_still_missing_when_absent() {
+		let context = context(&[], "");
+		let specs = [LoaderInputSpec::query("logs")];
+
+		let error = canonical_loader_inputs(&context, &specs).unwrap_err();
+
+		assert_eq!(
+			error,
+			LoaderInputError::Missing {
+				kind: LoaderInputKind::Query,
+				name: "logs".to_string(),
+			}
+		);
+	}
+
+	#[test]
+	fn optional_query_inputs_distinguish_missing_empty_and_present_values() {
+		let specs = [LoaderInputSpec::query("logs")];
+		let optional = ["logs"];
+		let missing = context(&[], "");
+		let empty = context(&[], "logs=");
+		let present = context(&[], "logs=42");
+		let leading_zero = context(&[], "logs=042");
+
+		let missing_shape =
+			canonical_loader_inputs_with_optional_queries(&missing, &specs, &optional).unwrap();
+		let empty_shape =
+			canonical_loader_inputs_with_optional_queries(&empty, &specs, &optional).unwrap();
+		let present_shape =
+			canonical_loader_inputs_with_optional_queries(&present, &specs, &optional).unwrap();
+		let leading_zero_shape =
+			canonical_loader_inputs_with_optional_queries(&leading_zero, &specs, &optional)
+				.unwrap();
+
+		assert_eq!(missing_shape, r#"{"path":[],"query":[["logs",null]]}"#);
+		assert_eq!(empty_shape, r#"{"path":[],"query":[["logs",""]]}"#);
+		assert_eq!(present_shape, r#"{"path":[],"query":[["logs","42"]]}"#);
+		assert_eq!(
+			leading_zero_shape,
+			r#"{"path":[],"query":[["logs","042"]]}"#
+		);
+
+		let id = RouteLoaderId::new("deployments");
+		let missing_id =
+			loader_cache_id_with_optional_queries(id, &missing, &specs, &optional).unwrap();
+		let empty_id =
+			loader_cache_id_with_optional_queries(id, &empty, &specs, &optional).unwrap();
+		let present_id =
+			loader_cache_id_with_optional_queries(id, &present, &specs, &optional).unwrap();
+		let leading_zero_id =
+			loader_cache_id_with_optional_queries(id, &leading_zero, &specs, &optional).unwrap();
+		assert_ne!(missing_id, empty_id);
+		assert_ne!(missing_id, present_id);
+		assert_ne!(empty_id, present_id);
+		assert_ne!(present_id, leading_zero_id);
+	}
+
+	#[test]
+	fn optional_query_input_uses_first_decoded_value() {
+		let context = context(&[], "logs=hello+world&logs=stale");
+		let specs = [LoaderInputSpec::query("logs")];
+
+		assert_eq!(
+			canonical_loader_inputs_with_optional_queries(&context, &specs, &["logs"]).unwrap(),
+			r#"{"path":[],"query":[["logs","hello world"]]}"#
 		);
 	}
 

--- a/crates/reinhardt-pages/src/router/loader_registry.rs
+++ b/crates/reinhardt-pages/src/router/loader_registry.rs
@@ -79,6 +79,26 @@ impl LoaderRegistration {
 
 inventory::collect!(LoaderRegistration);
 
+/// Static optional query input metadata for one route loader.
+#[doc(hidden)]
+pub struct LoaderOptionalQueryRegistration {
+	id: RouteLoaderId,
+	optional_query_inputs: &'static [&'static str],
+}
+
+impl LoaderOptionalQueryRegistration {
+	/// Creates static optional query input metadata.
+	#[doc(hidden)]
+	pub const fn new(id: RouteLoaderId, optional_query_inputs: &'static [&'static str]) -> Self {
+		Self {
+			id,
+			optional_query_inputs,
+		}
+	}
+}
+
+inventory::collect!(LoaderOptionalQueryRegistration);
+
 /// Static query-cache seeding registration generated alongside a `#[loader]`
 /// marker.
 pub struct LoaderQueryHydrationRegistration {
@@ -124,6 +144,7 @@ impl std::error::Error for LoaderRegistryError {}
 /// Read-only lookup table for erased loader registrations.
 pub struct LoaderRegistry {
 	entries: HashMap<RouteLoaderId, &'static LoaderRegistration>,
+	optional_query_inputs: HashMap<RouteLoaderId, &'static [&'static str]>,
 	query_seeders: HashMap<RouteLoaderId, LoaderQuerySeeder>,
 }
 
@@ -141,6 +162,7 @@ impl LoaderRegistry {
 		}
 		Ok(Self {
 			entries: indexed,
+			optional_query_inputs: HashMap::new(),
 			query_seeders: HashMap::new(),
 		})
 	}
@@ -152,6 +174,11 @@ impl LoaderRegistry {
 			registry
 				.query_seeders
 				.insert(registration.id, registration.seed_query);
+		}
+		for registration in inventory::iter::<LoaderOptionalQueryRegistration> {
+			registry
+				.optional_query_inputs
+				.insert(registration.id, registration.optional_query_inputs);
 		}
 		Ok(registry)
 	}
@@ -175,6 +202,10 @@ impl LoaderRegistry {
 	/// Returns whether no loaders are registered.
 	pub fn is_empty(&self) -> bool {
 		self.entries.is_empty()
+	}
+
+	pub(crate) fn optional_query_inputs(&self, id: RouteLoaderId) -> &'static [&'static str] {
+		self.optional_query_inputs.get(&id).copied().unwrap_or(&[])
 	}
 
 	/// Hydrates one loader and acquires its mounted-route query lease.

--- a/crates/reinhardt-pages/src/ssr/route.rs
+++ b/crates/reinhardt-pages/src/ssr/route.rs
@@ -5,7 +5,8 @@ use crate::cancellation::CancellationSource;
 use crate::component::{IntoPage, Page, PageElement};
 use crate::reactive::query::with_query_client_async;
 use crate::router::loader::{
-	LoaderStore, RouteLoaderError, loader_cache_id, route_context, with_loader_store,
+	LoaderStore, RouteLoaderError, loader_cache_id_with_optional_queries, route_context,
+	with_loader_store,
 };
 use crate::router::loader_registry::{LoaderConsumer, LoaderRegistry, execute_loader};
 use futures_util::future::try_join_all;
@@ -156,8 +157,13 @@ async fn prepare_route_loaders(
 		let registration = registry
 			.get(id)
 			.map_err(|error| RouteLoaderError::with_status(error.to_string(), 500))?;
-		let cache_key = loader_cache_id(id, &context, registration.inputs)
-			.map_err(|error| RouteLoaderError::with_status(error.to_string(), 400))?;
+		let cache_key = loader_cache_id_with_optional_queries(
+			id,
+			&context,
+			registration.inputs,
+			registry.optional_query_inputs(id),
+		)
+		.map_err(|error| RouteLoaderError::with_status(error.to_string(), 400))?;
 		let serialized = prepared.serialized().clone();
 		store.insert_prepared(prepared);
 		serialized_loaders.push((id, cache_key, serialized));

--- a/crates/reinhardt-pages/tests/component_invocation_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/component_invocation_integration_tests.rs
@@ -10,7 +10,7 @@
 
 use reinhardt_core::reactive::ReactiveScope;
 use reinhardt_pages::component::Page;
-use reinhardt_pages::{Loader, component, loader, page};
+use reinhardt_pages::{Loader, Query, component, loader, page};
 use rstest::rstest;
 
 #[loader]
@@ -27,6 +27,11 @@ fn integration_greeting(Loader(message): Loader<String>) -> Page {
 	page!(|message: String| {
 		p { { message } }
 	})(message)
+}
+
+#[component("/optional-query/", name = "integration-optional-query")]
+fn integration_optional_query(Query(logs): Query<Option<i64>>) -> Page {
+	Page::text(logs.map_or_else(|| "none".to_owned(), |id| id.to_string()))
 }
 
 #[derive(bon::Builder)]
@@ -186,4 +191,30 @@ fn routed_component_reads_prepared_loader_value() {
 	let rendered =
 		integration_greeting(IntegrationGreetingProps::builder().build()).render_to_string();
 	assert_eq!(rendered, "<p>prepared greeting</p>");
+}
+
+#[test]
+fn routed_component_extracts_optional_query_values() {
+	use reinhardt_pages::router::ClientRouter;
+
+	ReactiveScope::run(|| {
+		let router = ClientRouter::new().component(integration_optional_query);
+
+		assert_eq!(
+			router.render_path("/optional-query/").render_to_string(),
+			"none"
+		);
+		assert_eq!(
+			router
+				.render_path("/optional-query/?logs=42")
+				.render_to_string(),
+			"42"
+		);
+		assert_eq!(
+			router
+				.render_path("/optional-query/?logs=invalid")
+				.render_to_string(),
+			"route extraction error on `/optional-query/`: failed to parse `logs`: invalid digit found in string"
+		);
+	});
 }

--- a/crates/reinhardt-pages/tests/ssr_route_loader_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_route_loader_integration_tests.rs
@@ -1,9 +1,11 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use reinhardt_pages::router::loader::{loader_cache_id, route_context};
+use reinhardt_pages::router::loader::{
+	loader_cache_id, loader_cache_id_with_optional_queries, route_context,
+};
 use reinhardt_pages::router::loader_registry::LoaderRegistry;
 use reinhardt_pages::{
-	HydrationContext, Loader, Outlet, Page, Path, QueryClient, QueryDefaults, RouteLoader,
+	HydrationContext, Loader, Outlet, Page, Path, Query, QueryClient, QueryDefaults, RouteLoader,
 	SsrRenderer, component, layout, loader, page,
 };
 use reinhardt_urls::routers::ClientRouter;
@@ -53,6 +55,20 @@ fn ssr_greeting(Loader(message): Loader<String>) -> Page {
 	page!(|message: String| {
 		p { { message } }
 	})(message)
+}
+
+#[loader]
+async fn optional_ssr_loader(Query(logs): Query<Option<i64>>) -> Result<String, String> {
+	Ok(logs.map_or_else(|| "none".to_owned(), |id| id.to_string()))
+}
+
+#[component(
+	"/optional-loader/",
+	name = "ssr-optional-loader",
+	loader = optional_ssr_loader
+)]
+fn ssr_optional_loader(Loader(value): Loader<String>) -> Page {
+	Page::text(value)
 }
 
 #[loader]
@@ -172,6 +188,66 @@ fn route_loader_is_prepared_before_ssr_render() {
 		registry
 			.seed_hydrated_query(&client, loader_id, &route_context(&matched), &hydration)
 			.expect("loader value and query lease hydrate together");
+	});
+}
+
+#[test]
+fn optional_loader_query_reaches_ssr_and_uses_the_same_hydration_key() {
+	tokio_test::block_on(async {
+		let router = ClientRouter::new().component(ssr_optional_loader);
+		let loader_id = <optional_ssr_loader::marker as RouteLoader>::ID;
+
+		let mut absent_renderer = SsrRenderer::new();
+		let absent = absent_renderer
+			.render_route_to_string(&router, "/optional-loader/")
+			.await;
+		assert_eq!(absent.status, 200);
+		assert_eq!(
+			absent_renderer
+				.state()
+				.get_route_loader_state(loader_id.as_str()),
+			Some(&serde_json::json!("none"))
+		);
+		let absent_match = router
+			.match_tree("/optional-loader/")
+			.expect("optional loader route matches");
+		let absent_context = route_context(&absent_match);
+		let absent_key = loader_cache_id_with_optional_queries(
+			loader_id,
+			&absent_context,
+			optional_ssr_loader::INPUTS,
+			optional_ssr_loader::OPTIONAL_QUERY_INPUTS,
+		)
+		.expect("missing optional query has a cache key");
+		assert_eq!(
+			absent_renderer.state().get_resource_state(&absent_key),
+			Some(&serde_json::json!({ "Success": "none" }))
+		);
+		let registry = LoaderRegistry::global().expect("loader registry is available");
+		let client = QueryClient::new(QueryDefaults::default());
+		let hydration = HydrationContext::from_state(absent_renderer.state().clone());
+		registry
+			.seed_hydrated_query(&client, loader_id, &absent_context, &hydration)
+			.expect("optional loader hydrates under the SSR key");
+
+		let mut selected_renderer = SsrRenderer::new();
+		let selected = selected_renderer
+			.render_route_to_string(&router, "/optional-loader/?logs=42")
+			.await;
+		assert_eq!(selected.status, 200);
+		assert_eq!(
+			selected_renderer
+				.state()
+				.get_route_loader_state(loader_id.as_str()),
+			Some(&serde_json::json!("42"))
+		);
+
+		let mut invalid_renderer = SsrRenderer::new();
+		let invalid = invalid_renderer
+			.render_route_to_string(&router, "/optional-loader/?logs=invalid")
+			.await;
+		assert_eq!(invalid.status, 400);
+		assert_eq!(invalid_renderer.state().resource_count(), 0);
 	});
 }
 

--- a/crates/reinhardt-pages/tests/ui/component/pass/basic_path.rs
+++ b/crates/reinhardt-pages/tests/ui/component/pass/basic_path.rs
@@ -1,10 +1,10 @@
-use reinhardt_pages::{Page, Path, component, page};
+use reinhardt_pages::{Page, Path, Query, component, page};
 
 #[component("/users/{id}/", name = "user-detail")]
-fn user_page(Path(id): Path<i64>) -> Page {
-	page!(|id: i64| {
-		div { { id.to_string() } }
-	})(id)
+fn user_page(Path(id): Path<i64>, Query(logs): Query<Option<i64>>) -> Page {
+	page!(|id: i64, logs: Option<i64>| {
+		div { { format!("{id}:{logs:?}") } }
+	})(id, logs)
 }
 
 fn main() {

--- a/crates/reinhardt-pages/tests/ui/from_request/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/from_request/pass/basic.rs
@@ -1,11 +1,12 @@
 use reinhardt_pages::FromRequest;
-use reinhardt_pages::router::request::{PathParam, QueryParam};
+use reinhardt_pages::router::request::{OptionalQueryParam, PathParam, QueryParam};
 
 #[derive(FromRequest)]
 struct UserRequest {
 	id: PathParam<i64>,
 	#[from_request(name = "tab")]
 	selected_tab: QueryParam<String>,
+	logs: OptionalQueryParam<i64>,
 }
 
 fn main() {}

--- a/crates/reinhardt-pages/tests/ui/layout/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/layout/pass/basic.rs
@@ -1,14 +1,18 @@
-use reinhardt_pages::{Outlet, Page, Path, component, layout, page};
+use reinhardt_pages::{Outlet, Page, Path, Query, component, layout, page};
 use reinhardt_urls::routers::ClientRouter;
 
 #[layout("/workspaces/{workspace_id}/", name = "workspace-shell")]
-fn workspace_shell(Path(workspace_id): Path<i64>, outlet: Outlet) -> Page {
-	page!(|workspace_id: i64, outlet: Outlet| {
+fn workspace_shell(
+	Path(workspace_id): Path<i64>,
+	Query(tab): Query<std::option::Option<String>>,
+	outlet: Outlet,
+) -> Page {
+	page!(|workspace_id: i64, tab: Option<String>, outlet: Outlet| {
 		div {
-			{ workspace_id.to_string() }
+			{ format!("{workspace_id}:{tab:?}") }
 			{ outlet }
 		}
-	})(workspace_id, outlet)
+	})(workspace_id, tab, outlet)
 }
 
 #[component("jobs", name = "workspace-jobs")]

--- a/crates/reinhardt-pages/tests/ui/loader/pass/path_query.rs
+++ b/crates/reinhardt-pages/tests/ui/loader/pass/path_query.rs
@@ -4,10 +4,11 @@ use reinhardt_pages::{Path, Query, loader};
 async fn project_tab_loader(
 	Path(project_id): Path<i64>,
 	Query(tab): Query<String>,
+	Query(logs): Query<core::option::Option<i64>>,
 ) -> Result<String, String> {
-	Ok(format!("{project_id}:{tab}"))
+	Ok(format!("{project_id}:{tab}:{logs:?}"))
 }
 
 fn main() {
-	let _future = project_tab_loader(Path(42), Query("open".to_string()));
+	let _future = project_tab_loader(Path(42), Query("open".to_string()), Query(None));
 }

--- a/crates/reinhardt-pages/tests/ui/page_props/pass/basic.rs
+++ b/crates/reinhardt-pages/tests/ui/page_props/pass/basic.rs
@@ -6,13 +6,10 @@ struct UserPageProps {
 	#[from_request(path)]
 	id: i64,
 	#[from_request(query)]
-	tab: String,
+	tab: Option<String>,
 }
 
 fn main() {
-	let _ = UserPageProps::builder()
-		.id(7)
-		.tab("profile".to_string())
-		.build();
+	let _ = UserPageProps::builder().id(7).build();
 	let _extractor: fn(&RouteContext) -> Result<UserPageProps, _> = UserPageProps::from_request;
 }

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(urls)* support optional typed query extraction for manual request props
+
 ## [0.4.0-alpha.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.4.0-alpha.8...reinhardt-urls@v0.4.0-alpha.9) - 2026-08-23
 
 ### Documentation

--- a/crates/reinhardt-urls/src/routers/client_router.rs
+++ b/crates/reinhardt-urls/src/routers/client_router.rs
@@ -98,7 +98,9 @@ pub use error::{MergeError, PathError, RouteRegistrationError, RouterError};
 // Re-export the `FromRequest` building blocks at the
 // `client_router` module level so callers can write
 // `use reinhardt_urls::routers::client_router::{FromRequest, ...}`.
-pub use from_request::{ExtractError, FromRequest, PathParam, QueryParam, RouteContext};
+pub use from_request::{
+	ExtractError, FromRequest, OptionalQueryParam, PathParam, QueryParam, RouteContext,
+};
 pub use handler::RouteHandler;
 pub use loader::RouteLoaderId;
 // Issue #4217: drop helper-function re-exports from this module's

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -233,6 +233,57 @@ where
 	}
 }
 
+/// Extractor for an optional named query parameter, parsed via [`FromStr`]
+/// when present.
+///
+/// Construct with [`OptionalQueryParam::extract`] inside a [`FromRequest`]
+/// implementation. A missing key produces `None`; a present value that fails
+/// to parse still produces [`ExtractError::Parse`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OptionalQueryParam<T>(Option<T>);
+
+impl<T> OptionalQueryParam<T> {
+	/// Unwraps the optional inner value.
+	pub fn into_inner(self) -> Option<T> {
+		self.0
+	}
+}
+
+impl<T> AsRef<Option<T>> for OptionalQueryParam<T> {
+	fn as_ref(&self) -> &Option<T> {
+		&self.0
+	}
+}
+
+impl<T> std::ops::Deref for OptionalQueryParam<T> {
+	type Target = Option<T>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T: FromStr> OptionalQueryParam<T>
+where
+	T::Err: std::error::Error + Send + Sync + 'static,
+{
+	/// Extracts and parses query parameter `name` when it is present.
+	///
+	/// # Errors
+	///
+	/// Returns [`ExtractError::Parse`] when a present value fails to parse.
+	pub fn extract(ctx: &RouteContext, name: &str) -> Result<Self, ExtractError> {
+		let Some(raw) = parse_query(ctx.query(), name) else {
+			return Ok(Self(None));
+		};
+		let parsed = T::from_str(&raw).map_err(|source| ExtractError::Parse {
+			name: name.to_string(),
+			source: Box::new(source),
+		})?;
+		Ok(Self(Some(parsed)))
+	}
+}
+
 /// Minimal query-string parser: scans `k=v&k=v` pairs, returning
 /// the percent-decoded value for the first match.
 fn parse_query(query: &str, key: &str) -> Option<String> {

--- a/crates/reinhardt-urls/src/routers/client_router/from_request.rs
+++ b/crates/reinhardt-urls/src/routers/client_router/from_request.rs
@@ -239,6 +239,24 @@ where
 /// Construct with [`OptionalQueryParam::extract`] inside a [`FromRequest`]
 /// implementation. A missing key produces `None`; a present value that fails
 /// to parse still produces [`ExtractError::Parse`].
+///
+/// ```ignore
+/// use reinhardt_urls::routers::client_router::from_request::{
+///     ExtractError, FromRequest, OptionalQueryParam, RouteContext,
+/// };
+///
+/// struct DeploymentRequest {
+///     logs: OptionalQueryParam<i64>,
+/// }
+///
+/// impl FromRequest for DeploymentRequest {
+///     fn from_request(ctx: &RouteContext) -> Result<Self, ExtractError> {
+///         Ok(Self {
+///             logs: OptionalQueryParam::extract(ctx, "logs")?,
+///         })
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OptionalQueryParam<T>(Option<T>);
 

--- a/crates/reinhardt-urls/tests/from_request_unit_tests.rs
+++ b/crates/reinhardt-urls/tests/from_request_unit_tests.rs
@@ -5,7 +5,7 @@ use rstest::rstest;
 use std::collections::HashMap;
 
 use reinhardt_urls::routers::client_router::from_request::{
-	ExtractError, FromRequest, PathParam, QueryParam, RouteContext,
+	ExtractError, FromRequest, OptionalQueryParam, PathParam, QueryParam, RouteContext,
 };
 
 #[derive(Debug)]
@@ -169,4 +169,44 @@ fn query_param_decodes_plus_as_space() {
 
 	// Assert
 	assert_eq!(q.into_inner(), "a b");
+}
+
+#[rstest]
+fn optional_query_param_returns_none_when_absent() {
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "".to_string());
+
+	let query = OptionalQueryParam::<i32>::extract(&ctx, "n").unwrap();
+
+	assert_eq!(query.into_inner(), None);
+}
+
+#[rstest]
+fn optional_query_param_parses_present_value() {
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "n=42".to_string());
+
+	let query = OptionalQueryParam::<i32>::extract(&ctx, "n").unwrap();
+
+	assert_eq!(query.into_inner(), Some(42));
+}
+
+#[rstest]
+fn optional_query_param_returns_parse_error_for_invalid_present_value() {
+	let ctx = RouteContext::new(
+		"/x".to_string(),
+		HashMap::new(),
+		"n=not-a-number".to_string(),
+	);
+
+	let error = OptionalQueryParam::<i32>::extract(&ctx, "n").unwrap_err();
+
+	assert!(matches!(error, ExtractError::Parse { ref name, .. } if name == "n"));
+}
+
+#[rstest]
+fn optional_query_param_keeps_present_empty_string() {
+	let ctx = RouteContext::new("/x".to_string(), HashMap::new(), "q=".to_string());
+
+	let query = OptionalQueryParam::<String>::extract(&ctx, "q").unwrap();
+
+	assert_eq!(query.into_inner(), Some(String::new()));
 }


### PR DESCRIPTION
## Summary

- Add the additive `OptionalQueryParam<T>` extractor for absent, valid, empty, and invalid query values.
- Lower explicit outer `Option<T>` query parameters across component, layout, loader, and page-props macros.
- Preserve required-query APIs while making loader cache identity and SSR/hydration metadata optional-aware.
- Add focused runtime/UI coverage, rustdoc, route-loader guidance, and Unreleased changelog entries.

This PR addresses:

- Optional Pages component query extraction requested in #6144.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Required `QueryParam<T>` extraction rejects an absent key, while `Query<Option<T>>` cannot use the existing `FromStr` contract. Pages routes need an additive optional form for filters, tabs, and selected records without duplicating browser-only query parsing or changing required-query behavior.

Fixes #6144

Related to: [reinhardt-cloud#868](https://github.com/kent8192/reinhardt-cloud/issues/868)

## How Was This Tested?

- [x] `cargo nextest run -p reinhardt-urls --features client-router --test from_request_unit_tests` (15/15)
- [x] Pages loader and SSR focused tests (12/12 and 6/6)
- [x] Pages component/SSR integration tests (14/14) and UI tests (36/36)
- [x] `cargo check -p reinhardt-pages --target wasm32-unknown-unknown --all-features`
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`
- [x] `cargo make clippy-todo-check`
- [x] `cargo make placeholder-check`
- [x] `cargo doc -p reinhardt-urls -p reinhardt-pages --no-deps`
- [ ] `cargo test --workspace --all-features` — the workspace build completed, but 20 Docker-dependent admin E2E tests could not start Chrome because `/var/run/docker.sock` is unavailable in this environment.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [ ] New and existing unit tests pass locally (the Docker-dependent workspace E2E gate is unavailable here; focused affected tests pass)
- [x] I have tested with all affected database backends (not applicable; this change does not modify database behavior)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

<!-- ⚠️ CI CONTROL CHECKBOX - DO NOT EDIT MANUALLY ⚠️
The following checkbox controls CI runner selection.
Checking this option triggers self-hosted runner usage (AWS Spot instances),
which incurs infrastructure costs. Only the repository owner should enable this.
If this checkbox is missing or unchecked, CI defaults to GitHub-hosted runners.
Do NOT modify the checkbox text — CI parses it by exact pattern match. -->
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6144 — optional Pages component query extractors
- [reinhardt-cloud#868](https://github.com/kent8192/reinhardt-cloud/issues/868) — downstream deployment log selector

## Labels to Apply

### Type Label (select one)

- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)

- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

## Additional Context

- `OptionalQueryParam<T>` is re-exported from both requested Pages and URLs paths.
- Macro lowering recognizes only `Option<T>`, `std::option::Option<T>`, and `core::option::Option<T>`; type aliases remain required extraction.
- Missing, empty, and present loader query values retain distinct cache-key shapes (`null`, `""`, and a decoded string).
- Required `LoaderInputKind`, `LoaderInputSpec`, `LoaderRegistration`, canonical/cache helpers, and required query extraction remain source-compatible.
- Existing default-feature URL-test and affected-crate helper failures, plus existing rustdoc warnings, are outside this diff and are documented in the validation record.

🤖 Generated with [Codex](https://openai.com/codex/)
