### PR TITLE
fix(formatter): stabilize direct page capture indentation

### DIFF
--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -132,7 +132,8 @@ DSL macros are formatted with tree-sitter grammars and Topiary queries before
 `cargo fmt --all` formats the surrounding Rust code. For supported `page!`
 Rust expression islands and closure parameter lists, the formatter also runs
 rustfmt with the configured line-width options and reinserts the result
-conservatively:
+conservatively. Direct implicit-capture `page!({ ... })` bodies use the same
+relative indentation as closure bodies, so one formatting pass is stable:
 
 ```bash
 # Format all files in the project

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -80,7 +80,7 @@
 //! - ✅ **Nested transactions** support via savepoints (TransactionScope API)
 //! - ✅ **Isolation level** control with `transaction_with_isolation()`
 //!
-//! See [`transaction`](transaction/index.html) module for detailed documentation.
+//! See [`transaction`] module for detailed documentation.
 //!
 //! ## Migration System
 //!

--- a/crates/reinhardt-formatter/src/format_engine.rs
+++ b/crates/reinhardt-formatter/src/format_engine.rs
@@ -303,12 +303,24 @@ fn format_macro(
 	rustfmt_options: &RustfmtOptions,
 ) -> Result<String, String> {
 	let parts = split_macro(original, kind)?;
-	let dsl_input = if parts.open == '{' {
+	let direct_page_capture =
+		kind == MacroKind::Page && parts.open == '(' && parts.inner.trim_start().starts_with('{');
+	let dsl_input = if direct_page_capture {
+		format!("|| {}", parts.inner.trim_start())
+	} else if parts.open == '{' {
 		format!("{}{}{}", parts.open, parts.inner, parts.close)
 	} else {
 		parts.inner.to_string()
 	};
-	let formatted = format_dsl_with_options_preserving_markers(kind, &dsl_input, rustfmt_options)?;
+	let mut formatted =
+		format_dsl_with_options_preserving_markers(kind, &dsl_input, rustfmt_options)?;
+	if direct_page_capture {
+		formatted.output = formatted
+			.output
+			.strip_prefix("|| ")
+			.ok_or_else(|| "formatted direct page capture lost its closure prefix".to_string())?
+			.to_string();
+	}
 	let mut formatted_dsl = indent_relative(formatted.output.trim_end(), base_indent);
 	restore_protected_rustfmt_islands(&mut formatted_dsl, &formatted.protected_islands);
 
@@ -1739,6 +1751,43 @@ fn main() {}";
 
 		// Assert
 		assert_eq!(first.content, second.content);
+	}
+
+	#[rstest]
+	fn direct_page_capture_starting_with_interpolation_is_idempotent() {
+		// Arrange
+		let options = RustfmtOptions {
+			config: Some("hard_tabs=true".to_string()),
+			..RustfmtOptions::default()
+		};
+		let formatter = FormatEngine::with_rustfmt_options(options.clone());
+		let source = r#"fn render() -> Page {
+	Page::reactive(move || {
+		page!({
+			{ success_view }
+			{ error_view }
+			form {
+				class: "stack",
+				button {
+					type: "submit",
+					"Save"
+				}
+			}
+		})
+	})
+}"#;
+		// Act
+		let first_dsl = formatter.format(source).expect("first DSL format");
+		let first = crate::run_rustfmt(&first_dsl.content, &options).expect("first rustfmt");
+		let second_dsl = formatter.format(&first).expect("second DSL format");
+		let second = crate::run_rustfmt(&second_dsl.content, &options).expect("second rustfmt");
+
+		// Assert
+		assert_eq!(
+			first, second,
+			"first DSL:\n{}\nsecond DSL:\n{}",
+			first_dsl.content, second_dsl.content
+		);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR addresses:

- Normalize direct implicit-capture `page!({ ... })` bodies through the existing closure indentation path.
- Add a two-pass formatter and rustfmt regression test plus user-facing formatter documentation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Direct page captures whose first DSL child was an interpolation accumulated indentation on every `fmt-all` pass. Reusing the closure normalization path makes the formatter reach a fixed point without changing emitted page syntax.

Fixes #6186

## How Was This Tested?

- `cargo test -p reinhardt-formatter` (90 passed)
- `cargo make fmt-check`
- `cargo make clippy-check`
- `cargo check --workspace --all --all-features`
- `cargo build --workspace --all --all-features`
- `DOCKER_HOST=$ORBSTACK_DOCKER_SOCKET cargo test -p reinhardt-admin --test e2e_pages` (19 passed)
- `cargo test -p reinhardt-commands --test admin_scripts_tests -- --test-threads=1` (62 passed)

The full parallel workspace test run stopped in three pre-existing `reinhardt-commands` tests that share and remove the process current directory. Those same tests pass when serialized.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #6186

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix

### Scope Label (select all that apply)

- [x] `admin` - Admin interface, admin panels

---

**Additional Context:**

- The direct-capture output syntax remains `page!({ ... })`; the closure prefix is only an internal formatter normalization aid.

🤖 Generated with [Codex](https://openai.com/codex)
