### PR TITLE
fix(dependencies): patch vulnerable inactive rkyv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -793,7 +793,7 @@ redis = { version = "1.2.0", features = ["tokio-comp", "connection-manager"] }
 
 # Connection pooling & migrations
 refinery = { version = "0.9.0", features = ["tokio-postgres"] }
-rust_decimal = "1.41.0"
+rust_decimal = "1.42.1"
 
 # E2E browser testing
 fantoccini = "0.22.1"
@@ -846,6 +846,13 @@ tower-http = "0.6.0"
 [patch.crates-io]
 topiary-tree-sitter-facade = { path = "vendor/topiary-tree-sitter-facade" }
 topiary-web-tree-sitter-sys = { path = "vendor/topiary-web-tree-sitter-sys" }
+# Workaround for paupino/rust-decimal#818 (tracked in reinhardt-web#6177).
+# Remove this patch after rust_decimal 1.43.0 is released with the fix from
+# paupino/rust-decimal#819.
+#
+# Ideal implementation (without workaround):
+#   rust_decimal = "1.43.0"
+rust_decimal = { git = "https://github.com/paupino/rust-decimal", rev = "27e410358395b9036c21ef43ed19a098dc0a882c" }
 
 # Monitor and upgrade when upstream fixes num-bigint-dig v0.8.x future incompatibility
 # Issue: https://github.com/rust-lang/rust/issues/120192

--- a/deny.toml
+++ b/deny.toml
@@ -201,4 +201,4 @@ skip = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/paupino/rust-decimal"]

--- a/tests/integration/tests/commands/shell_e2e.rs
+++ b/tests/integration/tests/commands/shell_e2e.rs
@@ -1440,6 +1440,15 @@ codegen-units = 16
 panic = "unwind"
 incremental = true
 overflow-checks = true
+
+# Workaround for paupino/rust-decimal#818 (tracked in reinhardt-web#6177).
+# Cargo does not inherit patches from the workspace of a path dependency.
+# Remove this entry after rust_decimal 1.43.0 is released with #819.
+#
+# Ideal implementation (without workaround):
+#   rust_decimal = "1.43.0"
+[patch.crates-io]
+rust_decimal = {{ git = "https://github.com/paupino/rust-decimal", rev = "27e410358395b9036c21ef43ed19a098dc0a882c" }}
 "#,
 			repository_root.display()
 		),


### PR DESCRIPTION
## Summary

This PR addresses:

- Patch every workspace resolution of `rust_decimal` to upstream commit `27e41035`, which removes the inactive vulnerable `rkyv 0.7` dependency.
- Pin and allow only the reviewed `paupino/rust-decimal` Git source.
- Document the removal condition and the final crates.io dependency after `rust_decimal 1.43.0` is published.

> [!IMPORTANT]
> Keep this PR in Draft and do not merge the Git patch as the final release fix. Replace it with `rust_decimal = "1.43.0"` after upstream PR paupino/rust-decimal#819 is released, then rerun the listed gates.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`rust_decimal 1.42.1` declares optional `rkyv 0.7.46`, so Cargo retains the vulnerable package in downstream lockfiles even when the feature is inactive. RUSTSEC-2026-0235 affects the full rkyv 0.7 line, and no fixed crates.io release of rust_decimal exists yet.

Fixes #6177

Related to: paupino/rust-decimal#818, paupino/rust-decimal#819

## How Was This Tested?

- `cargo make fmt-check`
- `cargo check --workspace --all --all-features`
- `cargo make clippy-check`
- `cargo deny check advisories sources`
- `cargo package -p reinhardt-web --allow-dirty --no-verify`
- `cargo audit` confirmed RUSTSEC-2026-0235 and `rkyv 0.7.46` are absent; the only remaining vulnerability is the existing allowed `h2 0.3.27` advisory.
- `cargo tree --workspace --all-features --target all -e all` resolves one pinned Git instance of `rust_decimal` and no `rkyv 0.7` instance.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #6177
- Upstream advisory report: paupino/rust-decimal#818
- Upstream fix: paupino/rust-decimal#819

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

The Git patch is deliberately temporary because workspace patches are not propagated into published downstream manifests. The final mergeable state requires the upstream fix to be released on crates.io and the patch/allowlist to be removed.

🤖 Generated with [Codex](https://openai.com/codex)
