### PR TITLE
feat(pages): generate target-neutral ClientForm submits

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -495,6 +495,11 @@ assert_eq!(request.title, None);
 let outcome = form.submit(&runtime).await?;
 ```
 
+Generated `submit` methods have the same signature on native and WASM targets,
+so shared components can construct one action without target-specific branches.
+Submission executes only on WASM; native SSR code must not await or dispatch the
+generated method.
+
 `ClientFormChoices` mirrors serde's externally tagged string names for unit
 variants, including matching `rename_all` and variant `rename`; tagged,
 untagged, or directionally renamed enum representations are rejected because

--- a/crates/reinhardt-pages/macros/src/client_form.rs
+++ b/crates/reinhardt-pages/macros/src/client_form.rs
@@ -547,7 +547,6 @@ fn generate_submit_method(
 		{
 		}
 
-		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 		pub async fn submit<Deps>(
 			&self,
 			runtime: &#pages_crate::UseFormReturn<Self, Deps>,
@@ -562,13 +561,21 @@ fn generate_submit_method(
 				<#server_fn::marker as #pages_crate::server_fn::ServerFnResponseMetadata>::Error:
 					::core::convert::Into<#pages_crate::server_fn::ServerFnError>,
 			{
-			let _ = self;
-			runtime
-				.submit_server_fn(|| {
-					let request = #form_ident::to_request(runtime);
-					async move { #server_fn(request).await.map_err(::core::convert::Into::into) }
-				})
-				.await
+			#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+			{
+				let _ = self;
+				runtime
+					.submit_server_fn(|| {
+						let request = #form_ident::to_request(runtime);
+						async move { #server_fn(request).await.map_err(::core::convert::Into::into) }
+					})
+					.await
+			}
+			#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+			{
+				let _ = (self, runtime);
+				::core::unreachable!()
+			}
 		}
 	}
 }

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -524,6 +524,11 @@
 //! let outcome = form.submit(&runtime).await?;
 //! ```
 //!
+//! Generated `submit` methods have the same signature on native and WASM
+//! targets, so shared components can construct one action without
+//! target-specific branches. Submission executes only on WASM; native SSR code
+//! must not await or dispatch the generated method.
+//!
 //! [`ClientFormChoices`] mirrors serde's externally tagged string names for
 //! unit variants, including matching `rename_all` and variant `rename`; tagged,
 //! untagged, or directionally renamed enum representations are rejected because

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/server_fn_error_submit.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/server_fn_error_submit.rs
@@ -40,8 +40,6 @@ fn main() {
 	reinhardt_core::reactive::ReactiveScope::run(|| {
 		let form = ProfileRequestClientForm::new();
 		let runtime = use_form(&form).build();
-		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 		let _submit_future = async { assert_submit_output(form.submit(&runtime).await) };
-		let _ = (form, runtime);
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/server_fn_submit.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/server_fn_submit.rs
@@ -64,11 +64,8 @@ fn main() {
 		let injected_form = InjectedSettingsRequestClientForm::new();
 		let runtime = use_form(&form).build();
 		let injected_runtime = use_form(&injected_form).build();
-		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 		let _submit_future = async { assert_submit_output(form.submit(&runtime).await) };
-		#[cfg(all(target_family = "wasm", target_os = "unknown"))]
 		let _injected_submit_future =
 			async { assert_submit_output(injected_form.submit(&injected_runtime).await) };
-		let _ = (form, runtime, injected_form, injected_runtime);
 	});
 }

--- a/docs/rfc/2026-07-02-client-form-bindings-design.md
+++ b/docs/rfc/2026-07-02-client-form-bindings-design.md
@@ -101,6 +101,10 @@ instead of changing `UseFormReturn::handle_submit` semantics:
 let outcome = form.submit(&runtime).await?;
 ```
 
+The helper has the same signature on native and WASM targets so shared
+components can construct one action. Only WASM may await or dispatch it;
+native SSR uses the method for type checking and action construction only.
+
 `handle_submit` remains the generic runtime validation and lifecycle callback
 entry point. Server function submission is DTO-form-specific orchestration built
 on top of a new additive async runtime primitive described below.


### PR DESCRIPTION
## Summary

This PR addresses:

- Generates ClientForm::submit with the same typed signature on native SSR and WASM.
- Keeps server-function execution and structured error routing WASM-only.
- Covers standard, injected, and structured-error generated forms across targets.
- Documents the native action-construction-only contract.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Shared Pages components currently need separate native and WASM action closures because ClientForm::submit is generated only for WASM. A target-neutral signature lets existing use_action call sites compile once while preserving client-only execution.

Fixes #6189

Related to: kent8192/reinhardt-cloud#892

## How Was This Tested?

- Native generated fixtures: cargo check for server_fn_error_submit and server_fn_submit, including injected parameters.
- WASM generated fixture: cargo check --target wasm32-unknown-unknown for server_fn_error_submit.
- ClientForm runtime integration: 13 tests passed.
- cargo make fmt-check.
- cargo clippy -p reinhardt-pages-macros --lib -- -D warnings.
- RUSTDOCFLAGS=-D warnings cargo doc -p reinhardt-pages --no-deps.
- git diff --check.

The broader Pages clippy command reaches an existing reinhardt-db baseline failure for unused parse_server_version and postgres_row_lock_capabilities; the modified macro crate is clean under -D warnings.

## Performance Impact

No runtime impact on WASM. Native SSR only gains a generated type-checking surface and does not execute submission.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with cargo make fmt-fix
- [ ] I have checked the code with cargo make clippy-check
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Fixes #6189
- Related to kent8192/reinhardt-cloud#892

## Labels to Apply

### Type Label (select one)
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] performance
- [ ] refactoring
- [ ] code-quality

### Additional Labels
- [ ] breaking-change

### Scope Label
- [x] forms
- [x] pages

---

**Additional Context:**

The native generated body is intentionally unreachable if awaited or dispatched. Its supported purpose is compiling shared SSR/WASM component action construction without target-specific branches.