### PR TITLE
feat(pages): add client_form attribute macro

### DIFF
--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -468,6 +468,8 @@ assembly tied to the DTO while still using the same `use_form` runtime. The
 the paired `#[derive(ClientForm)]` and helper attribute remain supported for
 compatibility. Container and field-level serde metadata remains available even
 when the DTO does not derive `Serialize` or `Deserialize`.
+Import the attribute macro explicitly; it is intentionally not part of
+`prelude::*` so legacy derive/helper declarations remain helper-only.
 When no serde derive is present, place `#[client_form(...)]` before the
 DTO's `#[serde(...)]` attributes so the attribute macro can consume them.
 Add `validate` when the DTO implements `Validate` and should feed those errors

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -463,12 +463,14 @@ runtime.set_value(login_form.username_field(), "ada".to_string());
 
 DTO request types can opt in to generated client-form companions with
 `ClientForm`. This keeps request field names, enum choices, and typed request
-assembly tied to the DTO while still using the same `use_form` runtime. Add
-`#[client_form(validate)]` when the DTO implements `Validate` and should feed
-those errors into the generated form runtime:
+assembly tied to the DTO while still using the same `use_form` runtime. The
+`#[client_form(...)]` attribute generates the companion directly; the paired
+`#[derive(ClientForm)]` and helper attribute remain supported for compatibility.
+Add `validate` when the DTO implements `Validate` and should feed those errors
+into the generated form runtime:
 
 ```rust,ignore
-use reinhardt_pages::{ClientForm, ClientFormChoices, use_form};
+use reinhardt_pages::{ClientFormChoices, client_form, use_form};
 
 #[derive(Clone, Default, PartialEq, ClientFormChoices)]
 #[serde(rename_all = "snake_case")]
@@ -479,7 +481,7 @@ enum ProviderMode {
 }
 
 #[reinhardt::dto]
-#[derive(Clone, serde::Serialize, serde::Deserialize, ClientForm)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[client_form(server_fn = crate::server::submit_project, validate)]
 struct ProjectRequest {
     name: String,

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -464,8 +464,12 @@ runtime.set_value(login_form.username_field(), "ada".to_string());
 DTO request types can opt in to generated client-form companions with
 `ClientForm`. This keeps request field names, enum choices, and typed request
 assembly tied to the DTO while still using the same `use_form` runtime. The
-`#[client_form(...)]` attribute generates the companion directly; the paired
-`#[derive(ClientForm)]` and helper attribute remain supported for compatibility.
+`#[client_form(...)]` attribute uses the same expansion logic as the derive;
+the paired `#[derive(ClientForm)]` and helper attribute remain supported for
+compatibility. Container and field-level serde metadata remains available even
+when the DTO does not derive `Serialize` or `Deserialize`.
+When no serde derive is present, place `#[client_form(...)]` before the
+DTO's `#[serde(...)]` attributes so the attribute macro can consume them.
 Add `validate` when the DTO implements `Validate` and should feed those errors
 into the generated form runtime:
 

--- a/crates/reinhardt-pages/macros/src/client_form.rs
+++ b/crates/reinhardt-pages/macros/src/client_form.rs
@@ -5,15 +5,24 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
 use syn::{
-	Attribute, Data, DeriveInput, Fields, Ident, LitStr, Path, Token, Type, Visibility,
-	parse_macro_input, parse_quote,
+	Data, DeriveInput, Fields, Ident, LitStr, Path, Token, Type, Visibility, parse_macro_input,
+	parse_quote,
 };
 
 use crate::crate_paths::get_reinhardt_pages_crate;
 
+const CLIENT_FORM_ATTRIBUTE_MARKER: &str = "__reinhardt_client_form_attribute";
+
 /// Derives a `use_form` compatible companion form for a DTO request type.
 pub(crate) fn derive_client_form_impl(input: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(input as DeriveInput);
+	if input
+		.attrs
+		.iter()
+		.any(|attr| attr.path().is_ident(CLIENT_FORM_ATTRIBUTE_MARKER))
+	{
+		return TokenStream::new();
+	}
 	match expand_client_form(input) {
 		Ok(tokens) => tokens.into(),
 		Err(error) => error.to_compile_error().into(),
@@ -43,6 +52,14 @@ fn expand_client_form_attribute(
 
 	let mut input = input;
 	strip_client_form_attributes(&mut input);
+	let pages_crate = get_reinhardt_pages_crate();
+	let marker = format_ident!("{CLIENT_FORM_ATTRIBUTE_MARKER}");
+	// Register serde helper attributes for every emitted DTO and suppress any
+	// legacy ClientForm derive, including derives imported under an alias.
+	input
+		.attrs
+		.insert(0, parse_quote!(#[derive(#pages_crate::ClientForm)]));
+	input.attrs.insert(1, parse_quote!(#[#marker]));
 	Ok(quote! {
 		#input
 		#generated
@@ -50,66 +67,17 @@ fn expand_client_form_attribute(
 }
 
 fn strip_client_form_attributes(input: &mut DeriveInput) {
-	let preserve_serde = has_serde_derive(&input.attrs);
-	input.attrs.retain(|attr| {
-		!attr.path().is_ident("client_form") && (preserve_serde || !attr.path().is_ident("serde"))
-	});
-	strip_client_form_derive(&mut input.attrs);
+	input
+		.attrs
+		.retain(|attr| !attr.path().is_ident("client_form"));
 
 	if let Data::Struct(data_struct) = &mut input.data {
 		for field in data_struct.fields.iter_mut() {
-			field.attrs.retain(|attr| {
-				!attr.path().is_ident("client_form")
-					&& (preserve_serde || !attr.path().is_ident("serde"))
-			});
+			field
+				.attrs
+				.retain(|attr| !attr.path().is_ident("client_form"));
 		}
 	}
-}
-
-fn has_serde_derive(attrs: &[Attribute]) -> bool {
-	attrs.iter().any(|attr| {
-		attr.path().is_ident("derive")
-			&& attr
-				.parse_args_with(syn::punctuated::Punctuated::<Path, Token![,]>::parse_terminated)
-				.is_ok_and(|paths| {
-					paths.iter().any(|path| {
-						path.segments.last().is_some_and(|segment| {
-							segment.ident == "Serialize" || segment.ident == "Deserialize"
-						})
-					})
-				})
-	})
-}
-
-fn strip_client_form_derive(attrs: &mut Vec<Attribute>) {
-	attrs.retain_mut(|attr| {
-		if !attr.path().is_ident("derive") {
-			return true;
-		}
-
-		let Ok(paths) =
-			attr.parse_args_with(syn::punctuated::Punctuated::<Path, Token![,]>::parse_terminated)
-		else {
-			return true;
-		};
-		let original_len = paths.len();
-		let mut retained = paths.into_iter().collect::<Vec<_>>();
-		retained.retain(|path| {
-			path.segments
-				.last()
-				.is_none_or(|segment| segment.ident != "ClientForm")
-		});
-
-		if retained.len() == original_len {
-			return true;
-		}
-		if retained.is_empty() {
-			return false;
-		}
-
-		*attr = parse_quote!(#[derive(#(#retained),*)]);
-		true
-	});
 }
 
 fn expand_client_form(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {

--- a/crates/reinhardt-pages/macros/src/client_form.rs
+++ b/crates/reinhardt-pages/macros/src/client_form.rs
@@ -31,7 +31,7 @@ pub(crate) fn client_form_impl(args: TokenStream, input: TokenStream) -> TokenSt
 }
 
 fn expand_client_form_attribute(
-	mut input: DeriveInput,
+	input: DeriveInput,
 	args: proc_macro2::TokenStream,
 ) -> syn::Result<proc_macro2::TokenStream> {
 	let mut derive_input = input.clone();
@@ -41,6 +41,7 @@ fn expand_client_form_attribute(
 	derive_input.attrs.push(parse_quote!(#[client_form(#args)]));
 	let generated = expand_client_form(derive_input)?;
 
+	let mut input = input;
 	strip_client_form_attributes(&mut input);
 	Ok(quote! {
 		#input
@@ -49,18 +50,35 @@ fn expand_client_form_attribute(
 }
 
 fn strip_client_form_attributes(input: &mut DeriveInput) {
-	input
-		.attrs
-		.retain(|attr| !attr.path().is_ident("client_form"));
+	let preserve_serde = has_serde_derive(&input.attrs);
+	input.attrs.retain(|attr| {
+		!attr.path().is_ident("client_form") && (preserve_serde || !attr.path().is_ident("serde"))
+	});
 	strip_client_form_derive(&mut input.attrs);
 
 	if let Data::Struct(data_struct) = &mut input.data {
 		for field in data_struct.fields.iter_mut() {
-			field
-				.attrs
-				.retain(|attr| !attr.path().is_ident("client_form"));
+			field.attrs.retain(|attr| {
+				!attr.path().is_ident("client_form")
+					&& (preserve_serde || !attr.path().is_ident("serde"))
+			});
 		}
 	}
+}
+
+fn has_serde_derive(attrs: &[Attribute]) -> bool {
+	attrs.iter().any(|attr| {
+		attr.path().is_ident("derive")
+			&& attr
+				.parse_args_with(syn::punctuated::Punctuated::<Path, Token![,]>::parse_terminated)
+				.is_ok_and(|paths| {
+					paths.iter().any(|path| {
+						path.segments.last().is_some_and(|segment| {
+							segment.ident == "Serialize" || segment.ident == "Deserialize"
+						})
+					})
+				})
+	})
 }
 
 fn strip_client_form_derive(attrs: &mut Vec<Attribute>) {

--- a/crates/reinhardt-pages/macros/src/client_form.rs
+++ b/crates/reinhardt-pages/macros/src/client_form.rs
@@ -5,7 +5,8 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
 use syn::{
-	Data, DeriveInput, Fields, Ident, LitStr, Path, Token, Type, Visibility, parse_macro_input,
+	Attribute, Data, DeriveInput, Fields, Ident, LitStr, Path, Token, Type, Visibility,
+	parse_macro_input, parse_quote,
 };
 
 use crate::crate_paths::get_reinhardt_pages_crate;
@@ -17,6 +18,80 @@ pub(crate) fn derive_client_form_impl(input: TokenStream) -> TokenStream {
 		Ok(tokens) => tokens.into(),
 		Err(error) => error.to_compile_error().into(),
 	}
+}
+
+/// Expands the attribute form while reusing the derive implementation.
+pub(crate) fn client_form_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as DeriveInput);
+	let args: proc_macro2::TokenStream = args.into();
+	match expand_client_form_attribute(input, args) {
+		Ok(tokens) => tokens.into(),
+		Err(error) => error.to_compile_error().into(),
+	}
+}
+
+fn expand_client_form_attribute(
+	mut input: DeriveInput,
+	args: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+	let mut derive_input = input.clone();
+	derive_input
+		.attrs
+		.retain(|attr| !attr.path().is_ident("client_form"));
+	derive_input.attrs.push(parse_quote!(#[client_form(#args)]));
+	let generated = expand_client_form(derive_input)?;
+
+	strip_client_form_attributes(&mut input);
+	Ok(quote! {
+		#input
+		#generated
+	})
+}
+
+fn strip_client_form_attributes(input: &mut DeriveInput) {
+	input
+		.attrs
+		.retain(|attr| !attr.path().is_ident("client_form"));
+	strip_client_form_derive(&mut input.attrs);
+
+	if let Data::Struct(data_struct) = &mut input.data {
+		for field in data_struct.fields.iter_mut() {
+			field
+				.attrs
+				.retain(|attr| !attr.path().is_ident("client_form"));
+		}
+	}
+}
+
+fn strip_client_form_derive(attrs: &mut Vec<Attribute>) {
+	attrs.retain_mut(|attr| {
+		if !attr.path().is_ident("derive") {
+			return true;
+		}
+
+		let Ok(paths) =
+			attr.parse_args_with(syn::punctuated::Punctuated::<Path, Token![,]>::parse_terminated)
+		else {
+			return true;
+		};
+		let original_len = paths.len();
+		let mut retained = paths.into_iter().collect::<Vec<_>>();
+		retained.retain(|path| {
+			path.segments
+				.last()
+				.is_none_or(|segment| segment.ident != "ClientForm")
+		});
+
+		if retained.len() == original_len {
+			return true;
+		}
+		if retained.is_empty() {
+			return false;
+		}
+
+		*attr = parse_quote!(#[derive(#(#retained),*)]);
+		true
+	});
 }
 
 fn expand_client_form(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -175,7 +175,10 @@ pub fn derive_client_form_choices(input: TokenStream) -> TokenStream {
 }
 
 /// Derives a `use_form` compatible companion form for a DTO request type.
-#[proc_macro_derive(ClientForm, attributes(client_form, serde))]
+#[proc_macro_derive(
+	ClientForm,
+	attributes(client_form, serde, __reinhardt_client_form_attribute)
+)]
 pub fn derive_client_form(input: TokenStream) -> TokenStream {
 	client_form::derive_client_form_impl(input)
 }

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -9,6 +9,7 @@
 //! - `form!` - Type-safe form component macro with reactive bindings
 //! - `#[server_fn]` - Server Functions (RPC) macro
 //! - `#[server_fnset]` - Named server function set macro
+//! - `#[client_form]` - Client form companion generation attribute macro
 //! - `#[client_page]` - Client page function macro with native route-table stubs
 //! - `#[layout]` - Route-backed layout component macro for `ClientRouter`
 //! - `#[loader]` - Async route-level data loader with hydration registration
@@ -177,6 +178,12 @@ pub fn derive_client_form_choices(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(ClientForm, attributes(client_form, serde))]
 pub fn derive_client_form(input: TokenStream) -> TokenStream {
 	client_form::derive_client_form_impl(input)
+}
+
+/// Generates a `use_form` compatible companion form for a DTO request type.
+#[proc_macro_attribute]
+pub fn client_form(args: TokenStream, input: TokenStream) -> TokenStream {
+	client_form::client_form_impl(args, input)
 }
 
 /// Adds builder support and `FromRequest` extraction to a named props struct.

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -493,8 +493,12 @@
 //! DTO request types can opt in to generated client-form companions with
 //! [`ClientForm`]. The generated form keeps enum choices and typed request
 //! assembly tied to the request type while using the same [`use_form`] runtime.
-//! Use the `#[client_form(...)]` attribute for the concise form, or keep
+//! Use the `#[client_form(...)]` attribute for the concise form; it uses the
+//! same expansion logic as the derive and preserves container and field serde
+//! metadata even without serde derives. Alternatively, keep
 //! `#[derive(ClientForm)]` with its helper attribute for compatibility. Add
+//! `#[client_form(...)]` before `#[serde(...)]` when no serde derive is present
+//! so the attribute macro can consume those helper attributes.
 //! `validate` when the DTO implements `Validate` and should feed those errors
 //! into the generated form runtime:
 //!

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -496,10 +496,12 @@
 //! Use the `#[client_form(...)]` attribute for the concise form; it uses the
 //! same expansion logic as the derive and preserves container and field serde
 //! metadata even without serde derives. Alternatively, keep
-//! `#[derive(ClientForm)]` with its helper attribute for compatibility. Add
+//! `#[derive(ClientForm)]` with its helper attribute for compatibility.
+//! The `client_form` attribute macro must be imported explicitly; it is not re-exported by
+//! `prelude::*` so legacy derive/helper declarations remain helper-only.
 //! `#[client_form(...)]` before `#[serde(...)]` when no serde derive is present
 //! so the attribute macro can consume those helper attributes.
-//! `validate` when the DTO implements `Validate` and should feed those errors
+//! Add `validate` when the DTO implements `Validate` and should feed those errors
 //! into the generated form runtime:
 //!
 //! ```ignore

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -289,7 +289,7 @@
 //!   [`ui::ActionResultPanel`], and [`ui::ResourcePanel`])
 //! - [`form`](mod@form): Django Form integration
 //! - [`form_state`]: Typed `use_form` runtime state
-//! - [`client_form`]: Runtime support for DTO-derived client forms
+//! - [`mod@client_form`]: Runtime support for DTO-derived client forms
 //! - [`csrf`]: CSRF protection
 //! - [`auth`]: Authentication integration
 //! - [`api`]: API client with Django QuerySet-like interface
@@ -493,11 +493,13 @@
 //! DTO request types can opt in to generated client-form companions with
 //! [`ClientForm`]. The generated form keeps enum choices and typed request
 //! assembly tied to the request type while using the same [`use_form`] runtime.
-//! Add `#[client_form(validate)]` when the DTO implements `Validate` and should
-//! feed those errors into the generated form runtime:
+//! Use the `#[client_form(...)]` attribute for the concise form, or keep
+//! `#[derive(ClientForm)]` with its helper attribute for compatibility. Add
+//! `validate` when the DTO implements `Validate` and should feed those errors
+//! into the generated form runtime:
 //!
 //! ```ignore
-//! use reinhardt_pages::{ClientForm, ClientFormChoices, use_form};
+//! use reinhardt_pages::{ClientFormChoices, client_form, use_form};
 //!
 //! #[derive(Clone, Default, PartialEq, ClientFormChoices)]
 //! #[serde(rename_all = "snake_case")]
@@ -508,7 +510,7 @@
 //! }
 //!
 //! #[reinhardt::dto]
-//! #[derive(Clone, serde::Serialize, serde::Deserialize, ClientForm)]
+//! #[derive(Clone, serde::Serialize, serde::Deserialize)]
 //! #[client_form(server_fn = crate::server::submit_project, validate)]
 //! struct ProjectRequest {
 //!     name: String,
@@ -993,7 +995,7 @@ pub use reinhardt_pages_macros::style;
 pub use reinhardt_pages_macros::style_def;
 pub use reinhardt_pages_macros::wasm_server_api;
 pub use reinhardt_pages_macros::{
-	ClientForm, ClientFormChoices, FromRequest, client_page, component, page_props,
+	ClientForm, ClientFormChoices, FromRequest, client_form, client_page, component, page_props,
 };
 
 // Private re-exports used by macro-generated code. Not part of the public API.

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -110,7 +110,7 @@
 //! - [`page`] - Component DSL for defining views
 //! - [`head`] - HTML head section DSL
 //! - `#[component]` / `#[layout]` - Route-backed SPA component declarations
-//! - `#[client_form]` - DTO-derived client form declarations
+//! - `#[client_form]` - DTO-derived client form declarations (import explicitly from the crate root)
 //!
 //! ## Static Files
 //! - [`resolve_static`] - Resolve static file URLs
@@ -315,7 +315,6 @@ pub use reinhardt_forms::{
 
 pub use crate::ClientForm;
 pub use crate::ClientFormChoices;
-pub use crate::client_form;
 pub use crate::client_page;
 pub use crate::component;
 pub use crate::form;

--- a/crates/reinhardt-pages/src/prelude.rs
+++ b/crates/reinhardt-pages/src/prelude.rs
@@ -110,6 +110,7 @@
 //! - [`page`] - Component DSL for defining views
 //! - [`head`] - HTML head section DSL
 //! - `#[component]` / `#[layout]` - Route-backed SPA component declarations
+//! - `#[client_form]` - DTO-derived client form declarations
 //!
 //! ## Static Files
 //! - [`resolve_static`] - Resolve static file URLs
@@ -314,6 +315,7 @@ pub use reinhardt_forms::{
 
 pub use crate::ClientForm;
 pub use crate::ClientFormChoices;
+pub use crate::client_form;
 pub use crate::client_page;
 pub use crate::component;
 pub use crate::form;

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
@@ -2,12 +2,12 @@ use reinhardt_core::validators::{Validate, ValidationErrors};
 use reinhardt_pages::server_fn::ServerFnError;
 use reinhardt_pages::server_fn::server_fn;
 use reinhardt_pages::{
-	FormRuntimeSource, UseFormAsyncSubmitOutcome, client_form, use_form,
+	ClientForm as Form, FormRuntimeSource, UseFormAsyncSubmitOutcome, client_form, use_form,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize as De, Serialize as Ser};
 
 #[client_form(name = ProfileForm, server_fn = submit_profile, validate)]
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Ser, De)]
 pub struct ProfileRequest {
 	pub display_name: String,
 }
@@ -26,7 +26,15 @@ struct RenamedRequest {
 	preferred_name: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[reinhardt_pages::client_form(name = AliasedForm)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, PartialEq, Ser, De, Form)]
+struct AliasedRequest {
+	#[serde(rename = "preferredName")]
+	preferred_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Ser, De)]
 pub struct ProfileResponse {
 	display_name: String,
 }
@@ -56,6 +64,21 @@ fn main() {
 		assert_eq!(
 			RenamedForm::new().runtime_field_by_name("preferredName"),
 			Some(RenamedFormField::PreferredName),
+		);
+		assert_eq!(
+			AliasedForm::new().runtime_field_by_name("preferredName"),
+			Some(AliasedFormField::PreferredName),
+		);
+		let aliased = AliasedRequest {
+			preferred_name: "Ada".to_string(),
+		};
+		assert_eq!(
+			serde_json::to_string(&aliased).unwrap(),
+			r#"{"preferredName":"Ada"}"#,
+		);
+		assert_eq!(
+			serde_json::from_str::<AliasedRequest>(r#"{"preferredName":"Ada"}"#).unwrap(),
+			aliased,
 		);
 		let _submit_future = async { assert_submit_output(form.submit(&runtime).await) };
 	});

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
@@ -1,7 +1,9 @@
 use reinhardt_core::validators::{Validate, ValidationErrors};
 use reinhardt_pages::server_fn::ServerFnError;
 use reinhardt_pages::server_fn::server_fn;
-use reinhardt_pages::{UseFormAsyncSubmitOutcome, client_form, use_form};
+use reinhardt_pages::{
+	FormRuntimeSource, UseFormAsyncSubmitOutcome, client_form, use_form,
+};
 use serde::{Deserialize, Serialize};
 
 #[client_form(name = ProfileForm, server_fn = submit_profile, validate)]
@@ -14,6 +16,14 @@ impl Validate for ProfileRequest {
 	fn validate(&self) -> Result<(), ValidationErrors> {
 		Ok(())
 	}
+}
+
+#[client_form(name = RenamedForm)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq)]
+struct RenamedRequest {
+	#[serde(rename = "preferredName")]
+	preferred_name: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -43,6 +53,10 @@ fn main() {
 		runtime.set_value(ProfileFormField::DisplayName, "Ada".to_string());
 		let request = ProfileForm::to_request(&runtime);
 		assert_eq!(request.display_name, "Ada");
+		assert_eq!(
+			RenamedForm::new().runtime_field_by_name("preferredName"),
+			Some(RenamedFormField::PreferredName),
+		);
 		let _submit_future = async { assert_submit_output(form.submit(&runtime).await) };
 	});
 }

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/attribute.rs
@@ -1,0 +1,48 @@
+use reinhardt_core::validators::{Validate, ValidationErrors};
+use reinhardt_pages::server_fn::ServerFnError;
+use reinhardt_pages::server_fn::server_fn;
+use reinhardt_pages::{UseFormAsyncSubmitOutcome, client_form, use_form};
+use serde::{Deserialize, Serialize};
+
+#[client_form(name = ProfileForm, server_fn = submit_profile, validate)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileRequest {
+	pub display_name: String,
+}
+
+impl Validate for ProfileRequest {
+	fn validate(&self) -> Result<(), ValidationErrors> {
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProfileResponse {
+	display_name: String,
+}
+
+#[server_fn]
+async fn submit_profile(
+	request: crate::ProfileRequest,
+) -> Result<ProfileResponse, ServerFnError> {
+	Ok(ProfileResponse {
+		display_name: request.display_name,
+	})
+}
+
+fn assert_submit_output(
+	value: Result<UseFormAsyncSubmitOutcome<ProfileResponse>, ServerFnError>,
+) -> Result<UseFormAsyncSubmitOutcome<ProfileResponse>, ServerFnError> {
+	value
+}
+
+fn main() {
+	reinhardt_core::reactive::ReactiveScope::run(|| {
+		let form = ProfileForm::new();
+		let runtime = use_form(&form).build();
+		runtime.set_value(ProfileFormField::DisplayName, "Ada".to_string());
+		let request = ProfileForm::to_request(&runtime);
+		assert_eq!(request.display_name, "Ada");
+		let _submit_future = async { assert_submit_output(form.submit(&runtime).await) };
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/pass/prelude_legacy.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/pass/prelude_legacy.rs
@@ -1,0 +1,18 @@
+use reinhardt_core::reactive::ReactiveScope;
+use reinhardt_pages::ClientForm as Form;
+use reinhardt_pages::prelude::*;
+
+#[derive(Clone, PartialEq, Form)]
+#[client_form(name = LegacyForm)]
+struct LegacyRequest {
+	name: String,
+}
+
+fn main() {
+	ReactiveScope::run(|| {
+		assert_eq!(
+			LegacyForm::new().runtime_field_by_name("name"),
+			Some(LegacyFormField::Name),
+		);
+	});
+}


### PR DESCRIPTION
## Summary

This PR addresses:

- Add a `#[client_form(...)]` attribute macro that generates the existing client-form companion API directly from a DTO.
- Reuse the existing ClientForm expansion while preserving legacy `#[derive(ClientForm)]` plus helper-attribute usage.
- Document the new attribute syntax and cover it with a runtime-backed UI fixture.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Downstream DTOs currently need both the ClientForm derive and the `client_form` helper attribute. The attribute macro provides the concise form requested for the 0.4.0-alpha.10 migration path without removing the existing derive API.

Fixes #6195

Related to: none

## How Was This Tested?

- `cargo test -p reinhardt-pages --test ui test_client_form_pass -- --nocapture`
- `cargo test -p reinhardt-pages --test client_form_integration -- --nocapture`
- `cargo check -p reinhardt-pages --all-features`
- `cargo doc -p reinhardt-pages --no-deps`
- `cargo clippy -p reinhardt-pages-macros --lib -- -D warnings`

## Performance Impact

- No runtime performance impact; the change adds a procedural-macro entry point that reuses the existing expansion.

## Breaking Changes

- None.

## Related Issues

- #6195

## Labels to Apply

### Type Label

- [x] `enhancement` - New feature or improvement

### Additional Labels

- None

### Scope Label

- [x] `forms` - Form handling, validation, rendering

### Priority Label

- Maintainer decision

---

**Additional Context:**

- Full pages-package clippy with all test targets remains blocked by pre-existing `clone_on_copy` and dead-code diagnostics outside this change; the changed macro library passes with `-D warnings`.
