### PR TITLE
feat(macros): add opt-in DTO schema generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ server-fn-test = ["test", "reinhardt-test/server-fn-test"]
 # `reinhardt::test::msw::MockServiceWorker` and triggers `MockableServerFn`
 # impl generation for `#[server_fn]` in downstream crates.
 msw = ["test", "pages", "reinhardt-test/msw", "reinhardt-pages/msw"]
-openapi = ["reinhardt-rest", "reinhardt-rest/openapi", "reinhardt-views?/openapi", "rest", "dep:inventory"]
+openapi = ["core", "reinhardt-rest", "reinhardt-rest/openapi", "reinhardt-views?/openapi", "rest", "dep:inventory"]
 openapi-swagger-ui = ["openapi", "reinhardt-rest/openapi-swagger-ui"]
 openapi-router = ["reinhardt-openapi", "openapi", "reinhardt-commands/openapi-router"]
 reinhardt-browsable-api = ["reinhardt-rest", "reinhardt-rest/browsable-api", "reinhardt-views?/browsable-api"]

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -231,6 +231,15 @@ Provides compile-time code generation for common patterns.
   - Documentation comments become field descriptions
   - Automatic required/optional field detection
 
+#### Shared DTOs
+
+- **`#[dto]`** - Target-neutral DTO validation boilerplate
+  - Emits the native-only `Validate` derive
+  - Wraps field-level `#[validate(...)]` attributes for WASM compatibility
+- **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
+  - Requires the consumer's `openapi` feature
+  - Leaves the plain `#[dto]` behavior unchanged
+
 #### Application Configuration
 
 - **`#[derive(AppConfig)]`** - AppConfig factory method generation

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -237,7 +237,7 @@ Provides compile-time code generation for common patterns.
   - Emits the native-only `Validate` derive
   - Wraps `#[validate(...)]` and `#[schema(...)]` attributes for WASM compatibility
 - **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
-  - Requires the consumer's `openapi` feature
+  - Requires the consumer's `openapi` feature, which also enables the core validation surface
   - Supports native-only container and field `#[schema(...)]` customizations
   - Leaves the plain `#[dto]` behavior unchanged
 

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -235,9 +235,10 @@ Provides compile-time code generation for common patterns.
 
 - **`#[dto]`** - Target-neutral DTO validation boilerplate
   - Emits the native-only `Validate` derive
-  - Wraps field-level `#[validate(...)]` attributes for WASM compatibility
+  - Wraps `#[validate(...)]` and `#[schema(...)]` attributes for WASM compatibility
 - **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
   - Requires the consumer's `openapi` feature
+  - Supports native-only container and field `#[schema(...)]` customizations
   - Leaves the plain `#[dto]` behavior unchanged
 
 #### Application Configuration

--- a/crates/reinhardt-core/macros/src/crate_paths.rs
+++ b/crates/reinhardt-core/macros/src/crate_paths.rs
@@ -222,6 +222,20 @@ pub(crate) fn get_reinhardt_openapi_crate() -> TokenStream {
 	quote!(::reinhardt_openapi)
 }
 
+/// Resolves the path to a directly referenced `reinhardt-rest` crate.
+pub(crate) fn get_reinhardt_rest_crate() -> Option<TokenStream> {
+	use proc_macro_crate::{FoundCrate, crate_name};
+
+	match crate_name("reinhardt-rest") {
+		Ok(FoundCrate::Itself) => Some(quote!(crate)),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			Some(quote!(::#ident))
+		}
+		Err(_) => None,
+	}
+}
+
 /// Resolves the path to the reinhardt_db crate dynamically.
 pub(crate) fn get_reinhardt_db_crate() -> TokenStream {
 	use proc_macro_crate::{FoundCrate, crate_name};

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -4,7 +4,7 @@
 //! between native (server) and wasm (client) builds. See the public-facing
 //! rustdoc on `crate::dto` in `lib.rs` for the user-facing contract.
 
-use crate::crate_paths::get_reinhardt_crate;
+use crate::crate_paths::{get_reinhardt_crate, get_reinhardt_rest_crate};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -30,6 +30,11 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	let reinhardt = get_reinhardt_crate();
 	let schema_path: Path = parse_quote!(#reinhardt::rest::openapi::Schema);
+	let direct_rest_schema_path = if with_schema {
+		get_reinhardt_rest_crate().map(|rest| parse_quote!(#rest::openapi::Schema))
+	} else {
+		None
+	};
 	let first_schema_attr = input
 		.attrs
 		.iter()
@@ -77,9 +82,18 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
+	// Native `cfg_attr` derives can reach this macro as ordinary derives after
+	// the compiler evaluates the `native` predicate. Recognized qualified paths
+	// must suppress the generated Schema derive in that form as well.
+	let has_unconditional_schema = if with_schema {
+		find_unconditional_derive(&input.attrs, |path| {
+			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
+		})?
+	} else {
+		None
+	};
 	if with_schema
-		&& let Some(attr) =
-			find_unconditional_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?
+		&& let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Schema"))?
 	{
 		return Err(syn::Error::new_spanned(
 			attr,
@@ -90,7 +104,10 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	let needs_validate = !has_native_derive(&input.attrs, is_validate_derive)?;
 	let needs_schema = with_schema
-		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
+		&& has_unconditional_schema.is_none()
+		&& !has_native_derive(&input.attrs, |path| {
+			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
+		})?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
@@ -195,8 +212,14 @@ where
 	Ok(false)
 }
 
-fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
-	path.is_ident("Schema") || path.segments == schema_path.segments
+fn is_schema_derive(
+	path: &Path,
+	schema_path: &Path,
+	direct_rest_schema_path: Option<&Path>,
+) -> bool {
+	path.is_ident("Schema")
+		|| path.segments == schema_path.segments
+		|| direct_rest_schema_path.is_some_and(|candidate| path.segments == candidate.segments)
 }
 
 fn is_validate_derive(path: &Path) -> bool {
@@ -214,11 +237,22 @@ mod tests {
 		let expected: Path = parse_quote!(::reinhardt::rest::openapi::Schema);
 		let unqualified: Path = parse_quote!(Schema);
 		let qualified: Path = parse_quote!(reinhardt::rest::openapi::Schema);
+		let direct_rest: Path = parse_quote!(reinhardt_rest::openapi::Schema);
 		let unrelated: Path = parse_quote!(other_crate::Schema);
 
-		assert!(is_schema_derive(&unqualified, &expected));
-		assert!(is_schema_derive(&qualified, &expected));
-		assert!(!is_schema_derive(&unrelated, &expected));
+		assert!(is_schema_derive(
+			&unqualified,
+			&expected,
+			Some(&direct_rest)
+		));
+		assert!(is_schema_derive(&qualified, &expected, Some(&direct_rest)));
+		assert!(is_schema_derive(
+			&direct_rest,
+			&expected,
+			Some(&direct_rest)
+		));
+		assert!(!is_schema_derive(&direct_rest, &expected, None));
+		assert!(!is_schema_derive(&unrelated, &expected, Some(&direct_rest)));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -29,6 +29,16 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	};
 
 	let reinhardt = get_reinhardt_crate();
+	let first_schema_attr = input
+		.attrs
+		.iter()
+		.position(|attr| attr.path().is_ident("schema"));
+
+	for attr in &mut input.attrs {
+		if attr.path().is_ident("schema") {
+			*attr = wrap_in_cfg_attr_native(attr);
+		}
+	}
 
 	let fields = match &mut input.data {
 		Data::Struct(s) => match &mut s.fields {
@@ -47,7 +57,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	if let Some(fields) = fields {
 		for field in fields.iter_mut() {
 			for attr in field.attrs.iter_mut() {
-				if attr.path().is_ident("validate") {
+				if attr.path().is_ident("validate") || attr.path().is_ident("schema") {
 					*attr = wrap_in_cfg_attr_native(attr);
 				}
 			}
@@ -87,7 +97,11 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	if !derives.is_empty() {
 		let new_attr: Attribute = parse_quote!(#[cfg_attr(native, derive(#derives))]);
-		input.attrs.push(new_attr);
+		if let Some(index) = first_schema_attr {
+			input.attrs.insert(index, new_attr);
+		} else {
+			input.attrs.push(new_attr);
+		}
 	}
 
 	let to_schema_import = if with_schema {

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -69,7 +69,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
 	// native builds.
-	if let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Validate"))? {
+	if let Some(attr) = find_unconditional_derive(&input.attrs, is_validate_derive)? {
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto] cannot be combined with unconditional `#[derive(Validate)]`. \
@@ -88,7 +88,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		));
 	}
 
-	let needs_validate = !has_native_derive(&input.attrs, |path| path.is_ident("Validate"))?;
+	let needs_validate = !has_native_derive(&input.attrs, is_validate_derive)?;
 	let needs_schema = with_schema
 		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
 
@@ -199,6 +199,12 @@ fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
 	path.is_ident("Schema") || path.segments == schema_path.segments
 }
 
+fn is_validate_derive(path: &Path) -> bool {
+	path.segments
+		.last()
+		.is_some_and(|segment| segment.ident == "Validate")
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -213,5 +219,16 @@ mod tests {
 		assert!(is_schema_derive(&unqualified, &expected));
 		assert!(is_schema_derive(&qualified, &expected));
 		assert!(!is_schema_derive(&unrelated, &expected));
+	}
+
+	#[test]
+	fn validate_derive_matching_accepts_qualified_paths() {
+		let unqualified: Path = parse_quote!(Validate);
+		let qualified: Path = parse_quote!(reinhardt_macros::Validate);
+		let unrelated: Path = parse_quote!(other_crate::Schema);
+
+		assert!(is_validate_derive(&unqualified));
+		assert!(is_validate_derive(&qualified));
+		assert!(!is_validate_derive(&unrelated));
 	}
 }

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -13,12 +13,20 @@ use syn::{
 };
 
 pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<TokenStream> {
-	if !args.is_empty() {
-		return Err(syn::Error::new_spanned(
-			args,
-			"#[dto] does not accept arguments in this version",
-		));
-	}
+	let with_schema = if args.is_empty() {
+		false
+	} else {
+		let option: syn::Ident = syn::parse2(args.clone()).map_err(|_| {
+			syn::Error::new_spanned(args.clone(), "#[dto] accepts only the `schema` option")
+		})?;
+		if option != "schema" {
+			return Err(syn::Error::new_spanned(
+				option,
+				"#[dto] accepts only the `schema` option",
+			));
+		}
+		true
+	};
 
 	let reinhardt = get_reinhardt_crate();
 
@@ -49,8 +57,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// Reject unconditional `#[derive(Validate)]` upfront. `Validate` lives
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
-	// native builds. OpenAPI `Schema` is intentionally not emitted implicitly:
-	// it pulls in the OpenAPI feature graph and must remain an explicit opt-in.
+	// native builds.
 	if let Some(attr) = find_unconditional_derive(&input.attrs, "Validate")? {
 		return Err(syn::Error::new_spanned(
 			attr,
@@ -59,12 +66,23 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
+	if with_schema && let Some(attr) = find_unconditional_derive(&input.attrs, "Schema")? {
+		return Err(syn::Error::new_spanned(
+			attr,
+			"#[dto(schema)] cannot be combined with `#[derive(Schema)]`. \
+			 Remove the derive because #[dto(schema)] emits it for native builds.",
+		));
+	}
 
 	let needs_validate = !has_native_derive(&input.attrs, "Validate")?;
+	let needs_schema = with_schema && !has_native_derive(&input.attrs, "Schema")?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
 		derives.push(parse_quote!(#reinhardt::Validate));
+	}
+	if needs_schema {
+		derives.push(parse_quote!(#reinhardt::rest::openapi::Schema));
 	}
 
 	if !derives.is_empty() {
@@ -72,8 +90,20 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		input.attrs.push(new_attr);
 	}
 
+	let to_schema_import = if with_schema {
+		quote! {
+			#[cfg(native)]
+			// The generated Schema implementation uses trait-method syntax at module scope.
+			#[allow(unused_imports)]
+			use #reinhardt::rest::openapi::ToSchema as _;
+		}
+	} else {
+		quote! {}
+	};
+
 	Ok(quote! {
 		#input
+		#to_schema_import
 	})
 }
 

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -29,6 +29,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	};
 
 	let reinhardt = get_reinhardt_crate();
+	let schema_path: Path = parse_quote!(#reinhardt::rest::openapi::Schema);
 	let first_schema_attr = input
 		.attrs
 		.iter()
@@ -68,7 +69,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
 	// native builds.
-	if let Some(attr) = find_unconditional_derive(&input.attrs, "Validate")? {
+	if let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Validate"))? {
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto] cannot be combined with unconditional `#[derive(Validate)]`. \
@@ -76,7 +77,10 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
-	if with_schema && let Some(attr) = find_unconditional_derive(&input.attrs, "Schema")? {
+	if with_schema
+		&& let Some(attr) =
+			find_unconditional_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?
+	{
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto(schema)] cannot be combined with `#[derive(Schema)]`. \
@@ -84,8 +88,9 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		));
 	}
 
-	let needs_validate = !has_native_derive(&input.attrs, "Validate")?;
-	let needs_schema = with_schema && !has_native_derive(&input.attrs, "Schema")?;
+	let needs_validate = !has_native_derive(&input.attrs, |path| path.is_ident("Validate"))?;
+	let needs_schema = with_schema
+		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
@@ -126,16 +131,13 @@ fn wrap_in_cfg_attr_native(attr: &Attribute) -> Attribute {
 	parse_quote!(#[cfg_attr(native, #meta)])
 }
 
-/// Returns the first unconditional `#[derive(... TraitName ...)]` attribute on
-/// `attrs`, if any. Used to detect derives that would clash with the
-/// macro-emitted `cfg_attr(native, derive(...))`.
-///
-/// Path matching is by the last segment's identifier, mirroring `has_native_derive`,
-/// so both `Validate` and `validator::Validate`-style paths are caught.
-fn find_unconditional_derive<'a>(
-	attrs: &'a [Attribute],
-	trait_name: &str,
-) -> Result<Option<&'a Attribute>> {
+/// Returns the first unconditional derive matching `matches` on `attrs`, if any.
+/// Used to detect derives that would clash with the macro-emitted
+/// `cfg_attr(native, derive(...))`.
+fn find_unconditional_derive<F>(attrs: &[Attribute], matches: F) -> Result<Option<&Attribute>>
+where
+	F: Fn(&Path) -> bool,
+{
 	for attr in attrs {
 		if !attr.path().is_ident("derive") {
 			continue;
@@ -145,21 +147,21 @@ fn find_unconditional_derive<'a>(
 		};
 		let derives =
 			Punctuated::<Path, Token![,]>::parse_terminated.parse2(list.tokens.clone())?;
-		if derives
-			.iter()
-			.any(|p| p.segments.last().is_some_and(|seg| seg.ident == trait_name))
-		{
+		if derives.iter().any(&matches) {
 			return Ok(Some(attr));
 		}
 	}
 	Ok(None)
 }
 
-/// Returns true if `attrs` already contains `#[cfg_attr(native, derive(... TraitName ...))]`.
+/// Returns true if `attrs` already contains a matching native derive.
 ///
 /// Only inspects the `native` cfg branch — unconditional `#[derive(TraitName)]`
 /// is handled separately by `find_unconditional_derive` and reported as an error.
-fn has_native_derive(attrs: &[Attribute], trait_name: &str) -> Result<bool> {
+fn has_native_derive<F>(attrs: &[Attribute], matches: F) -> Result<bool>
+where
+	F: Fn(&Path) -> bool,
+{
 	for attr in attrs {
 		if !attr.path().is_ident("cfg_attr") {
 			continue;
@@ -185,13 +187,31 @@ fn has_native_derive(attrs: &[Attribute], trait_name: &str) -> Result<bool> {
 			}
 			let derives = Punctuated::<Path, Token![,]>::parse_terminated
 				.parse2(inner_list.tokens.clone())?;
-			if derives
-				.iter()
-				.any(|p| p.segments.last().is_some_and(|seg| seg.ident == trait_name))
-			{
+			if derives.iter().any(&matches) {
 				return Ok(true);
 			}
 		}
 	}
 	Ok(false)
+}
+
+fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
+	path.is_ident("Schema") || path.segments == schema_path.segments
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn schema_derive_matching_rejects_unrelated_paths() {
+		let expected: Path = parse_quote!(::reinhardt::rest::openapi::Schema);
+		let unqualified: Path = parse_quote!(Schema);
+		let qualified: Path = parse_quote!(reinhardt::rest::openapi::Schema);
+		let unrelated: Path = parse_quote!(other_crate::Schema);
+
+		assert!(is_schema_derive(&unqualified, &expected));
+		assert!(is_schema_derive(&qualified, &expected));
+		assert!(!is_schema_derive(&unrelated, &expected));
+	}
 }

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1056,7 +1056,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///
 /// 1. Emits `#[cfg_attr(native, derive(::reinhardt::Validate))]`
 ///    on the struct so the server build gets validation while the wasm build
-///    sees a plain serializable type.
+///    sees a plain serializable type. With the explicit `schema` option, it
+///    also emits `::reinhardt::rest::openapi::Schema` on native builds.
 /// 2. Wraps every `#[validate(...)]` field attribute in `#[cfg_attr(native, ...)]`
 ///    so the same source compiles unchanged for `wasm32-unknown-unknown`.
 /// 3. Is idempotent: if the user already wrote
@@ -1073,7 +1074,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// | What | A persistent record | A wire-level data shape |
 /// | Where it lives | `apps/<app>/models/*.rs` | `apps/<app>/shared/types.rs` |
 /// | Where it runs | Server only (`native`) | Both server (`native`) and client (`wasm`) |
-/// | What it adds | Table mapping, primary key, FK fields, migrations | `Validate` derive (native-only), wraps `#[validate(...)]` |
+/// | What it adds | Table mapping, primary key, FK fields, migrations | `Validate` derive (native-only), optional `Schema` derive, wraps `#[validate(...)]` |
 /// | Boundary it crosses | Rust ↔ database | Server ↔ client (via `#[server_fn]`, REST handlers, WebSocket payloads) |
 ///
 /// "DTO" is the industry-standard term for the second row — a data-transfer
@@ -1086,7 +1087,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// use reinhardt::dto;
 /// use serde::{Deserialize, Serialize};
 ///
-/// #[dto]
+/// #[dto(schema)]
 /// #[derive(Debug, Clone, Serialize, Deserialize)]
 /// pub struct LoginRequest {
 ///     #[validate(email(message = "Invalid email address"))]
@@ -1100,7 +1101,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// Expands (conceptually) to:
 ///
 /// ```rust,ignore
-/// #[cfg_attr(native, derive(::reinhardt::Validate))]
+/// #[cfg_attr(native, derive(::reinhardt::Validate, ::reinhardt::rest::openapi::Schema))]
 /// #[derive(Debug, Clone, Serialize, Deserialize)]
 /// pub struct LoginRequest {
 ///     #[cfg_attr(native, validate(email(message = "Invalid email address")))]
@@ -1113,18 +1114,23 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///
 /// # Requirements
 ///
-/// - OpenAPI schema generation is not implicit. If a DTO should be part of
-///   generated OpenAPI documentation, explicitly add a `Schema` derive in a
-///   build that enables the OpenAPI feature graph.
+/// - OpenAPI schema generation is not implicit. Add `schema` as an explicit
+///   option (`#[dto(schema)]`) for a DTO that should be part of generated
+///   OpenAPI documentation. The consumer's native build must enable the
+///   `openapi` feature.
 /// - Applies only to `struct` items (named, tuple, or unit). Enums and unions
+///   produce a compile error. The `schema` option additionally requires named
+///   fields because the OpenAPI `Schema` derive does not support tuple or unit
+///   structs.
+/// - The only supported argument is the bare `schema` option. Other arguments
 ///   produce a compile error.
-/// - Does not accept arguments in this version. Passing any tokens (e.g.
-///   `#[dto(no_schema)]`) is a compile error.
-/// - Unconditional `#[derive(Validate)]` on the same struct is a compile
-///   error. `Validate` lives behind the `native` cfg, so an unconditional
-///   derive cannot resolve on wasm and would duplicate the macro's emission on
-///   native. Either delete the derive (and let `#[dto]` emit it) or wrap it in
-///   `#[cfg_attr(native, derive(Validate))]` yourself.
+/// - Unconditional `#[derive(Validate)]` is a compile error. `Validate` lives
+///   behind the `native` cfg, so an unconditional derive cannot resolve on wasm
+///   and would duplicate the macro's emission on native. Either delete the
+///   derive (and let `#[dto]` emit it) or wrap it in
+///   `#[cfg_attr(native, derive(Validate))]` yourself. When using
+///   `#[dto(schema)]`, do not add a separate `Schema` derive because the
+///   option emits it for native builds.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear
@@ -1134,7 +1140,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   ordering:
 ///
 /// ```rust,ignore
-/// #[dto]
+/// #[dto(schema)]
 /// #[cfg_attr(native, derive(Validate))]
 /// pub struct LoginRequest { /* ... */ }
 /// ```

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1058,8 +1058,9 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///    on the struct so the server build gets validation while the wasm build
 ///    sees a plain serializable type. With the explicit `schema` option, it
 ///    also emits `::reinhardt::rest::openapi::Schema` on native builds.
-/// 2. Wraps every `#[validate(...)]` field attribute in `#[cfg_attr(native, ...)]`
-///    so the same source compiles unchanged for `wasm32-unknown-unknown`.
+/// 2. Wraps every `#[validate(...)]` and `#[schema(...)]` attribute in
+///    `#[cfg_attr(native, ...)]` so the same source compiles unchanged for
+///    `wasm32-unknown-unknown`.
 /// 3. Is idempotent: if the user already wrote
 ///    `#[cfg_attr(native, derive(Validate))]` on the struct, that derive is
 ///    not duplicated.

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1132,6 +1132,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   `#[cfg_attr(native, derive(Validate))]` yourself. When using
 ///   `#[dto(schema)]`, do not add a separate `Schema` derive because the
 ///   option emits it for native builds.
+/// - Existing `Validate` derives may use a qualified path; the final path
+///   segment is used when checking for an existing derive.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1134,6 +1134,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   option emits it for native builds.
 /// - Existing `Validate` derives may use a qualified path; the final path
 ///   segment is used when checking for an existing derive.
+/// - Existing `Schema` derives may use the facade path or a directly referenced
+///   `reinhardt_rest::openapi::Schema` path.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -32,6 +32,13 @@ fn dto_schema_option_compiles_and_generates_native_schema() {
 	);
 	let repo_root_toml = serde_json::to_string(&repo_root.to_string_lossy().into_owned())
 		.expect("escape repository root for TOML");
+	let rest_root_toml = serde_json::to_string(
+		&repo_root
+			.join("crates/reinhardt-rest")
+			.to_string_lossy()
+			.into_owned(),
+	)
+	.expect("escape reinhardt-rest root for TOML");
 
 	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
 	fs::write(
@@ -47,8 +54,10 @@ publish = false
 
 [dependencies]
 reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["openapi"] }}
+reinhardt_rest = {{ path = {}, package = "reinhardt-rest", default-features = false, features = ["openapi"] }}
 "#,
-			repo_root_toml
+			repo_root_toml,
+			rest_root_toml
 		),
 	)
 	.expect("write fixture manifest");
@@ -81,9 +90,16 @@ struct Profile {
 	display_name: String,
 }
 
+#[dto(schema)]
+#[cfg_attr(native, derive(reinhardt_rest::openapi::Schema))]
+struct DirectRestSchema {
+	name: String,
+}
+
 fn main() {
 	assert_eq!(LoginRequest::schema_name(), Some(String::from("LoginRequest")));
 	assert_eq!(Profile::schema_name(), Some(String::from("Profile")));
+	assert_eq!(DirectRestSchema::schema_name(), Some(String::from("DirectRestSchema")));
 }
 "#,
 	)

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
@@ -7,10 +7,31 @@ fn dto_schema_option_compiles_and_generates_native_schema() {
 	let crate_dir = tempfile::tempdir().expect("create temporary fixture directory");
 	let target_dir = tempfile::tempdir().expect("create temporary target directory");
 	let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-	let repo_root = manifest_dir
-		.join("../../..")
-		.canonicalize()
-		.expect("resolve repository root");
+	let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+	let metadata = Command::new(&cargo)
+		.arg("metadata")
+		.arg("--manifest-path")
+		.arg(manifest_dir.join("Cargo.toml"))
+		.arg("--no-deps")
+		.arg("--offline")
+		.arg("--format-version")
+		.arg("1")
+		.output()
+		.expect("resolve workspace metadata");
+	assert!(
+		metadata.status.success(),
+		"workspace metadata should resolve\nstderr:\n{}",
+		String::from_utf8_lossy(&metadata.stderr),
+	);
+	let metadata: serde_json::Value =
+		serde_json::from_slice(&metadata.stdout).expect("parse workspace metadata");
+	let repo_root = PathBuf::from(
+		metadata["workspace_root"]
+			.as_str()
+			.expect("workspace metadata should include an absolute root"),
+	);
+	let repo_root_toml = serde_json::to_string(&repo_root.to_string_lossy().into_owned())
+		.expect("escape repository root for TOML");
 
 	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
 	fs::write(
@@ -25,10 +46,9 @@ publish = false
 [workspace]
 
 [dependencies]
-reinhardt = {{ path = "{}", package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
-inventory = "0.3"
+reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
 "#,
-			repo_root.display()
+			repo_root_toml
 		),
 	)
 	.expect("write fixture manifest");
@@ -48,7 +68,9 @@ inventory = "0.3"
 use reinhardt::dto;
 
 #[dto(schema)]
+#[schema(title = "Login request")]
 struct LoginRequest {
+	#[schema(description = "Username")]
 	username: String,
 }
 
@@ -65,7 +87,7 @@ fn main() {
 	)
 	.expect("write fixture source");
 
-	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+	let output = Command::new(&cargo)
 		.arg("check")
 		.arg("--manifest-path")
 		.arg(crate_dir.path().join("Cargo.toml"))

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -1,0 +1,84 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn dto_schema_option_compiles_and_generates_native_schema() {
+	let crate_dir = tempfile::tempdir().expect("create temporary fixture directory");
+	let target_dir = tempfile::tempdir().expect("create temporary target directory");
+	let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let repo_root = manifest_dir
+		.join("../../..")
+		.canonicalize()
+		.expect("resolve repository root");
+
+	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
+	fs::write(
+		crate_dir.path().join("Cargo.toml"),
+		format!(
+			r#"[package]
+name = "reinhardt-dto-schema-parity-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+reinhardt = {{ path = "{}", package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
+inventory = "0.3"
+"#,
+			repo_root.display()
+		),
+	)
+	.expect("write fixture manifest");
+	fs::write(
+		crate_dir.path().join("build.rs"),
+		r#"fn main() {
+	println!("cargo::rustc-check-cfg=cfg(native)");
+	println!("cargo::rustc-cfg=native");
+}
+"#,
+	)
+	.expect("write fixture build script");
+	fs::write(
+		crate_dir.path().join("src/main.rs"),
+		r#"#![deny(unexpected_cfgs)]
+
+use reinhardt::dto;
+
+#[dto(schema)]
+struct LoginRequest {
+	username: String,
+}
+
+#[dto(schema)]
+struct Profile {
+	display_name: String,
+}
+
+fn main() {
+	assert_eq!(LoginRequest::schema_name(), Some(String::from("LoginRequest")));
+	assert_eq!(Profile::schema_name(), Some(String::from("Profile")));
+}
+"#,
+	)
+	.expect("write fixture source");
+
+	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+		.arg("check")
+		.arg("--manifest-path")
+		.arg(crate_dir.path().join("Cargo.toml"))
+		.arg("--target-dir")
+		.arg(target_dir.path())
+		.arg("--offline")
+		.output()
+		.expect("run native DTO schema parity fixture");
+
+	assert!(
+		output.status.success(),
+		"native DTO schema parity fixture should compile\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -46,7 +46,7 @@ publish = false
 [workspace]
 
 [dependencies]
-reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
+reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["openapi"] }}
 "#,
 			repo_root_toml
 		),
@@ -70,8 +70,10 @@ use reinhardt::dto;
 #[dto(schema)]
 #[schema(title = "Login request")]
 struct LoginRequest {
-	#[schema(description = "Username")]
+	#[schema(description = "Username", example = "alice")]
 	username: String,
+	#[schema(default_value = "0")]
+	attempts: i64,
 }
 
 #[dto(schema)]

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
@@ -1,0 +1,17 @@
+//! Verifies that `#[dto(schema)]` rejects an unconditional `Schema` derive.
+
+#![allow(unexpected_cfgs)]
+
+use reinhardt_macros::dto;
+
+// Synthetic name to test the attribute validation without requiring OpenAPI.
+#[derive()]
+pub struct Schema;
+
+#[dto(schema)]
+#[derive(Schema)]
+pub struct LoginRequest {
+	pub email: String,
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
@@ -1,5 +1,7 @@
 //! Verifies that `#[dto(schema)]` rejects an unconditional `Schema` derive.
 
+// This standalone trybuild fixture intentionally exercises macro-generated
+// `cfg(native)` without the facade build script's `check-cfg` declaration.
 #![allow(unexpected_cfgs)]
 
 use reinhardt_macros::dto;

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
@@ -1,5 +1,5 @@
 error: #[dto(schema)] cannot be combined with `#[derive(Schema)]`. Remove the derive because #[dto(schema)] emits it for native builds.
-  --> tests/ui/dto/fail/unconditional_schema.rs:12:1
+  --> tests/ui/dto/fail/unconditional_schema.rs:14:1
    |
-12 | #[derive(Schema)]
+14 | #[derive(Schema)]
    | ^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
@@ -1,0 +1,5 @@
+error: #[dto(schema)] cannot be combined with `#[derive(Schema)]`. Remove the derive because #[dto(schema)] emits it for native builds.
+  --> tests/ui/dto/fail/unconditional_schema.rs:12:1
+   |
+12 | #[derive(Schema)]
+   | ^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.rs
@@ -1,4 +1,4 @@
-//! Verifies that `#[dto(...)]` rejects arguments in v1.
+//! Verifies that `#[dto(...)]` rejects options other than `schema`.
 
 use reinhardt_macros::dto;
 

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.stderr
@@ -1,4 +1,4 @@
-error: #[dto] does not accept arguments in this version
+error: #[dto] accepts only the `schema` option
  --> tests/ui/dto/fail/with_args.rs:5:7
   |
 5 | #[dto(no_schema)]

--- a/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
@@ -1,13 +1,17 @@
 //! Verifies that `#[dto(schema)]` is accepted and remains inert on non-native
 //! builds, where the OpenAPI feature graph is intentionally unavailable.
 
+// This standalone trybuild fixture intentionally exercises macro-generated
+// `cfg(native)` without the facade build script's `check-cfg` declaration.
 #![allow(unexpected_cfgs)]
 
 use reinhardt_macros::dto;
 
 #[dto(schema)]
+#[schema(title = "Login request")]
 pub struct LoginRequest {
 	#[validate(length(min = 1))]
+	#[schema(description = "Email address")]
 	pub email: String,
 	pub password: String,
 }

--- a/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
@@ -1,0 +1,20 @@
+//! Verifies that `#[dto(schema)]` is accepted and remains inert on non-native
+//! builds, where the OpenAPI feature graph is intentionally unavailable.
+
+#![allow(unexpected_cfgs)]
+
+use reinhardt_macros::dto;
+
+#[dto(schema)]
+pub struct LoginRequest {
+	#[validate(length(min = 1))]
+	pub email: String,
+	pub password: String,
+}
+
+fn main() {
+	let _ = LoginRequest {
+		email: String::from("user@example.com"),
+		password: String::from("password"),
+	};
+}

--- a/crates/reinhardt-rest/openapi-macros/src/lib.rs
+++ b/crates/reinhardt-rest/openapi-macros/src/lib.rs
@@ -388,8 +388,8 @@ fn generate_container_modifications(
 	if let Some(ref example) = attrs.example {
 		// Parse the example string as JSON; fall back to a JSON string if invalid
 		mods.push(quote! {
-			let example_value: serde_json::Value = serde_json::from_str(#example)
-				.unwrap_or_else(|_| serde_json::json!(#example));
+			let example_value: #openapi_crate::serde_json::Value = #openapi_crate::serde_json::from_str(#example)
+				.unwrap_or_else(|_| #openapi_crate::serde_json::json!(#example));
 			match schema {
 				Schema::Object(ref mut obj) => {
 					obj.example = Some(example_value);
@@ -497,7 +497,7 @@ fn generate_simple_enum_schema(
 		Schema::Object(
 			ObjectBuilder::new()
 				.schema_type(SchemaType::Type(Type::String))
-				.enum_values(Some(vec![#(serde_json::Value::String(#variant_names.to_string())),*]))
+				.enum_values(Some(vec![#(#openapi_crate::serde_json::Value::String(#variant_names.to_string())),*]))
 				.build()
 		)
 	}
@@ -759,8 +759,8 @@ fn build_field_schema(field_type: &syn::Type, attrs: &FieldAttributes) -> proc_m
 		modifications.push(quote! {
 			if let Schema::Object(ref mut obj) = schema {
 				obj.example = Some(
-					serde_json::from_str(#example)
-						.unwrap_or_else(|_| serde_json::json!(#example))
+					#openapi_crate::serde_json::from_str(#example)
+						.unwrap_or_else(|_| #openapi_crate::serde_json::json!(#example))
 				);
 			}
 		});
@@ -946,7 +946,7 @@ fn build_field_schema(field_type: &syn::Type, attrs: &FieldAttributes) -> proc_m
 	if let Some(ref default_value) = attrs.default_value {
 		modifications.push(quote! {
 			if let Schema::Object(ref mut obj) = schema {
-				obj.default = Some(serde_json::json!(#default_value));
+				obj.default = Some(#openapi_crate::serde_json::json!(#default_value));
 			}
 		});
 	}

--- a/crates/reinhardt-rest/openapi-macros/src/lib.rs
+++ b/crates/reinhardt-rest/openapi-macros/src/lib.rs
@@ -241,7 +241,7 @@ fn derive_struct_schema(input: &DeriveInput, data: &syn::DataStruct) -> TokenStr
 		quote! {
 			// Automatic schema registration via inventory
 			// This allows the framework to discover all schemas at compile time
-			::inventory::submit! {
+			#openapi_crate::inventory::submit! {
 				#openapi_crate::SchemaRegistration::new(
 					#struct_name,
 					#name::schema
@@ -319,7 +319,7 @@ fn derive_enum_schema(input: &DeriveInput, data: &syn::DataEnum) -> TokenStream 
 	// Generate inventory registration only for non-generic types
 	let inventory_registration = if generics.params.is_empty() {
 		quote! {
-			::inventory::submit! {
+			#openapi_crate::inventory::submit! {
 				#openapi_crate::SchemaRegistration::new(
 					#enum_name,
 					#name::schema

--- a/crates/reinhardt-rest/src/openapi.rs
+++ b/crates/reinhardt-rest/src/openapi.rs
@@ -184,6 +184,7 @@ pub use utoipa::Number;
 
 // Re-export utoipa and inventory for macro-generated code
 pub use inventory;
+pub use serde_json;
 pub use utoipa;
 
 /// Errors that can occur during OpenAPI schema operations.


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds the explicit `#[dto(schema)]` option for native-only OpenAPI `Schema` generation.
- Keeps plain `#[dto]` free of the optional OpenAPI feature graph.
- Adds option diagnostics, wasm-inert UI coverage, and native schema parity coverage.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Shared DTOs need OpenAPI schemas on the server while remaining usable by wasm clients. The opt-in keeps OpenAPI dependencies out of DTOs that only need validation.

Fixes #6196

Related to: kent8192/reinhardt-cloud#894

## How Was This Tested?

- [x] `cargo test -p reinhardt-macros --test ui test_dto_macro_pass -- --nocapture`
- [x] `cargo test -p reinhardt-macros --test ui test_dto_macro_fail -- --nocapture`
- [x] `cargo test -p reinhardt-macros --test dto_schema_parity -- --nocapture`
- [x] `cargo doc -p reinhardt-macros --no-deps`
- [x] `cargo check --workspace --all-features`
- [x] `cargo make fmt-check`
- [x] `cargo make clippy-check`

## Performance Impact

No runtime impact; the additional derive is native compile-time generation only.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

- kent8192/reinhardt-cloud#894

## Labels to Apply

### Type Label
- [x] `enhancement` - New feature or improvement

### Scope Label
- [x] `api` - REST API, serializers, views

---

🤖 Generated with [Codex](https://openai.com/codex/)