### PR TITLE
fix(ci): allow current miniz_oxide duplicate versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -163,6 +163,7 @@ skip = [
   { crate = "linux-raw-sys@0.4.15", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "matchit@0.8.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "md-5@0.10.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "miniz_oxide:>=0.8,<0.10", reason = "backtrace and flate2 retain incompatible miniz_oxide lines in the full feature graph." },
   { crate = "nix@0.29.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "nom@7.1.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "openssl-probe@0.1.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Unblocking `Security Audit / Check dependency policy` for the full-feature workspace dependency graph by allowing the unavoidable `miniz_oxide` 0.8/0.9 duplicate range.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`backtrace` retains `miniz_oxide` 0.8.9 while `flate2` retains 0.9.1. Their incompatible version requirements cannot be unified by Cargo, and cargo-deny therefore reports the duplicate as a policy failure. This adds a narrow range skip covering only the retained 0.8 and 0.9 lines.

## How Was This Tested?

- `cargo deny --workspace --all-features check all` with a freshly resolved ignored `Cargo.lock` — passed; advisories, bans, licenses, and sources all passed.
- `cargo make fmt-check` — passed.
- `git diff --check` — passed.
- `cargo make clippy-check` was started but interrupted after approximately eight minutes because the shared Cargo workspace remained blocked while other worktrees were compiling; no code files changed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable; the policy reason documents this configuration exception)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable; this is a configuration-only change validated by cargo-deny)
- [ ] New and existing unit tests pass locally with my changes (not run; no code changed)
- [x] I have tested with all affected database backends (if applicable; not applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check` (interrupted due shared Cargo contention; no code changed)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `ci-cd` - CI/CD workflow changes

**Additional Context:**

The change is limited to one `deny.toml` skip entry.
