### PR TITLE
chore: merge main into develop/0.4.0

### DIFF
--- a/.github/workflows/reinhardt-feature-check.yml
+++ b/.github/workflows/reinhardt-feature-check.yml
@@ -15,7 +15,7 @@ on:
   # GitHub Actions branch scoping: PR branches can only restore caches
   # from the default branch (main). This trigger runs a single
   # --all-features check on main to populate the shared cache that all
-  # 25 feature-check matrix entries restore from.
+  # 27 feature-check matrix entries restore from.
   push:
     branches: [main]
     paths:
@@ -121,6 +121,7 @@ jobs:
           - { name: "admin-forms",       pkg: "reinhardt-web",  features: "minimal,admin,database,db-postgres,auth", no_default: "true" }
           - { name: "plugins",           pkg: "reinhardt-web",  features: "minimal,dentdelion,deeplink,dispatch,grpc", no_default: "true" }
           - { name: "openapi-router",    pkg: "reinhardt-web",  features: "minimal,openapi-router,database,db-postgres", no_default: "true" }
+          - { name: "social-auth-redis", pkg: "reinhardt-web",  features: "minimal,social-auth,session-redis", no_default: "true" }
           # --- Key sub-crate extremes (no-default and full) ---
           - { name: "core-minimal",      pkg: "reinhardt-core", features: "",                    no_default: "true"  }
           - { name: "core-full",         pkg: "reinhardt-core", features: "core-full",           no_default: "true"  }
@@ -130,6 +131,7 @@ jobs:
           - { name: "auth-full",         pkg: "reinhardt-auth", features: "auth-full",           no_default: "true"  }
           - { name: "rest-minimal",      pkg: "reinhardt-rest", features: "",                    no_default: "true"  }
           - { name: "rest-full",         pkg: "reinhardt-rest", features: "rest-full",           no_default: "true"  }
+          - { name: "middleware-social-auth", pkg: "reinhardt-middleware", features: "social-auth,session-redis", no_default: "true" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -152,7 +154,7 @@ jobs:
           cache-directories: /tmp/cargo_target
           cache-on-failure: "true"
           # Don't save on PR branches - restore from main's cache only.
-          # Avoids 25 matrix entries competing to save the same key.
+          # Avoids 27 matrix entries competing to save the same key.
           save-if: "false"
 
       - name: Run feature check (${{ matrix.combo.name }})

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,12 @@ i18n = ["reinhardt-i18n"]
 mail = ["reinhardt-mail"]
 sessions = ["reinhardt-auth", "reinhardt-auth/sessions"]
 session-redis = ["sessions", "middleware", "reinhardt-middleware/session-redis"]
+social-auth = [
+  "auth",
+  "middleware",
+  "reinhardt-auth/social",
+  "reinhardt-middleware/social-auth",
+]
 middleware = [
   "reinhardt-middleware",
   "reinhardt-middleware/sessions",
@@ -205,6 +211,7 @@ full = [
   "i18n",
   "mail",
   "sessions",
+  "social-auth",
   "static-files",
   "storage",
   "commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ server-fn-test = ["test", "reinhardt-test/server-fn-test"]
 # `reinhardt::test::msw::MockServiceWorker` and triggers `MockableServerFn`
 # impl generation for `#[server_fn]` in downstream crates.
 msw = ["test", "pages", "reinhardt-test/msw", "reinhardt-pages/msw"]
-openapi = ["reinhardt-rest", "reinhardt-rest/openapi", "reinhardt-views?/openapi", "rest", "dep:inventory"]
+openapi = ["core", "reinhardt-rest", "reinhardt-rest/openapi", "reinhardt-views?/openapi", "rest", "dep:inventory"]
 openapi-swagger-ui = ["openapi", "reinhardt-rest/openapi-swagger-ui"]
 openapi-router = ["reinhardt-openapi", "openapi", "reinhardt-commands/openapi-router"]
 reinhardt-browsable-api = ["reinhardt-rest", "reinhardt-rest/browsable-api", "reinhardt-views?/browsable-api"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -548,7 +548,7 @@ args = ["llvm-cov", "nextest", "--workspace", "--lib", "--all-features", "--no-f
 # ============================================================================
 
 [tasks.feature-check]
-description = "Check representative feature combinations (30 patterns)"
+description = "Check representative feature combinations (32 patterns)"
 dependencies = ["feature-check-facade", "feature-check-subcrate"]
 
 [tasks.dependency-feature-audit]
@@ -561,7 +561,7 @@ scripts/dependency-feature-audit.sh "${label}"
 '''
 
 [tasks.feature-check-facade]
-description = "Check facade crate feature combinations (19 patterns)"
+description = "Check facade crate feature combinations (20 patterns)"
 script_runner = "bash"
 script = '''
 set -e
@@ -587,6 +587,7 @@ combos=(
 	"admin-forms|reinhardt-web|--no-default-features -F minimal,admin,database,db-postgres,auth"
 	"plugins|reinhardt-web|--no-default-features -F minimal,dentdelion,deeplink,dispatch,grpc"
 	"openapi-router|reinhardt-web|--no-default-features -F minimal,openapi-router,database,db-postgres"
+	"social-auth-redis|reinhardt-web|--no-default-features -F minimal,social-auth,session-redis"
 )
 
 for combo in "${combos[@]}"; do
@@ -600,7 +601,7 @@ echo "=== All facade checks passed ==="
 '''
 
 [tasks.feature-check-subcrate]
-description = "Check key sub-crate feature combinations (11 patterns)"
+description = "Check key sub-crate feature combinations (12 patterns)"
 script_runner = "bash"
 script = '''
 set -e
@@ -618,6 +619,7 @@ combos=(
 	"auth-sessions-no-db|reinhardt-auth|--no-default-features -F sessions"
 	"rest-minimal|reinhardt-rest|--no-default-features"
 	"rest-full|reinhardt-rest|--no-default-features -F rest-full"
+	"middleware-social-auth|reinhardt-middleware|--no-default-features -F social-auth,session-redis"
 )
 
 for combo in "${combos[@]}"; do

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ reinhardt-db = "0.3.13"
 # Optional: Authentication
 reinhardt-auth = "0.3.13"
 
+# Optional: browser-bound social OAuth state (add `session-redis` for Redis)
+reinhardt = { version = "0.3.13", package = "reinhardt-web", default-features = false, features = ["social-auth"] }
+
 # Optional: REST API features
 reinhardt-rest = "0.3.13"
 
@@ -1318,7 +1321,7 @@ Reinhardt offers modular components you can mix and match:
 | **Database**        |                           |                                             |
 | ORM                 | `reinhardt-db`            | reinhardt-query integration                |
 | **Authentication**  |                           |                                             |
-| Auth                | `reinhardt-auth`          | JWT, Token, Session, Basic auth, User models|
+| Auth                | `reinhardt-auth`          | JWT, Token, Session, Basic auth, social OAuth state, User models|
 | **REST API**        |                           |                                             |
 | Serializers         | `reinhardt-rest`          | built-in serialization and validation, ViewSets |
 | **Forms**           |                           |                                             |
@@ -1334,7 +1337,7 @@ Reinhardt offers modular components you can mix and match:
 | gRPC                | `reinhardt-grpc`          | gRPC services, protobuf types               |
 | Deep Link           | `reinhardt-deeplink`      | iOS Universal Links, Android App Links      |
 | **Middleware**       |                           |                                             |
-| Middleware          | `reinhardt-middleware`    | HTTP middleware components, CORS, security  |
+| Middleware          | `reinhardt-middleware`    | HTTP middleware components, CORS, security, session-backed social OAuth state |
 | **Testing**         |                           |                                             |
 | Test Utilities      | `reinhardt-test`          | Testing helpers, fixtures, TestContainers   |
 | Test Kit            | `reinhardt-testkit`       | Higher-level test abstractions and utilities|

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -623,6 +623,42 @@ let token = oauth2.exchange_code(&code, "client123").await?;
 let claims = oauth2.verify_token(&token.access_token).await?;
 ```
 
+#### Browser-Bound Social OAuth State
+
+Enable the `social-auth` feature to bind a social OAuth callback to a
+high-entropy browser or session value and to carry opaque application context
+through the provider redirect. Only a SHA-256 digest of the binding is stored;
+the binding itself remains in the application-controlled cookie or session.
+State is consumed before the provider exchange, so a replay, provider swap,
+expired state, or binding mismatch cannot be retried with the same state.
+
+```rust,ignore
+use reinhardt::auth::{ContextualCallbackResult, SocialAuthBackend};
+
+let authorization = backend
+    .begin_auth_with_context(
+        "github",
+        None,
+        None,
+        browser_cookie_value.as_bytes(),
+        serialized_link_intent,
+    )
+    .await?;
+
+let ContextualCallbackResult { callback, context } = backend
+    .handle_callback_with_context(
+        "github",
+        code,
+        state,
+        browser_cookie_value.as_bytes(),
+    )
+    .await?;
+```
+
+Use a per-browser, unpredictable binding with appropriate `Secure`,
+`HttpOnly`, and `SameSite` cookie settings. The context is opaque and is not
+encrypted by the state store, so do not place secrets in it.
+
 ### Token Blacklist & Rotation
 
 #### Token Blacklist

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -213,9 +213,10 @@ pub use reinhardt_core::exception::Error as BaseUserManagerError;
 pub use serde_json::Value as JsonValue;
 #[cfg(feature = "social")]
 pub use social::{
-	AppleProvider, GenericOidcConfig, GenericOidcProvider, GitHubProvider, GoogleProvider, IdToken,
-	MicrosoftProvider, OAuthProvider, OAuthToken, PkceFlow, ProviderConfig, SocialAuthBackend,
-	SocialAuthError, StandardClaims, StateStore, TokenResponse, UserInfoMapper,
+	AppleProvider, ContextualStateData, GenericOidcConfig, GenericOidcProvider, GitHubProvider,
+	GoogleProvider, IdToken, MicrosoftProvider, OAuthProvider, OAuthToken, PkceFlow,
+	ProviderConfig, SocialAuthBackend, SocialAuthError, StandardClaims, StateStore, TokenResponse,
+	UserInfoMapper,
 };
 
 #[cfg(feature = "rate-limit")]

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -213,10 +213,10 @@ pub use reinhardt_core::exception::Error as BaseUserManagerError;
 pub use serde_json::Value as JsonValue;
 #[cfg(feature = "social")]
 pub use social::{
-	AppleProvider, ContextualStateData, GenericOidcConfig, GenericOidcProvider, GitHubProvider,
-	GoogleProvider, IdToken, MicrosoftProvider, OAuthProvider, OAuthToken, PkceFlow,
-	ProviderConfig, SocialAuthBackend, SocialAuthError, StandardClaims, StateStore, TokenResponse,
-	UserInfoMapper,
+	AppleProvider, ContextualCallbackResult, ContextualStateData, GenericOidcConfig,
+	GenericOidcProvider, GitHubProvider, GoogleProvider, IdToken, MicrosoftProvider, OAuthProvider,
+	OAuthToken, PkceFlow, ProviderConfig, SocialAuthBackend, SocialAuthError, StandardClaims,
+	StateStore, TokenResponse, UserInfoMapper,
 };
 
 #[cfg(feature = "rate-limit")]

--- a/crates/reinhardt-auth/src/lib.rs
+++ b/crates/reinhardt-auth/src/lib.rs
@@ -11,7 +11,7 @@
 //! - **Object-Level Permissions**: Fine-grained access control on individual objects
 //! - **User Management**: CRUD operations for users with password hashing
 //! - **Group Management**: User groups and permission assignment
-//! - **REST API Authentication**: Multiple authentication backends (JWT, Token, Session, OAuth2)
+//! - **REST API Authentication**: Multiple authentication backends (JWT, Token, Session, OAuth2, social OAuth state)
 //! - **Standard Permissions**: Permission classes for common authorization scenarios
 //! - **createsuperuser Command**: CLI tool for creating admin users
 //!

--- a/crates/reinhardt-auth/src/social.rs
+++ b/crates/reinhardt-auth/src/social.rs
@@ -74,7 +74,9 @@ pub use providers::{
 };
 
 // Re-export backend
-pub use backend::{AuthorizationResult, CallbackResult, SocialAuthBackend};
+pub use backend::{
+	AuthorizationResult, CallbackResult, ContextualCallbackResult, SocialAuthBackend,
+};
 
 // Re-export user mapping
 pub use user_mapping::{DefaultUserMapper, MappedUser, UserMapper};

--- a/crates/reinhardt-auth/src/social.rs
+++ b/crates/reinhardt-auth/src/social.rs
@@ -58,7 +58,8 @@ pub use core::{
 
 // Re-export flow types
 pub use flow::{
-	AuthorizationFlow, PkceFlow, RefreshFlow, StateData, StateStore, TokenExchangeFlow,
+	AuthorizationFlow, ContextualStateData, PkceFlow, RefreshFlow, StateData, StateStore,
+	TokenExchangeFlow,
 };
 
 // Re-export OIDC types

--- a/crates/reinhardt-auth/src/social/backend.rs
+++ b/crates/reinhardt-auth/src/social/backend.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::social::core::{OAuthProvider, SocialAuthError, StandardClaims, TokenResponse};
-use crate::social::flow::{InMemoryStateStore, StateData, StateStore};
+use crate::social::flow::{ContextualStateData, InMemoryStateStore, StateData, StateStore};
 
 /// Result of beginning an authorization flow
 pub struct AuthorizationResult {
@@ -26,6 +26,14 @@ pub struct CallbackResult {
 	pub token_response: TokenResponse,
 	/// The user's claims (from ID token or UserInfo endpoint)
 	pub claims: Option<StandardClaims>,
+}
+
+/// Result of handling a contextual authorization callback.
+pub struct ContextualCallbackResult {
+	/// The callback result from the provider.
+	pub callback: CallbackResult,
+	/// Opaque application context stored when authorization began.
+	pub context: Vec<u8>,
 }
 
 /// Social authentication backend
@@ -73,6 +81,44 @@ impl SocialAuthBackend {
 		code_challenge: Option<&str>,
 		code_verifier: Option<String>,
 	) -> Result<AuthorizationResult, SocialAuthError> {
+		let (authorization, state_data) = self
+			.prepare_authorization(provider_name, code_challenge, code_verifier)
+			.await?;
+		self.state_store.store(state_data).await?;
+		Ok(authorization)
+	}
+
+	/// Begin an authorization flow with browser or session binding and opaque context.
+	pub async fn begin_auth_with_context(
+		&self,
+		provider_name: &str,
+		code_challenge: Option<&str>,
+		code_verifier: Option<String>,
+		binding: &[u8],
+		context: Vec<u8>,
+	) -> Result<AuthorizationResult, SocialAuthError> {
+		if binding.is_empty() {
+			return Err(SocialAuthError::StateValidation(
+				"OAuth state binding must not be empty".to_string(),
+			));
+		}
+
+		let (authorization, state_data) = self
+			.prepare_authorization(provider_name, code_challenge, code_verifier)
+			.await?;
+		let contextual =
+			ContextualStateData::new(state_data, provider_name.to_string(), binding, context)?;
+		self.state_store.store_contextual(contextual).await?;
+		Ok(authorization)
+	}
+
+	/// Prepare the provider authorization URL and state record shared by both flows.
+	async fn prepare_authorization(
+		&self,
+		provider_name: &str,
+		code_challenge: Option<&str>,
+		code_verifier: Option<String>,
+	) -> Result<(AuthorizationResult, StateData), SocialAuthError> {
 		let provider = self.providers.get(provider_name).ok_or_else(|| {
 			SocialAuthError::Provider(format!("Provider not registered: {}", provider_name))
 		})?;
@@ -94,14 +140,15 @@ impl SocialAuthBackend {
 
 		// Store state data for callback verification
 		let state_data = StateData::new(state.clone(), nonce.clone(), code_verifier.clone());
-		self.state_store.store(state_data).await?;
-
-		Ok(AuthorizationResult {
-			authorization_url,
-			state,
-			nonce,
-			code_verifier,
-		})
+		Ok((
+			AuthorizationResult {
+				authorization_url,
+				state,
+				nonce,
+				code_verifier,
+			},
+			state_data,
+		))
 	}
 
 	/// Handle an authorization callback
@@ -115,10 +162,51 @@ impl SocialAuthBackend {
 			SocialAuthError::Provider(format!("Provider not registered: {}", provider_name))
 		})?;
 
-		// Verify and consume state
-		let state_data = self.state_store.retrieve(state).await?;
-		self.state_store.remove(state).await?;
+		let state_data = self.state_store.consume(state).await?;
+		self.complete_callback(provider.as_ref(), provider_name, code, &state_data)
+			.await
+	}
 
+	/// Handle a contextual authorization callback with binding verification.
+	pub async fn handle_callback_with_context(
+		&self,
+		provider_name: &str,
+		code: &str,
+		state: &str,
+		binding: &[u8],
+	) -> Result<ContextualCallbackResult, SocialAuthError> {
+		if binding.is_empty() {
+			return Err(SocialAuthError::StateValidation(
+				"OAuth state binding must not be empty".to_string(),
+			));
+		}
+
+		let provider = self.providers.get(provider_name).ok_or_else(|| {
+			SocialAuthError::Provider(format!("Provider not registered: {}", provider_name))
+		})?;
+		let contextual = self.state_store.consume_contextual(state).await?;
+		if contextual.state_data().is_expired()
+			|| contextual.provider_name() != provider_name
+			|| !contextual.binding_matches(binding)
+		{
+			return Err(SocialAuthError::InvalidState);
+		}
+
+		let (state_data, context) = contextual.into_parts();
+		let callback = self
+			.complete_callback(provider.as_ref(), provider_name, code, &state_data)
+			.await?;
+		Ok(ContextualCallbackResult { callback, context })
+	}
+
+	/// Complete provider token exchange and claims retrieval for a validated state.
+	async fn complete_callback(
+		&self,
+		provider: &dyn OAuthProvider,
+		provider_name: &str,
+		code: &str,
+		state_data: &StateData,
+	) -> Result<CallbackResult, SocialAuthError> {
 		// Exchange code for tokens
 		let token_response = provider
 			.exchange_code(code, state_data.code_verifier.as_deref())

--- a/crates/reinhardt-auth/src/social/flow.rs
+++ b/crates/reinhardt-auth/src/social/flow.rs
@@ -9,5 +9,7 @@ pub mod token_exchange;
 pub use authorization::AuthorizationFlow;
 pub use pkce::PkceFlow;
 pub use refresh::RefreshFlow;
-pub use state::{InMemoryStateStore, SessionStateStore, StateData, StateStore};
+pub use state::{
+	ContextualStateData, InMemoryStateStore, SessionStateStore, StateData, StateStore,
+};
 pub use token_exchange::TokenExchangeFlow;

--- a/crates/reinhardt-auth/src/social/flow/state.rs
+++ b/crates/reinhardt-auth/src/social/flow/state.rs
@@ -5,7 +5,9 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 use std::collections::HashMap;
+use subtle::ConstantTimeEq;
 use tokio::sync::RwLock;
 
 use crate::sessions::backends::cache::{SessionBackend, SessionError};
@@ -56,6 +58,69 @@ impl StateData {
 	}
 }
 
+/// OAuth state data with provider and caller-supplied binding context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ContextualStateData {
+	state_data: StateData,
+	provider_name: String,
+	binding_digest: [u8; 32],
+	context: Vec<u8>,
+}
+
+impl ContextualStateData {
+	/// Creates contextual state data from an OAuth state record and binding.
+	pub fn new(
+		state_data: StateData,
+		provider_name: String,
+		binding: &[u8],
+		context: Vec<u8>,
+	) -> Result<Self, SocialAuthError> {
+		if binding.is_empty() {
+			return Err(SocialAuthError::StateValidation(
+				"OAuth state binding must not be empty".to_string(),
+			));
+		}
+
+		Ok(Self {
+			state_data,
+			provider_name,
+			binding_digest: sha2::Sha256::digest(binding).into(),
+			context,
+		})
+	}
+
+	/// Returns the embedded OAuth state data.
+	pub fn state_data(&self) -> &StateData {
+		&self.state_data
+	}
+
+	/// Returns the provider recorded when authorization began.
+	pub fn provider_name(&self) -> &str {
+		&self.provider_name
+	}
+
+	/// Returns the opaque caller-supplied context bytes.
+	pub fn context(&self) -> &[u8] {
+		&self.context
+	}
+
+	/// Compares a binding with the stored digest in constant time.
+	pub fn binding_matches(&self, binding: &[u8]) -> bool {
+		if binding.is_empty() {
+			return false;
+		}
+
+		let candidate: [u8; 32] = sha2::Sha256::digest(binding).into();
+		self.binding_digest.ct_eq(&candidate).into()
+	}
+
+	/// Splits the OAuth state data and opaque context for a validated callback.
+	pub fn into_parts(self) -> (StateData, Vec<u8>) {
+		(self.state_data, self.context)
+	}
+}
+
 /// Trait for state storage implementations
 #[async_trait]
 pub trait StateStore: Send + Sync {
@@ -67,6 +132,49 @@ pub trait StateStore: Send + Sync {
 
 	/// Removes state data by state string
 	async fn remove(&self, state: &str) -> Result<(), SocialAuthError>;
+
+	/// Atomically consumes state data when the store provides that capability.
+	async fn consume(&self, state: &str) -> Result<StateData, SocialAuthError> {
+		let data = self.retrieve(state).await?;
+		self.remove(state).await?;
+		Ok(data)
+	}
+
+	/// Stores contextual state data.
+	///
+	/// Stores that do not support contextual state return a storage error.
+	async fn store_contextual(&self, _data: ContextualStateData) -> Result<(), SocialAuthError> {
+		Err(SocialAuthError::Storage(
+			"Context-aware OAuth state is not supported by this store".to_string(),
+		))
+	}
+
+	/// Atomically consumes contextual state data.
+	///
+	/// Stores that do not support contextual state return a storage error.
+	async fn consume_contextual(
+		&self,
+		_state: &str,
+	) -> Result<ContextualStateData, SocialAuthError> {
+		Err(SocialAuthError::Storage(
+			"Context-aware OAuth state is not supported by this store".to_string(),
+		))
+	}
+}
+
+#[derive(Debug, Clone)]
+enum StoredStateData {
+	Legacy(StateData),
+	Contextual(ContextualStateData),
+}
+
+impl StoredStateData {
+	fn is_expired(&self) -> bool {
+		match self {
+			Self::Legacy(data) => data.is_expired(),
+			Self::Contextual(data) => data.state_data().is_expired(),
+		}
+	}
 }
 
 /// In-memory state store for development and testing
@@ -75,7 +183,7 @@ pub trait StateStore: Send + Sync {
 /// For production, use a distributed store like Redis or database-backed storage.
 #[derive(Debug, Default)]
 pub struct InMemoryStateStore {
-	store: RwLock<HashMap<String, StateData>>,
+	store: RwLock<HashMap<String, StoredStateData>>,
 }
 
 impl InMemoryStateStore {
@@ -100,16 +208,18 @@ impl StateStore for InMemoryStateStore {
 		self.cleanup_expired().await;
 
 		let mut store = self.store.write().await;
-		store.insert(data.state.clone(), data);
+		store.insert(data.state.clone(), StoredStateData::Legacy(data));
 		Ok(())
 	}
 
 	async fn retrieve(&self, state: &str) -> Result<StateData, SocialAuthError> {
 		let store = self.store.read().await;
-		let data = store
-			.get(state)
-			.ok_or(SocialAuthError::InvalidState)?
-			.clone();
+		let data = match store.get(state) {
+			Some(StoredStateData::Legacy(data)) => data.clone(),
+			Some(StoredStateData::Contextual(_)) | None => {
+				return Err(SocialAuthError::InvalidState);
+			}
+		};
 
 		if data.is_expired() {
 			return Err(SocialAuthError::InvalidState);
@@ -122,6 +232,40 @@ impl StateStore for InMemoryStateStore {
 		let mut store = self.store.write().await;
 		store.remove(state).ok_or(SocialAuthError::InvalidState)?;
 		Ok(())
+	}
+
+	async fn consume(&self, state: &str) -> Result<StateData, SocialAuthError> {
+		let mut store = self.store.write().await;
+		match store.remove(state) {
+			Some(StoredStateData::Legacy(data)) if !data.is_expired() => Ok(data),
+			Some(StoredStateData::Legacy(_)) | Some(StoredStateData::Contextual(_)) | None => {
+				Err(SocialAuthError::InvalidState)
+			}
+		}
+	}
+
+	async fn store_contextual(&self, data: ContextualStateData) -> Result<(), SocialAuthError> {
+		self.cleanup_expired().await;
+
+		let mut store = self.store.write().await;
+		store.insert(
+			data.state_data().state.clone(),
+			StoredStateData::Contextual(data),
+		);
+		Ok(())
+	}
+
+	async fn consume_contextual(
+		&self,
+		state: &str,
+	) -> Result<ContextualStateData, SocialAuthError> {
+		let mut store = self.store.write().await;
+		match store.remove(state) {
+			Some(StoredStateData::Contextual(data)) if !data.state_data().is_expired() => Ok(data),
+			Some(StoredStateData::Legacy(_)) | Some(StoredStateData::Contextual(_)) | None => {
+				Err(SocialAuthError::InvalidState)
+			}
+		}
 	}
 }
 
@@ -215,6 +359,7 @@ mod tests {
 	use super::*;
 	use crate::sessions::backends::InMemorySessionBackend;
 	use rstest::rstest;
+	use std::sync::Arc;
 
 	#[rstest]
 	#[tokio::test]
@@ -301,6 +446,120 @@ mod tests {
 
 		// Assert
 		assert!(result.is_err());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_in_memory_contextual_state_round_trip() {
+		// Arrange
+		let store = InMemoryStateStore::new();
+		let data = ContextualStateData::new(
+			StateData::new("state-1".to_string(), None, None),
+			"github".to_string(),
+			b"browser-binding",
+			b"link-user-42".to_vec(),
+		)
+		.unwrap();
+		store.store_contextual(data).await.unwrap();
+
+		// Act
+		let consumed = store.consume_contextual("state-1").await.unwrap();
+
+		// Assert
+		assert_eq!(consumed.provider_name(), "github");
+		assert_eq!(consumed.context(), b"link-user-42");
+		assert!(consumed.binding_matches(b"browser-binding"));
+		assert!(matches!(
+			store.consume_contextual("state-1").await,
+			Err(SocialAuthError::InvalidState),
+		));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_in_memory_contextual_consume_has_one_winner() {
+		// Arrange
+		let store = Arc::new(InMemoryStateStore::new());
+		let data = ContextualStateData::new(
+			StateData::new("state-1".to_string(), None, None),
+			"github".to_string(),
+			b"binding",
+			Vec::new(),
+		)
+		.unwrap();
+		store.store_contextual(data).await.unwrap();
+
+		// Act
+		let (first, second) = tokio::join!(
+			store.consume_contextual("state-1"),
+			store.consume_contextual("state-1"),
+		);
+
+		// Assert
+		assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+	}
+
+	#[rstest]
+	fn test_contextual_state_rejects_empty_binding() {
+		let result = ContextualStateData::new(
+			StateData::new("state-1".to_string(), None, None),
+			"github".to_string(),
+			b"",
+			Vec::new(),
+		);
+
+		assert!(matches!(result, Err(SocialAuthError::StateValidation(_))));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_in_memory_contextual_state_rejects_expired_record() {
+		let store = InMemoryStateStore::new();
+		let data = ContextualStateData::new(
+			StateData::with_ttl("expired".to_string(), None, None, Duration::seconds(-1)),
+			"github".to_string(),
+			b"binding",
+			Vec::new(),
+		)
+		.unwrap();
+		store.store_contextual(data).await.unwrap();
+
+		assert!(matches!(
+			store.consume_contextual("expired").await,
+			Err(SocialAuthError::InvalidState),
+		));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_in_memory_legacy_consume_has_one_winner() {
+		let store = Arc::new(InMemoryStateStore::new());
+		store
+			.store(StateData::new("state-1".to_string(), None, None))
+			.await
+			.unwrap();
+
+		let (first, second) = tokio::join!(store.consume("state-1"), store.consume("state-1"));
+
+		assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_session_state_store_rejects_contextual_record() {
+		let store = SessionStateStore::new(InMemorySessionBackend::new());
+		let data = ContextualStateData::new(
+			StateData::new("state-1".to_string(), None, None),
+			"github".to_string(),
+			b"binding",
+			Vec::new(),
+		)
+		.unwrap();
+
+		assert!(matches!(
+			store.store_contextual(data).await,
+			Err(SocialAuthError::Storage(_)),
+		));
 	}
 
 	#[rstest]

--- a/crates/reinhardt-auth/tests/social.rs
+++ b/crates/reinhardt-auth/tests/social.rs
@@ -6,6 +6,8 @@
 mod claims_test;
 #[path = "social/config_test.rs"]
 mod config_test;
+#[path = "social/contextual_backend_test.rs"]
+mod contextual_backend_test;
 #[path = "social/error_test.rs"]
 mod error_test;
 #[path = "social/jwks_cache_test.rs"]

--- a/crates/reinhardt-auth/tests/social/contextual_backend_test.rs
+++ b/crates/reinhardt-auth/tests/social/contextual_backend_test.rs
@@ -1,0 +1,290 @@
+//! Context-aware social authentication regression tests.
+
+use async_trait::async_trait;
+use reinhardt_auth::social::{
+	OAuthProvider, SocialAuthBackend, SocialAuthError, StandardClaims, TokenResponse,
+};
+use std::collections::HashMap;
+use std::sync::{
+	Arc,
+	atomic::{AtomicUsize, Ordering},
+};
+
+struct TestProvider {
+	name: &'static str,
+	exchange_calls: Arc<AtomicUsize>,
+}
+
+impl TestProvider {
+	fn new(name: &'static str, exchange_calls: Arc<AtomicUsize>) -> Self {
+		Self {
+			name,
+			exchange_calls,
+		}
+	}
+}
+
+#[async_trait]
+impl OAuthProvider for TestProvider {
+	fn name(&self) -> &str {
+		self.name
+	}
+
+	fn is_oidc(&self) -> bool {
+		false
+	}
+
+	async fn authorization_url(
+		&self,
+		state: &str,
+		_nonce: Option<&str>,
+		_code_challenge: Option<&str>,
+	) -> Result<String, SocialAuthError> {
+		Ok(format!("https://provider.example/authorize?state={state}"))
+	}
+
+	async fn exchange_code(
+		&self,
+		_code: &str,
+		_code_verifier: Option<&str>,
+	) -> Result<TokenResponse, SocialAuthError> {
+		self.exchange_calls.fetch_add(1, Ordering::SeqCst);
+		Ok(TokenResponse {
+			access_token: "access-token".to_string(),
+			token_type: "Bearer".to_string(),
+			expires_in: Some(3600),
+			refresh_token: None,
+			scope: None,
+			id_token: None,
+		})
+	}
+
+	async fn refresh_token(&self, _refresh_token: &str) -> Result<TokenResponse, SocialAuthError> {
+		Err(SocialAuthError::NotSupported("refresh".to_string()))
+	}
+
+	async fn get_user_info(&self, _access_token: &str) -> Result<StandardClaims, SocialAuthError> {
+		Ok(StandardClaims {
+			sub: "user-42".to_string(),
+			email: None,
+			email_verified: None,
+			name: None,
+			given_name: None,
+			family_name: None,
+			picture: None,
+			locale: None,
+			additional_claims: HashMap::new(),
+		})
+	}
+}
+
+#[tokio::test]
+async fn contextual_callback_returns_bound_context() {
+	// Arrange
+	let exchange_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new(
+		"github",
+		exchange_calls.clone(),
+	)));
+	let authorization = backend
+		.begin_auth_with_context(
+			"github",
+			None,
+			Some("pkce-verifier".to_string()),
+			b"browser-a",
+			b"link-user-42".to_vec(),
+		)
+		.await
+		.unwrap();
+
+	// Act
+	let result = backend
+		.handle_callback_with_context(
+			"github",
+			"provider-code",
+			&authorization.state,
+			b"browser-a",
+		)
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(result.context, b"link-user-42");
+	assert_eq!(result.callback.token_response.access_token, "access-token");
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 1);
+
+	let replay = backend
+		.handle_callback_with_context(
+			"github",
+			"provider-code",
+			&authorization.state,
+			b"browser-a",
+		)
+		.await;
+	assert!(matches!(replay, Err(SocialAuthError::InvalidState)));
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn contextual_callback_rejects_login_csrf_and_consumes_state() {
+	// Arrange
+	let exchange_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new(
+		"github",
+		exchange_calls.clone(),
+	)));
+	let authorization = backend
+		.begin_auth_with_context("github", None, None, b"browser-a", Vec::new())
+		.await
+		.unwrap();
+
+	// Act
+	let mismatched = backend
+		.handle_callback_with_context(
+			"github",
+			"provider-code",
+			&authorization.state,
+			b"browser-b",
+		)
+		.await;
+	let retry = backend
+		.handle_callback_with_context(
+			"github",
+			"provider-code",
+			&authorization.state,
+			b"browser-a",
+		)
+		.await;
+
+	// Assert
+	assert!(matches!(mismatched, Err(SocialAuthError::InvalidState)));
+	assert!(matches!(retry, Err(SocialAuthError::InvalidState)));
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn contextual_callback_rejects_session_swap() {
+	// Arrange
+	let exchange_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new(
+		"github",
+		exchange_calls.clone(),
+	)));
+	let authorization = backend
+		.begin_auth_with_context("github", None, None, b"session-user-a", Vec::new())
+		.await
+		.unwrap();
+
+	// Act
+	let result = backend
+		.handle_callback_with_context(
+			"github",
+			"provider-code",
+			&authorization.state,
+			b"session-user-b",
+		)
+		.await;
+
+	// Assert
+	assert!(matches!(result, Err(SocialAuthError::InvalidState)));
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn contextual_callback_rejects_provider_swap_before_exchange() {
+	// Arrange
+	let github_calls = Arc::new(AtomicUsize::new(0));
+	let google_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new("github", github_calls.clone())));
+	backend.register_provider(Arc::new(TestProvider::new("google", google_calls.clone())));
+	let authorization = backend
+		.begin_auth_with_context("github", None, None, b"browser-a", Vec::new())
+		.await
+		.unwrap();
+
+	// Act
+	let result = backend
+		.handle_callback_with_context(
+			"google",
+			"provider-code",
+			&authorization.state,
+			b"browser-a",
+		)
+		.await;
+
+	// Assert
+	assert!(matches!(result, Err(SocialAuthError::InvalidState)));
+	assert_eq!(github_calls.load(Ordering::SeqCst), 0);
+	assert_eq!(google_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn contextual_begin_rejects_empty_binding() {
+	let backend = SocialAuthBackend::new();
+
+	let result = backend
+		.begin_auth_with_context("missing", None, None, b"", Vec::new())
+		.await;
+
+	assert!(matches!(result, Err(SocialAuthError::StateValidation(_))));
+}
+
+#[tokio::test]
+async fn contextual_callback_rejects_empty_binding_without_consuming_state() {
+	// Arrange
+	let exchange_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new(
+		"github",
+		exchange_calls.clone(),
+	)));
+	let authorization = backend
+		.begin_auth_with_context("github", None, None, b"browser-a", Vec::new())
+		.await
+		.unwrap();
+
+	// Act
+	let empty_binding = backend
+		.handle_callback_with_context("github", "code", &authorization.state, b"")
+		.await;
+	let valid_binding = backend
+		.handle_callback_with_context("github", "code", &authorization.state, b"browser-a")
+		.await;
+
+	// Assert
+	assert!(matches!(
+		empty_binding,
+		Err(SocialAuthError::StateValidation(_))
+	));
+	assert!(valid_binding.is_ok());
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn legacy_callback_still_succeeds() {
+	// Arrange
+	let exchange_calls = Arc::new(AtomicUsize::new(0));
+	let mut backend = SocialAuthBackend::new();
+	backend.register_provider(Arc::new(TestProvider::new(
+		"github",
+		exchange_calls.clone(),
+	)));
+	let authorization = backend
+		.begin_auth("github", None, Some("pkce-verifier".to_string()))
+		.await
+		.unwrap();
+
+	// Act
+	let result = backend
+		.handle_callback("github", "provider-code", &authorization.state)
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(result.token_response.access_token, "access-token");
+	assert_eq!(exchange_calls.load(Ordering::SeqCst), 1);
+}

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -231,6 +231,15 @@ Provides compile-time code generation for common patterns.
   - Documentation comments become field descriptions
   - Automatic required/optional field detection
 
+#### Shared DTOs
+
+- **`#[dto]`** - Target-neutral DTO validation boilerplate
+  - Emits the native-only `Validate` derive
+  - Wraps field-level `#[validate(...)]` attributes for WASM compatibility
+- **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
+  - Requires the consumer's `openapi` feature
+  - Leaves the plain `#[dto]` behavior unchanged
+
 #### Application Configuration
 
 - **`#[derive(AppConfig)]`** - AppConfig factory method generation

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -237,7 +237,7 @@ Provides compile-time code generation for common patterns.
   - Emits the native-only `Validate` derive
   - Wraps `#[validate(...)]` and `#[schema(...)]` attributes for WASM compatibility
 - **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
-  - Requires the consumer's `openapi` feature
+  - Requires the consumer's `openapi` feature, which also enables the core validation surface
   - Supports native-only container and field `#[schema(...)]` customizations
   - Leaves the plain `#[dto]` behavior unchanged
 

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -235,9 +235,10 @@ Provides compile-time code generation for common patterns.
 
 - **`#[dto]`** - Target-neutral DTO validation boilerplate
   - Emits the native-only `Validate` derive
-  - Wraps field-level `#[validate(...)]` attributes for WASM compatibility
+  - Wraps `#[validate(...)]` and `#[schema(...)]` attributes for WASM compatibility
 - **`#[dto(schema)]`** - Opts the DTO into native-only OpenAPI `Schema` generation
   - Requires the consumer's `openapi` feature
+  - Supports native-only container and field `#[schema(...)]` customizations
   - Leaves the plain `#[dto]` behavior unchanged
 
 #### Application Configuration

--- a/crates/reinhardt-core/macros/src/crate_paths.rs
+++ b/crates/reinhardt-core/macros/src/crate_paths.rs
@@ -222,6 +222,20 @@ pub(crate) fn get_reinhardt_openapi_crate() -> TokenStream {
 	quote!(::reinhardt_openapi)
 }
 
+/// Resolves the path to a directly referenced `reinhardt-rest` crate.
+pub(crate) fn get_reinhardt_rest_crate() -> Option<TokenStream> {
+	use proc_macro_crate::{FoundCrate, crate_name};
+
+	match crate_name("reinhardt-rest") {
+		Ok(FoundCrate::Itself) => Some(quote!(crate)),
+		Ok(FoundCrate::Name(name)) => {
+			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+			Some(quote!(::#ident))
+		}
+		Err(_) => None,
+	}
+}
+
 /// Resolves the path to the reinhardt_db crate dynamically.
 pub(crate) fn get_reinhardt_db_crate() -> TokenStream {
 	use proc_macro_crate::{FoundCrate, crate_name};

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -4,7 +4,7 @@
 //! between native (server) and wasm (client) builds. See the public-facing
 //! rustdoc on `crate::dto` in `lib.rs` for the user-facing contract.
 
-use crate::crate_paths::get_reinhardt_crate;
+use crate::crate_paths::{get_reinhardt_crate, get_reinhardt_rest_crate};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -30,6 +30,11 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	let reinhardt = get_reinhardt_crate();
 	let schema_path: Path = parse_quote!(#reinhardt::rest::openapi::Schema);
+	let direct_rest_schema_path = if with_schema {
+		get_reinhardt_rest_crate().map(|rest| parse_quote!(#rest::openapi::Schema))
+	} else {
+		None
+	};
 	let first_schema_attr = input
 		.attrs
 		.iter()
@@ -77,9 +82,18 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
+	// Native `cfg_attr` derives can reach this macro as ordinary derives after
+	// the compiler evaluates the `native` predicate. Recognized qualified paths
+	// must suppress the generated Schema derive in that form as well.
+	let has_unconditional_schema = if with_schema {
+		find_unconditional_derive(&input.attrs, |path| {
+			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
+		})?
+	} else {
+		None
+	};
 	if with_schema
-		&& let Some(attr) =
-			find_unconditional_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?
+		&& let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Schema"))?
 	{
 		return Err(syn::Error::new_spanned(
 			attr,
@@ -90,7 +104,10 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	let needs_validate = !has_native_derive(&input.attrs, is_validate_derive)?;
 	let needs_schema = with_schema
-		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
+		&& has_unconditional_schema.is_none()
+		&& !has_native_derive(&input.attrs, |path| {
+			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
+		})?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
@@ -195,8 +212,14 @@ where
 	Ok(false)
 }
 
-fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
-	path.is_ident("Schema") || path.segments == schema_path.segments
+fn is_schema_derive(
+	path: &Path,
+	schema_path: &Path,
+	direct_rest_schema_path: Option<&Path>,
+) -> bool {
+	path.is_ident("Schema")
+		|| path.segments == schema_path.segments
+		|| direct_rest_schema_path.is_some_and(|candidate| path.segments == candidate.segments)
 }
 
 fn is_validate_derive(path: &Path) -> bool {
@@ -214,11 +237,22 @@ mod tests {
 		let expected: Path = parse_quote!(::reinhardt::rest::openapi::Schema);
 		let unqualified: Path = parse_quote!(Schema);
 		let qualified: Path = parse_quote!(reinhardt::rest::openapi::Schema);
+		let direct_rest: Path = parse_quote!(reinhardt_rest::openapi::Schema);
 		let unrelated: Path = parse_quote!(other_crate::Schema);
 
-		assert!(is_schema_derive(&unqualified, &expected));
-		assert!(is_schema_derive(&qualified, &expected));
-		assert!(!is_schema_derive(&unrelated, &expected));
+		assert!(is_schema_derive(
+			&unqualified,
+			&expected,
+			Some(&direct_rest)
+		));
+		assert!(is_schema_derive(&qualified, &expected, Some(&direct_rest)));
+		assert!(is_schema_derive(
+			&direct_rest,
+			&expected,
+			Some(&direct_rest)
+		));
+		assert!(!is_schema_derive(&direct_rest, &expected, None));
+		assert!(!is_schema_derive(&unrelated, &expected, Some(&direct_rest)));
 	}
 
 	#[test]

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -29,6 +29,16 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	};
 
 	let reinhardt = get_reinhardt_crate();
+	let first_schema_attr = input
+		.attrs
+		.iter()
+		.position(|attr| attr.path().is_ident("schema"));
+
+	for attr in &mut input.attrs {
+		if attr.path().is_ident("schema") {
+			*attr = wrap_in_cfg_attr_native(attr);
+		}
+	}
 
 	let fields = match &mut input.data {
 		Data::Struct(s) => match &mut s.fields {
@@ -47,7 +57,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	if let Some(fields) = fields {
 		for field in fields.iter_mut() {
 			for attr in field.attrs.iter_mut() {
-				if attr.path().is_ident("validate") {
+				if attr.path().is_ident("validate") || attr.path().is_ident("schema") {
 					*attr = wrap_in_cfg_attr_native(attr);
 				}
 			}
@@ -87,7 +97,11 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 
 	if !derives.is_empty() {
 		let new_attr: Attribute = parse_quote!(#[cfg_attr(native, derive(#derives))]);
-		input.attrs.push(new_attr);
+		if let Some(index) = first_schema_attr {
+			input.attrs.insert(index, new_attr);
+		} else {
+			input.attrs.push(new_attr);
+		}
 	}
 
 	let to_schema_import = if with_schema {

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -69,7 +69,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
 	// native builds.
-	if let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Validate"))? {
+	if let Some(attr) = find_unconditional_derive(&input.attrs, is_validate_derive)? {
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto] cannot be combined with unconditional `#[derive(Validate)]`. \
@@ -88,7 +88,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		));
 	}
 
-	let needs_validate = !has_native_derive(&input.attrs, |path| path.is_ident("Validate"))?;
+	let needs_validate = !has_native_derive(&input.attrs, is_validate_derive)?;
 	let needs_schema = with_schema
 		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
 
@@ -199,6 +199,12 @@ fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
 	path.is_ident("Schema") || path.segments == schema_path.segments
 }
 
+fn is_validate_derive(path: &Path) -> bool {
+	path.segments
+		.last()
+		.is_some_and(|segment| segment.ident == "Validate")
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -213,5 +219,16 @@ mod tests {
 		assert!(is_schema_derive(&unqualified, &expected));
 		assert!(is_schema_derive(&qualified, &expected));
 		assert!(!is_schema_derive(&unrelated, &expected));
+	}
+
+	#[test]
+	fn validate_derive_matching_accepts_qualified_paths() {
+		let unqualified: Path = parse_quote!(Validate);
+		let qualified: Path = parse_quote!(reinhardt_macros::Validate);
+		let unrelated: Path = parse_quote!(other_crate::Schema);
+
+		assert!(is_validate_derive(&unqualified));
+		assert!(is_validate_derive(&qualified));
+		assert!(!is_validate_derive(&unrelated));
 	}
 }

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -13,12 +13,20 @@ use syn::{
 };
 
 pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<TokenStream> {
-	if !args.is_empty() {
-		return Err(syn::Error::new_spanned(
-			args,
-			"#[dto] does not accept arguments in this version",
-		));
-	}
+	let with_schema = if args.is_empty() {
+		false
+	} else {
+		let option: syn::Ident = syn::parse2(args.clone()).map_err(|_| {
+			syn::Error::new_spanned(args.clone(), "#[dto] accepts only the `schema` option")
+		})?;
+		if option != "schema" {
+			return Err(syn::Error::new_spanned(
+				option,
+				"#[dto] accepts only the `schema` option",
+			));
+		}
+		true
+	};
 
 	let reinhardt = get_reinhardt_crate();
 
@@ -49,8 +57,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// Reject unconditional `#[derive(Validate)]` upfront. `Validate` lives
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
-	// native builds. OpenAPI `Schema` is intentionally not emitted implicitly:
-	// it pulls in the OpenAPI feature graph and must remain an explicit opt-in.
+	// native builds.
 	if let Some(attr) = find_unconditional_derive(&input.attrs, "Validate")? {
 		return Err(syn::Error::new_spanned(
 			attr,
@@ -59,12 +66,23 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
+	if with_schema && let Some(attr) = find_unconditional_derive(&input.attrs, "Schema")? {
+		return Err(syn::Error::new_spanned(
+			attr,
+			"#[dto(schema)] cannot be combined with `#[derive(Schema)]`. \
+			 Remove the derive because #[dto(schema)] emits it for native builds.",
+		));
+	}
 
 	let needs_validate = !has_native_derive(&input.attrs, "Validate")?;
+	let needs_schema = with_schema && !has_native_derive(&input.attrs, "Schema")?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
 		derives.push(parse_quote!(#reinhardt::Validate));
+	}
+	if needs_schema {
+		derives.push(parse_quote!(#reinhardt::rest::openapi::Schema));
 	}
 
 	if !derives.is_empty() {
@@ -72,8 +90,20 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		input.attrs.push(new_attr);
 	}
 
+	let to_schema_import = if with_schema {
+		quote! {
+			#[cfg(native)]
+			// The generated Schema implementation uses trait-method syntax at module scope.
+			#[allow(unused_imports)]
+			use #reinhardt::rest::openapi::ToSchema as _;
+		}
+	} else {
+		quote! {}
+	};
+
 	Ok(quote! {
 		#input
+		#to_schema_import
 	})
 }
 

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -42,7 +42,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			Fields::Named(fields) => {
 				for field in &mut fields.named {
 					for attr in &mut field.attrs {
-						if attr.path().is_ident("schema") {
+						if with_schema && attr.path().is_ident("schema") {
 							*attr = wrap_in_cfg_attr_native(attr);
 						}
 					}
@@ -75,13 +75,6 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		.attrs
 		.iter()
 		.position(|attr| attr.path().is_ident("schema"));
-	let has_unconditional_schema = if with_schema {
-		find_unconditional_derive(&input.attrs, |path| {
-			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
-		})?
-	} else {
-		None
-	};
 	if with_schema
 		&& let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Schema"))?
 	{
@@ -91,9 +84,14 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 Remove the derive because #[dto(schema)] emits it for native builds.",
 		));
 	}
+	if with_schema {
+		gate_unconditional_derives(&mut input.attrs, |path| {
+			!path.is_ident("Schema")
+				&& is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
+		})?;
+	}
 
 	let needs_schema = with_schema
-		&& has_unconditional_schema.is_none()
 		&& !has_native_derive(&input.attrs, |path| {
 			is_schema_derive(path, &schema_path, direct_rest_schema_path.as_ref())
 		})?;
@@ -108,7 +106,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	}
 
 	for attr in &mut input.attrs {
-		if attr.path().is_ident("schema") {
+		if with_schema && attr.path().is_ident("schema") {
 			*attr = wrap_in_cfg_attr_native(attr);
 		}
 	}
@@ -191,6 +189,46 @@ where
 		}
 	}
 	Ok(false)
+}
+
+fn gate_unconditional_derives<F>(attrs: &mut Vec<Attribute>, matches: F) -> Result<()>
+where
+	F: Fn(&Path) -> bool,
+{
+	let mut normalized = Vec::with_capacity(attrs.len());
+
+	for attr in attrs.drain(..) {
+		if !attr.path().is_ident("derive") {
+			normalized.push(attr);
+			continue;
+		}
+		let Meta::List(list) = &attr.meta else {
+			normalized.push(attr);
+			continue;
+		};
+		let derives =
+			Punctuated::<Path, Token![,]>::parse_terminated.parse2(list.tokens.clone())?;
+		let mut shared = Punctuated::<Path, Token![,]>::new();
+		let mut native = Punctuated::<Path, Token![,]>::new();
+		for derive in derives {
+			if matches(&derive) {
+				native.push(derive);
+			} else {
+				shared.push(derive);
+			}
+		}
+		if native.is_empty() {
+			normalized.push(attr);
+			continue;
+		}
+		if !shared.is_empty() {
+			normalized.push(parse_quote!(#[derive(#shared)]));
+		}
+		normalized.push(parse_quote!(#[cfg_attr(native, derive(#native))]));
+	}
+
+	*attrs = normalized;
+	Ok(())
 }
 
 fn remove_native_validate_derives(attrs: &mut Vec<Attribute>, trait_name: &str) -> Result<()> {
@@ -309,5 +347,73 @@ mod tests {
 		assert!(is_validate_derive(&unqualified));
 		assert!(is_validate_derive(&qualified));
 		assert!(!is_validate_derive(&unrelated));
+	}
+
+	#[test]
+	fn plain_dto_keeps_schema_attributes_unconditional() {
+		let input: DeriveInput = parse_quote! {
+			#[schema(title = "Request")]
+			struct Request {
+				#[schema(description = "Name")]
+				name: String,
+			}
+		};
+
+		let output: DeriveInput =
+			syn::parse2(dto_impl(TokenStream::new(), input).unwrap()).unwrap();
+		assert_eq!(
+			output
+				.attrs
+				.iter()
+				.filter(|attr| attr.path().is_ident("schema"))
+				.count(),
+			1
+		);
+		let Data::Struct(data) = output.data else {
+			panic!("DTO output should remain a struct");
+		};
+		let Fields::Named(fields) = data.fields else {
+			panic!("DTO output should retain named fields");
+		};
+		assert_eq!(
+			fields.named[0]
+				.attrs
+				.iter()
+				.filter(|attr| attr.path().is_ident("schema"))
+				.count(),
+			1
+		);
+	}
+
+	#[test]
+	fn schema_dto_gates_qualified_unconditional_schema_derive() {
+		let input: DeriveInput = parse_quote! {
+			#[derive(Clone, reinhardt_core::rest::openapi::Schema)]
+			struct Request {
+				name: String,
+			}
+		};
+
+		let output: syn::File =
+			syn::parse2(dto_impl(parse_quote!(schema), input).unwrap()).unwrap();
+		let syn::Item::Struct(item) = &output.items[0] else {
+			panic!("DTO output should remain a struct");
+		};
+		let expected: Path = parse_quote!(::reinhardt_core::rest::openapi::Schema);
+		assert_eq!(
+			find_unconditional_derive(&item.attrs, |path| {
+				is_schema_derive(path, &expected, None)
+			})
+			.unwrap()
+			.is_none(),
+			true
+		);
+		assert_eq!(
+			has_native_derive(&item.attrs, |path| {
+				is_schema_derive(path, &expected, None)
+			})
+			.unwrap(),
+			true
+		);
 	}
 }

--- a/crates/reinhardt-core/macros/src/dto.rs
+++ b/crates/reinhardt-core/macros/src/dto.rs
@@ -29,6 +29,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	};
 
 	let reinhardt = get_reinhardt_crate();
+	let schema_path: Path = parse_quote!(#reinhardt::rest::openapi::Schema);
 	let first_schema_attr = input
 		.attrs
 		.iter()
@@ -68,7 +69,7 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 	// behind the `native` cfg, so an unconditional derive cannot resolve on wasm
 	// builds and would duplicate the macro's `cfg_attr(native, derive(...))` on
 	// native builds.
-	if let Some(attr) = find_unconditional_derive(&input.attrs, "Validate")? {
+	if let Some(attr) = find_unconditional_derive(&input.attrs, |path| path.is_ident("Validate"))? {
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto] cannot be combined with unconditional `#[derive(Validate)]`. \
@@ -76,7 +77,10 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 			 or replace it with `#[cfg_attr(native, derive(Validate))]`.",
 		));
 	}
-	if with_schema && let Some(attr) = find_unconditional_derive(&input.attrs, "Schema")? {
+	if with_schema
+		&& let Some(attr) =
+			find_unconditional_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?
+	{
 		return Err(syn::Error::new_spanned(
 			attr,
 			"#[dto(schema)] cannot be combined with `#[derive(Schema)]`. \
@@ -84,8 +88,9 @@ pub(crate) fn dto_impl(args: TokenStream, mut input: DeriveInput) -> Result<Toke
 		));
 	}
 
-	let needs_validate = !has_native_derive(&input.attrs, "Validate")?;
-	let needs_schema = with_schema && !has_native_derive(&input.attrs, "Schema")?;
+	let needs_validate = !has_native_derive(&input.attrs, |path| path.is_ident("Validate"))?;
+	let needs_schema = with_schema
+		&& !has_native_derive(&input.attrs, |path| is_schema_derive(path, &schema_path))?;
 
 	let mut derives: Punctuated<Path, Token![,]> = Punctuated::new();
 	if needs_validate {
@@ -126,16 +131,13 @@ fn wrap_in_cfg_attr_native(attr: &Attribute) -> Attribute {
 	parse_quote!(#[cfg_attr(native, #meta)])
 }
 
-/// Returns the first unconditional `#[derive(... TraitName ...)]` attribute on
-/// `attrs`, if any. Used to detect derives that would clash with the
-/// macro-emitted `cfg_attr(native, derive(...))`.
-///
-/// Path matching is by the last segment's identifier, mirroring `has_native_derive`,
-/// so both `Validate` and `validator::Validate`-style paths are caught.
-fn find_unconditional_derive<'a>(
-	attrs: &'a [Attribute],
-	trait_name: &str,
-) -> Result<Option<&'a Attribute>> {
+/// Returns the first unconditional derive matching `matches` on `attrs`, if any.
+/// Used to detect derives that would clash with the macro-emitted
+/// `cfg_attr(native, derive(...))`.
+fn find_unconditional_derive<F>(attrs: &[Attribute], matches: F) -> Result<Option<&Attribute>>
+where
+	F: Fn(&Path) -> bool,
+{
 	for attr in attrs {
 		if !attr.path().is_ident("derive") {
 			continue;
@@ -145,21 +147,21 @@ fn find_unconditional_derive<'a>(
 		};
 		let derives =
 			Punctuated::<Path, Token![,]>::parse_terminated.parse2(list.tokens.clone())?;
-		if derives
-			.iter()
-			.any(|p| p.segments.last().is_some_and(|seg| seg.ident == trait_name))
-		{
+		if derives.iter().any(&matches) {
 			return Ok(Some(attr));
 		}
 	}
 	Ok(None)
 }
 
-/// Returns true if `attrs` already contains `#[cfg_attr(native, derive(... TraitName ...))]`.
+/// Returns true if `attrs` already contains a matching native derive.
 ///
 /// Only inspects the `native` cfg branch — unconditional `#[derive(TraitName)]`
 /// is handled separately by `find_unconditional_derive` and reported as an error.
-fn has_native_derive(attrs: &[Attribute], trait_name: &str) -> Result<bool> {
+fn has_native_derive<F>(attrs: &[Attribute], matches: F) -> Result<bool>
+where
+	F: Fn(&Path) -> bool,
+{
 	for attr in attrs {
 		if !attr.path().is_ident("cfg_attr") {
 			continue;
@@ -185,13 +187,31 @@ fn has_native_derive(attrs: &[Attribute], trait_name: &str) -> Result<bool> {
 			}
 			let derives = Punctuated::<Path, Token![,]>::parse_terminated
 				.parse2(inner_list.tokens.clone())?;
-			if derives
-				.iter()
-				.any(|p| p.segments.last().is_some_and(|seg| seg.ident == trait_name))
-			{
+			if derives.iter().any(&matches) {
 				return Ok(true);
 			}
 		}
 	}
 	Ok(false)
+}
+
+fn is_schema_derive(path: &Path, schema_path: &Path) -> bool {
+	path.is_ident("Schema") || path.segments == schema_path.segments
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn schema_derive_matching_rejects_unrelated_paths() {
+		let expected: Path = parse_quote!(::reinhardt::rest::openapi::Schema);
+		let unqualified: Path = parse_quote!(Schema);
+		let qualified: Path = parse_quote!(reinhardt::rest::openapi::Schema);
+		let unrelated: Path = parse_quote!(other_crate::Schema);
+
+		assert!(is_schema_derive(&unqualified, &expected));
+		assert!(is_schema_derive(&qualified, &expected));
+		assert!(!is_schema_derive(&unrelated, &expected));
+	}
 }

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1056,7 +1056,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///
 /// 1. Emits `#[cfg_attr(native, derive(::reinhardt::Validate))]`
 ///    on the struct so the server build gets validation while the wasm build
-///    sees a plain serializable type.
+///    sees a plain serializable type. With the explicit `schema` option, it
+///    also emits `::reinhardt::rest::openapi::Schema` on native builds.
 /// 2. Wraps every `#[validate(...)]` field attribute in `#[cfg_attr(native, ...)]`
 ///    so the same source compiles unchanged for `wasm32-unknown-unknown`.
 /// 3. Is idempotent: if the user already wrote
@@ -1073,7 +1074,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// | What | A persistent record | A wire-level data shape |
 /// | Where it lives | `apps/<app>/models/*.rs` | `apps/<app>/shared/types.rs` |
 /// | Where it runs | Server only (`native`) | Both server (`native`) and client (`wasm`) |
-/// | What it adds | Table mapping, primary key, FK fields, migrations | `Validate` derive (native-only), wraps `#[validate(...)]` |
+/// | What it adds | Table mapping, primary key, FK fields, migrations | `Validate` derive (native-only), optional `Schema` derive, wraps `#[validate(...)]` |
 /// | Boundary it crosses | Rust ↔ database | Server ↔ client (via `#[server_fn]`, REST handlers, WebSocket payloads) |
 ///
 /// "DTO" is the industry-standard term for the second row — a data-transfer
@@ -1086,7 +1087,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// use reinhardt::dto;
 /// use serde::{Deserialize, Serialize};
 ///
-/// #[dto]
+/// #[dto(schema)]
 /// #[derive(Debug, Clone, Serialize, Deserialize)]
 /// pub struct LoginRequest {
 ///     #[validate(email(message = "Invalid email address"))]
@@ -1100,7 +1101,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// Expands (conceptually) to:
 ///
 /// ```rust,ignore
-/// #[cfg_attr(native, derive(::reinhardt::Validate))]
+/// #[cfg_attr(native, derive(::reinhardt::Validate, ::reinhardt::rest::openapi::Schema))]
 /// #[derive(Debug, Clone, Serialize, Deserialize)]
 /// pub struct LoginRequest {
 ///     #[cfg_attr(native, validate(email(message = "Invalid email address")))]
@@ -1113,18 +1114,23 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///
 /// # Requirements
 ///
-/// - OpenAPI schema generation is not implicit. If a DTO should be part of
-///   generated OpenAPI documentation, explicitly add a `Schema` derive in a
-///   build that enables the OpenAPI feature graph.
+/// - OpenAPI schema generation is not implicit. Add `schema` as an explicit
+///   option (`#[dto(schema)]`) for a DTO that should be part of generated
+///   OpenAPI documentation. The consumer's native build must enable the
+///   `openapi` feature.
 /// - Applies only to `struct` items (named, tuple, or unit). Enums and unions
+///   produce a compile error. The `schema` option additionally requires named
+///   fields because the OpenAPI `Schema` derive does not support tuple or unit
+///   structs.
+/// - The only supported argument is the bare `schema` option. Other arguments
 ///   produce a compile error.
-/// - Does not accept arguments in this version. Passing any tokens (e.g.
-///   `#[dto(no_schema)]`) is a compile error.
-/// - Unconditional `#[derive(Validate)]` on the same struct is a compile
-///   error. `Validate` lives behind the `native` cfg, so an unconditional
-///   derive cannot resolve on wasm and would duplicate the macro's emission on
-///   native. Either delete the derive (and let `#[dto]` emit it) or wrap it in
-///   `#[cfg_attr(native, derive(Validate))]` yourself.
+/// - Unconditional `#[derive(Validate)]` is a compile error. `Validate` lives
+///   behind the `native` cfg, so an unconditional derive cannot resolve on wasm
+///   and would duplicate the macro's emission on native. Either delete the
+///   derive (and let `#[dto]` emit it) or wrap it in
+///   `#[cfg_attr(native, derive(Validate))]` yourself. When using
+///   `#[dto(schema)]`, do not add a separate `Schema` derive because the
+///   option emits it for native builds.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear
@@ -1134,7 +1140,7 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   ordering:
 ///
 /// ```rust,ignore
-/// #[dto]
+/// #[dto(schema)]
 /// #[cfg_attr(native, derive(Validate))]
 /// pub struct LoginRequest { /* ... */ }
 /// ```

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1265,8 +1265,9 @@ pub fn derive_model_enum(input: TokenStream) -> TokenStream {
 /// - Existing `Validate` derives may use a qualified path; the final path
 ///   segment is used when checking for an existing derive.
 /// - With `#[dto(schema)]`, a bare separate `#[derive(Schema)]` is rejected.
-///   Existing qualified facade or directly referenced
-///   `reinhardt_rest::openapi::Schema` derives are recognized and not duplicated.
+///   Qualified facade and directly referenced
+///   `reinhardt_rest::openapi::Schema` derives are normalized to native-only
+///   `cfg_attr` derives.
 ///
 /// ```rust,ignore
 /// #[dto(schema)]

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1058,8 +1058,9 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///    on the struct so the server build gets validation while the wasm build
 ///    sees a plain serializable type. With the explicit `schema` option, it
 ///    also emits `::reinhardt::rest::openapi::Schema` on native builds.
-/// 2. Wraps every `#[validate(...)]` field attribute in `#[cfg_attr(native, ...)]`
-///    so the same source compiles unchanged for `wasm32-unknown-unknown`.
+/// 2. Wraps every `#[validate(...)]` and `#[schema(...)]` attribute in
+///    `#[cfg_attr(native, ...)]` so the same source compiles unchanged for
+///    `wasm32-unknown-unknown`.
 /// 3. Is idempotent: if the user already wrote
 ///    `#[cfg_attr(native, derive(Validate))]` on the struct, that derive is
 ///    not duplicated.

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1132,6 +1132,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   `#[cfg_attr(native, derive(Validate))]` yourself. When using
 ///   `#[dto(schema)]`, do not add a separate `Schema` derive because the
 ///   option emits it for native builds.
+/// - Existing `Validate` derives may use a qualified path; the final path
+///   segment is used when checking for an existing derive.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -1134,6 +1134,8 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 ///   option emits it for native builds.
 /// - Existing `Validate` derives may use a qualified path; the final path
 ///   segment is used when checking for an existing derive.
+/// - Existing `Schema` derives may use the facade path or a directly referenced
+///   `reinhardt_rest::openapi::Schema` path.
 /// - Any pre-existing `#[cfg_attr(native, derive(Validate))]` MUST be written
 ///   *below* `#[dto]`,
 ///   not above it. Attribute proc macros only observe attributes that appear

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -32,6 +32,13 @@ fn dto_schema_option_compiles_and_generates_native_schema() {
 	);
 	let repo_root_toml = serde_json::to_string(&repo_root.to_string_lossy().into_owned())
 		.expect("escape repository root for TOML");
+	let rest_root_toml = serde_json::to_string(
+		&repo_root
+			.join("crates/reinhardt-rest")
+			.to_string_lossy()
+			.into_owned(),
+	)
+	.expect("escape reinhardt-rest root for TOML");
 
 	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
 	fs::write(
@@ -47,8 +54,10 @@ publish = false
 
 [dependencies]
 reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["openapi"] }}
+reinhardt_rest = {{ path = {}, package = "reinhardt-rest", default-features = false, features = ["openapi"] }}
 "#,
-			repo_root_toml
+			repo_root_toml,
+			rest_root_toml
 		),
 	)
 	.expect("write fixture manifest");
@@ -81,9 +90,16 @@ struct Profile {
 	display_name: String,
 }
 
+#[dto(schema)]
+#[cfg_attr(native, derive(reinhardt_rest::openapi::Schema))]
+struct DirectRestSchema {
+	name: String,
+}
+
 fn main() {
 	assert_eq!(LoginRequest::schema_name(), Some(String::from("LoginRequest")));
 	assert_eq!(Profile::schema_name(), Some(String::from("Profile")));
+	assert_eq!(DirectRestSchema::schema_name(), Some(String::from("DirectRestSchema")));
 }
 "#,
 	)

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
@@ -7,10 +7,31 @@ fn dto_schema_option_compiles_and_generates_native_schema() {
 	let crate_dir = tempfile::tempdir().expect("create temporary fixture directory");
 	let target_dir = tempfile::tempdir().expect("create temporary target directory");
 	let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-	let repo_root = manifest_dir
-		.join("../../..")
-		.canonicalize()
-		.expect("resolve repository root");
+	let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+	let metadata = Command::new(&cargo)
+		.arg("metadata")
+		.arg("--manifest-path")
+		.arg(manifest_dir.join("Cargo.toml"))
+		.arg("--no-deps")
+		.arg("--offline")
+		.arg("--format-version")
+		.arg("1")
+		.output()
+		.expect("resolve workspace metadata");
+	assert!(
+		metadata.status.success(),
+		"workspace metadata should resolve\nstderr:\n{}",
+		String::from_utf8_lossy(&metadata.stderr),
+	);
+	let metadata: serde_json::Value =
+		serde_json::from_slice(&metadata.stdout).expect("parse workspace metadata");
+	let repo_root = PathBuf::from(
+		metadata["workspace_root"]
+			.as_str()
+			.expect("workspace metadata should include an absolute root"),
+	);
+	let repo_root_toml = serde_json::to_string(&repo_root.to_string_lossy().into_owned())
+		.expect("escape repository root for TOML");
 
 	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
 	fs::write(
@@ -25,10 +46,9 @@ publish = false
 [workspace]
 
 [dependencies]
-reinhardt = {{ path = "{}", package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
-inventory = "0.3"
+reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
 "#,
-			repo_root.display()
+			repo_root_toml
 		),
 	)
 	.expect("write fixture manifest");
@@ -48,7 +68,9 @@ inventory = "0.3"
 use reinhardt::dto;
 
 #[dto(schema)]
+#[schema(title = "Login request")]
 struct LoginRequest {
+	#[schema(description = "Username")]
 	username: String,
 }
 
@@ -65,7 +87,7 @@ fn main() {
 	)
 	.expect("write fixture source");
 
-	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+	let output = Command::new(&cargo)
 		.arg("check")
 		.arg("--manifest-path")
 		.arg(crate_dir.path().join("Cargo.toml"))

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -1,0 +1,84 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn dto_schema_option_compiles_and_generates_native_schema() {
+	let crate_dir = tempfile::tempdir().expect("create temporary fixture directory");
+	let target_dir = tempfile::tempdir().expect("create temporary target directory");
+	let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let repo_root = manifest_dir
+		.join("../../..")
+		.canonicalize()
+		.expect("resolve repository root");
+
+	fs::create_dir(crate_dir.path().join("src")).expect("create fixture src directory");
+	fs::write(
+		crate_dir.path().join("Cargo.toml"),
+		format!(
+			r#"[package]
+name = "reinhardt-dto-schema-parity-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+reinhardt = {{ path = "{}", package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
+inventory = "0.3"
+"#,
+			repo_root.display()
+		),
+	)
+	.expect("write fixture manifest");
+	fs::write(
+		crate_dir.path().join("build.rs"),
+		r#"fn main() {
+	println!("cargo::rustc-check-cfg=cfg(native)");
+	println!("cargo::rustc-cfg=native");
+}
+"#,
+	)
+	.expect("write fixture build script");
+	fs::write(
+		crate_dir.path().join("src/main.rs"),
+		r#"#![deny(unexpected_cfgs)]
+
+use reinhardt::dto;
+
+#[dto(schema)]
+struct LoginRequest {
+	username: String,
+}
+
+#[dto(schema)]
+struct Profile {
+	display_name: String,
+}
+
+fn main() {
+	assert_eq!(LoginRequest::schema_name(), Some(String::from("LoginRequest")));
+	assert_eq!(Profile::schema_name(), Some(String::from("Profile")));
+}
+"#,
+	)
+	.expect("write fixture source");
+
+	let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+		.arg("check")
+		.arg("--manifest-path")
+		.arg(crate_dir.path().join("Cargo.toml"))
+		.arg("--target-dir")
+		.arg(target_dir.path())
+		.arg("--offline")
+		.output()
+		.expect("run native DTO schema parity fixture");
+
+	assert!(
+		output.status.success(),
+		"native DTO schema parity fixture should compile\nstdout:\n{}\nstderr:\n{}",
+		String::from_utf8_lossy(&output.stdout),
+		String::from_utf8_lossy(&output.stderr),
+	);
+}

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -46,7 +46,7 @@ publish = false
 [workspace]
 
 [dependencies]
-reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["core", "openapi"] }}
+reinhardt = {{ path = {}, package = "reinhardt-web", default-features = false, features = ["openapi"] }}
 "#,
 			repo_root_toml
 		),
@@ -70,8 +70,10 @@ use reinhardt::dto;
 #[dto(schema)]
 #[schema(title = "Login request")]
 struct LoginRequest {
-	#[schema(description = "Username")]
+	#[schema(description = "Username", example = "alice")]
 	username: String,
+	#[schema(default_value = "0")]
+	attempts: i64,
 }
 
 #[dto(schema)]

--- a/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
+++ b/crates/reinhardt-core/macros/tests/dto_schema_parity.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::process::Output;
 
 #[test]
 fn dto_schema_option_compiles_and_generates_native_schema() {
@@ -114,6 +115,18 @@ fn main() {
 		.arg("--offline")
 		.output()
 		.expect("run native DTO schema parity fixture");
+	let output = if output.status.success() || !offline_dependency_resolution_failed(&output) {
+		output
+	} else {
+		Command::new(&cargo)
+			.arg("check")
+			.arg("--manifest-path")
+			.arg(crate_dir.path().join("Cargo.toml"))
+			.arg("--target-dir")
+			.arg(target_dir.path())
+			.output()
+			.expect("run native DTO schema parity fixture without offline mode")
+	};
 
 	assert!(
 		output.status.success(),
@@ -121,4 +134,12 @@ fn main() {
 		String::from_utf8_lossy(&output.stdout),
 		String::from_utf8_lossy(&output.stderr),
 	);
+}
+
+fn offline_dependency_resolution_failed(output: &Output) -> bool {
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	stderr.contains("--offline")
+		|| stderr.contains("no matching package named")
+		|| stderr.contains("failed to download")
+		|| stderr.contains("candidate versions found which didn't match")
 }

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
@@ -1,0 +1,17 @@
+//! Verifies that `#[dto(schema)]` rejects an unconditional `Schema` derive.
+
+#![allow(unexpected_cfgs)]
+
+use reinhardt_macros::dto;
+
+// Synthetic name to test the attribute validation without requiring OpenAPI.
+#[derive()]
+pub struct Schema;
+
+#[dto(schema)]
+#[derive(Schema)]
+pub struct LoginRequest {
+	pub email: String,
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.rs
@@ -1,5 +1,7 @@
 //! Verifies that `#[dto(schema)]` rejects an unconditional `Schema` derive.
 
+// This standalone trybuild fixture intentionally exercises macro-generated
+// `cfg(native)` without the facade build script's `check-cfg` declaration.
 #![allow(unexpected_cfgs)]
 
 use reinhardt_macros::dto;

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
@@ -1,5 +1,5 @@
 error: #[dto(schema)] cannot be combined with `#[derive(Schema)]`. Remove the derive because #[dto(schema)] emits it for native builds.
-  --> tests/ui/dto/fail/unconditional_schema.rs:12:1
+  --> tests/ui/dto/fail/unconditional_schema.rs:14:1
    |
-12 | #[derive(Schema)]
+14 | #[derive(Schema)]
    | ^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/unconditional_schema.stderr
@@ -1,0 +1,5 @@
+error: #[dto(schema)] cannot be combined with `#[derive(Schema)]`. Remove the derive because #[dto(schema)] emits it for native builds.
+  --> tests/ui/dto/fail/unconditional_schema.rs:12:1
+   |
+12 | #[derive(Schema)]
+   | ^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.rs
@@ -1,4 +1,4 @@
-//! Verifies that `#[dto(...)]` rejects arguments in v1.
+//! Verifies that `#[dto(...)]` rejects options other than `schema`.
 
 use reinhardt_macros::dto;
 

--- a/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/dto/fail/with_args.stderr
@@ -1,4 +1,4 @@
-error: #[dto] does not accept arguments in this version
+error: #[dto] accepts only the `schema` option
  --> tests/ui/dto/fail/with_args.rs:5:7
   |
 5 | #[dto(no_schema)]

--- a/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
@@ -1,13 +1,17 @@
 //! Verifies that `#[dto(schema)]` is accepted and remains inert on non-native
 //! builds, where the OpenAPI feature graph is intentionally unavailable.
 
+// This standalone trybuild fixture intentionally exercises macro-generated
+// `cfg(native)` without the facade build script's `check-cfg` declaration.
 #![allow(unexpected_cfgs)]
 
 use reinhardt_macros::dto;
 
 #[dto(schema)]
+#[schema(title = "Login request")]
 pub struct LoginRequest {
 	#[validate(length(min = 1))]
+	#[schema(description = "Email address")]
 	pub email: String,
 	pub password: String,
 }

--- a/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
+++ b/crates/reinhardt-core/macros/tests/ui/dto/pass/schema_opt_in.rs
@@ -1,0 +1,20 @@
+//! Verifies that `#[dto(schema)]` is accepted and remains inert on non-native
+//! builds, where the OpenAPI feature graph is intentionally unavailable.
+
+#![allow(unexpected_cfgs)]
+
+use reinhardt_macros::dto;
+
+#[dto(schema)]
+pub struct LoginRequest {
+	#[validate(length(min = 1))]
+	pub email: String,
+	pub password: String,
+}
+
+fn main() {
+	let _ = LoginRequest {
+		email: String::from("user@example.com"),
+		password: String::from("password"),
+	};
+}

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -30,8 +30,11 @@ sqlx = ["dep:sqlx"]
 # Redis-backed session storage
 session-redis = ["sessions", "dep:redis"]
 
+# Async session-backed social authentication state
+social-auth = ["sessions", "reinhardt-auth/social"]
+
 # Aggregate all middleware features
-full = ["broken-link-email", "cors", "compression", "security", "rate-limit", "sessions", "auth-jwt", "sqlx", "session-redis"]
+full = ["broken-link-email", "cors", "compression", "security", "rate-limit", "sessions", "auth-jwt", "sqlx", "session-redis", "social-auth"]
 
 # Test-only fixtures shared between the in-crate unit tests and external
 # integration tests (Issue #4462). Enabled implicitly when `cargo make test`

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -352,3 +352,25 @@ pub async fn logout(
     Ok(())
 }
 ```
+
+## Async Social OAuth State
+
+Enable `social-auth` for the async session adapter and add `session-redis` when
+the backing store is Redis. The adapter stores contextual OAuth state as a
+short-lived session and consumes it atomically through the backend's
+`AtomicSessionBackend` capability.
+
+```rust,ignore
+use reinhardt_auth::social::SocialAuthBackend;
+use reinhardt_middleware::session::AsyncSessionStateStore;
+use reinhardt_middleware::RedisSessionBackend;
+use std::sync::Arc;
+
+let redis = RedisSessionBackend::new_from_url("redis://127.0.0.1/")?;
+let state_store = AsyncSessionStateStore::new(redis);
+let backend = SocialAuthBackend::with_state_store(Arc::new(state_store));
+```
+
+Redis-backed atomic consumption uses `GETDEL` and therefore requires Redis
+6.2 or later. Store only opaque, non-secret context; the application owns the
+browser/session binding transport and cookie security settings.

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -253,6 +253,8 @@ pub use remote_user::{PersistentRemoteUserMiddleware, REMOTE_USER_HEADER, Remote
 pub use request_id::{REQUEST_ID_HEADER, RequestIdConfig, RequestIdMiddleware};
 #[cfg(feature = "security")]
 pub use security_middleware::SecurityMiddleware;
+#[cfg(feature = "social-auth")]
+pub use session::AsyncSessionStateStore;
 pub use session::{SessionConfig, SessionData, SessionMiddleware, SessionStore};
 pub use site::{SITE_ID_HEADER, Site, SiteConfig, SiteMiddleware, SiteRegistry};
 pub use timeout::{TimeoutConfig, TimeoutMiddleware};

--- a/crates/reinhardt-middleware/src/lib.rs
+++ b/crates/reinhardt-middleware/src/lib.rs
@@ -57,6 +57,7 @@
 //! ### Session & State
 //!
 //! - **[`SessionMiddleware`]**: Session management with pluggable storage backends
+//! - **`AsyncSessionStateStore`**: Atomic session-backed social OAuth state (requires `social-auth`)
 //! - **[`SiteMiddleware`]**: Multi-site support with site identification
 //! - **[`LocaleMiddleware`]**: Internationalization and locale detection
 //!

--- a/crates/reinhardt-middleware/src/redis_session.rs
+++ b/crates/reinhardt-middleware/src/redis_session.rs
@@ -11,13 +11,16 @@ use async_trait::async_trait;
 use redis::AsyncCommands;
 use reinhardt_http::Result;
 
-use crate::session::{AsyncSessionBackend, SessionData};
+use crate::session::{AsyncSessionBackend, AtomicSessionBackend, SessionData};
 
 /// Session backend backed by Redis.
 ///
 /// Sessions are stored as JSON strings under the key `<prefix><session_id>`.
 /// Redis native TTL (`SET ... EX`) is used for expiry so that Redis handles
 /// garbage collection automatically.
+///
+/// The atomic [`AtomicSessionBackend::take`] capability requires Redis 6.2 or
+/// later because it uses the `GETDEL` command.
 ///
 /// # Example
 ///
@@ -31,6 +34,11 @@ use crate::session::{AsyncSessionBackend, SessionData};
 pub struct RedisSessionBackend {
 	client: redis::Client,
 	key_prefix: String,
+}
+
+fn decode_session(json: &str) -> Result<SessionData> {
+	serde_json::from_str(json)
+		.map_err(|error| reinhardt_core::exception::Error::Serialization(error.to_string()))
 }
 
 impl RedisSessionBackend {
@@ -87,8 +95,7 @@ impl AsyncSessionBackend for RedisSessionBackend {
 		match raw {
 			None => Ok(None),
 			Some(json) => {
-				let session: SessionData = serde_json::from_str(&json)
-					.map_err(|e| reinhardt_core::exception::Error::Serialization(e.to_string()))?;
+				let session = decode_session(&json)?;
 
 				if session.expires_at <= SystemTime::now() {
 					// Session expired in-process; eagerly remove from Redis.
@@ -161,6 +168,25 @@ impl AsyncSessionBackend for RedisSessionBackend {
 			.map_err(|e| reinhardt_core::exception::Error::Internal(e.to_string()))?;
 
 		Ok(())
+	}
+}
+
+#[async_trait]
+impl AtomicSessionBackend for RedisSessionBackend {
+	async fn take(&self, id: &str) -> Result<Option<SessionData>> {
+		let mut conn = self.connection().await?;
+		let key = self.redis_key(id);
+		let raw: Option<String> = redis::cmd("GETDEL")
+			.arg(&key)
+			.query_async(&mut conn)
+			.await
+			.map_err(|error| reinhardt_core::exception::Error::Internal(error.to_string()))?;
+		let Some(json) = raw else {
+			return Ok(None);
+		};
+
+		let session = decode_session(&json)?;
+		Ok((session.expires_at > SystemTime::now()).then_some(session))
 	}
 }
 

--- a/crates/reinhardt-middleware/src/session.rs
+++ b/crates/reinhardt-middleware/src/session.rs
@@ -28,6 +28,8 @@ mod data;
 mod id;
 mod injectable;
 mod middleware;
+#[cfg(feature = "social-auth")]
+mod social_state;
 mod store;
 mod value;
 
@@ -40,11 +42,13 @@ mod value;
 pub mod test_support;
 
 pub use auth_ext::SessionAuthExt;
-pub use backend::AsyncSessionBackend;
+pub use backend::{AsyncSessionBackend, AtomicSessionBackend};
 pub use config::SessionConfig;
 pub use data::{SessionData, USER_ID_SESSION_KEY};
 pub use id::{ActiveSessionId, SessionCookieName, SessionId};
 pub use middleware::SessionMiddleware;
+#[cfg(feature = "social-auth")]
+pub use social_state::AsyncSessionStateStore;
 pub use store::{SessionStore, SessionStoreKey};
 pub use value::{
 	OptionalSessionValue, OptionalSessionValueNamed, SessionKey, SessionValue, SessionValueNamed,

--- a/crates/reinhardt-middleware/src/session/backend.rs
+++ b/crates/reinhardt-middleware/src/session/backend.rs
@@ -43,3 +43,13 @@ pub trait AsyncSessionBackend: Send + Sync {
 	/// Refresh the TTL of an existing session without rewriting the full payload.
 	async fn touch(&self, id: &str, ttl: Duration) -> Result<()>;
 }
+
+/// Optional atomic capability for session backends.
+///
+/// Implementations must return and delete one session in a single backend
+/// operation. Missing and expired sessions are returned as `None`.
+#[async_trait]
+pub trait AtomicSessionBackend: AsyncSessionBackend {
+	/// Atomically load and delete one unexpired session.
+	async fn take(&self, id: &str) -> Result<Option<SessionData>>;
+}

--- a/crates/reinhardt-middleware/src/session/social_state.rs
+++ b/crates/reinhardt-middleware/src/session/social_state.rs
@@ -1,0 +1,287 @@
+//! Async session-backed OAuth state storage.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use reinhardt_auth::social::{ContextualStateData, SocialAuthError, StateData, StateStore};
+use serde::{Deserialize, Serialize};
+
+use super::{AtomicSessionBackend, SessionData};
+
+const DEFAULT_KEY_PREFIX: &str = "_social_auth_state:";
+const STATE_PAYLOAD_KEY: &str = "oauth_state";
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+enum StoredStateData {
+	Legacy(StateData),
+	Contextual(ContextualStateData),
+}
+
+impl StoredStateData {
+	fn state_data(&self) -> &StateData {
+		match self {
+			Self::Legacy(data) => data,
+			Self::Contextual(data) => data.state_data(),
+		}
+	}
+}
+
+/// State store backed by an async session backend with atomic take support.
+pub struct AsyncSessionStateStore<B: AtomicSessionBackend> {
+	backend: B,
+	key_prefix: String,
+}
+
+impl<B: AtomicSessionBackend> AsyncSessionStateStore<B> {
+	/// Creates a state store with the default OAuth session key prefix.
+	pub fn new(backend: B) -> Self {
+		Self {
+			backend,
+			key_prefix: DEFAULT_KEY_PREFIX.to_string(),
+		}
+	}
+
+	/// Creates a state store with a custom OAuth session key prefix.
+	pub fn with_prefix(backend: B, prefix: impl Into<String>) -> Self {
+		Self {
+			backend,
+			key_prefix: prefix.into(),
+		}
+	}
+
+	fn session_key(&self, state: &str) -> String {
+		format!("{}{}", self.key_prefix, state)
+	}
+
+	fn session_for_payload(
+		&self,
+		payload: StoredStateData,
+	) -> Result<SessionData, SocialAuthError> {
+		let state_data = payload.state_data();
+		let state = state_data.state.clone();
+		let ttl = (state_data.expires_at - Utc::now())
+			.to_std()
+			.map_err(|_| SocialAuthError::InvalidState)?;
+		if ttl.is_zero() {
+			return Err(SocialAuthError::InvalidState);
+		}
+
+		let mut session = SessionData::new(ttl);
+		session.id = self.session_key(&state);
+		session
+			.set(STATE_PAYLOAD_KEY.to_string(), payload)
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))?;
+		Ok(session)
+	}
+
+	fn decode_payload(&self, session: SessionData) -> Result<StoredStateData, SocialAuthError> {
+		let value = session
+			.data
+			.get(STATE_PAYLOAD_KEY)
+			.cloned()
+			.ok_or(SocialAuthError::InvalidState)?;
+		serde_json::from_value(value).map_err(|error| SocialAuthError::Storage(error.to_string()))
+	}
+}
+
+#[async_trait]
+impl<B: AtomicSessionBackend + 'static> StateStore for AsyncSessionStateStore<B> {
+	async fn store(&self, data: StateData) -> Result<(), SocialAuthError> {
+		let session = self.session_for_payload(StoredStateData::Legacy(data))?;
+		self.backend
+			.save(&session)
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))
+	}
+
+	async fn retrieve(&self, state: &str) -> Result<StateData, SocialAuthError> {
+		let session = self
+			.backend
+			.load(&self.session_key(state))
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))?
+			.ok_or(SocialAuthError::InvalidState)?;
+
+		match self.decode_payload(session)? {
+			StoredStateData::Legacy(data) if !data.is_expired() => Ok(data),
+			StoredStateData::Legacy(_) | StoredStateData::Contextual(_) => {
+				Err(SocialAuthError::InvalidState)
+			}
+		}
+	}
+
+	async fn remove(&self, state: &str) -> Result<(), SocialAuthError> {
+		self.backend
+			.destroy(&self.session_key(state))
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))
+	}
+
+	async fn consume(&self, state: &str) -> Result<StateData, SocialAuthError> {
+		let session = self
+			.backend
+			.take(&self.session_key(state))
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))?
+			.ok_or(SocialAuthError::InvalidState)?;
+
+		match self.decode_payload(session)? {
+			StoredStateData::Legacy(data) if !data.is_expired() => Ok(data),
+			StoredStateData::Legacy(_) | StoredStateData::Contextual(_) => {
+				Err(SocialAuthError::InvalidState)
+			}
+		}
+	}
+
+	async fn store_contextual(&self, data: ContextualStateData) -> Result<(), SocialAuthError> {
+		let session = self.session_for_payload(StoredStateData::Contextual(data))?;
+		self.backend
+			.save(&session)
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))
+	}
+
+	async fn consume_contextual(
+		&self,
+		state: &str,
+	) -> Result<ContextualStateData, SocialAuthError> {
+		let session = self
+			.backend
+			.take(&self.session_key(state))
+			.await
+			.map_err(|error| SocialAuthError::Storage(error.to_string()))?
+			.ok_or(SocialAuthError::InvalidState)?;
+
+		match self.decode_payload(session)? {
+			StoredStateData::Contextual(data) if !data.state_data().is_expired() => Ok(data),
+			StoredStateData::Legacy(_) | StoredStateData::Contextual(_) => {
+				Err(SocialAuthError::InvalidState)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::session::AsyncSessionBackend;
+	use async_trait::async_trait;
+	use reinhardt_auth::social::flow::{ContextualStateData, StateData, StateStore};
+	use std::collections::HashMap;
+	use std::sync::{Arc, Mutex};
+	use std::time::{Duration, SystemTime};
+
+	#[derive(Clone, Default)]
+	struct TestAtomicBackend {
+		sessions: Arc<Mutex<HashMap<String, SessionData>>>,
+	}
+
+	#[async_trait]
+	impl AsyncSessionBackend for TestAtomicBackend {
+		async fn load(&self, id: &str) -> reinhardt_http::Result<Option<SessionData>> {
+			Ok(self.sessions.lock().unwrap().get(id).cloned())
+		}
+
+		async fn save(&self, session: &SessionData) -> reinhardt_http::Result<()> {
+			self.sessions
+				.lock()
+				.unwrap()
+				.insert(session.id.clone(), session.clone());
+			Ok(())
+		}
+
+		async fn destroy(&self, id: &str) -> reinhardt_http::Result<()> {
+			self.sessions.lock().unwrap().remove(id);
+			Ok(())
+		}
+
+		async fn touch(&self, id: &str, ttl: Duration) -> reinhardt_http::Result<()> {
+			if let Some(session) = self.sessions.lock().unwrap().get_mut(id) {
+				session.touch(ttl);
+			}
+			Ok(())
+		}
+	}
+
+	#[async_trait]
+	impl AtomicSessionBackend for TestAtomicBackend {
+		async fn take(&self, id: &str) -> reinhardt_http::Result<Option<SessionData>> {
+			let session = self.sessions.lock().unwrap().remove(id);
+			Ok(session.filter(|data| data.expires_at > SystemTime::now()))
+		}
+	}
+
+	#[tokio::test]
+	async fn contextual_state_has_one_winner_across_adapter_instances() {
+		let backend = TestAtomicBackend::default();
+		let first = AsyncSessionStateStore::new(backend.clone());
+		let second = AsyncSessionStateStore::new(backend);
+		first
+			.store_contextual(
+				ContextualStateData::new(
+					StateData::new("state-1".to_string(), None, None),
+					"github".to_string(),
+					b"binding",
+					b"context".to_vec(),
+				)
+				.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		let (left, right) = tokio::join!(
+			first.consume_contextual("state-1"),
+			second.consume_contextual("state-1"),
+		);
+		let contexts: Vec<Vec<u8>> = [left, right]
+			.into_iter()
+			.filter_map(Result::ok)
+			.map(|record| record.context().to_vec())
+			.collect();
+
+		assert_eq!(contexts, vec![b"context".to_vec()]);
+	}
+
+	#[tokio::test]
+	async fn legacy_state_round_trips_through_async_adapter() {
+		let store = AsyncSessionStateStore::new(TestAtomicBackend::default());
+		let data = StateData::new(
+			"state-1".to_string(),
+			Some("nonce".to_string()),
+			Some("verifier".to_string()),
+		);
+		store.store(data).await.unwrap();
+
+		let retrieved = store.retrieve("state-1").await.unwrap();
+		assert_eq!(retrieved.state, "state-1");
+		assert_eq!(retrieved.nonce.as_deref(), Some("nonce"));
+		assert_eq!(retrieved.code_verifier.as_deref(), Some("verifier"));
+
+		let consumed = store.consume("state-1").await.unwrap();
+		assert_eq!(consumed.state, "state-1");
+		assert!(matches!(
+			store.consume("state-1").await,
+			Err(reinhardt_auth::social::SocialAuthError::InvalidState),
+		));
+	}
+
+	#[tokio::test]
+	async fn malformed_payload_maps_to_storage_error() {
+		let backend = TestAtomicBackend::default();
+		let store = AsyncSessionStateStore::new(backend.clone());
+		let mut session = SessionData::new(Duration::from_secs(60));
+		session.id = store.session_key("invalid");
+		session.data.insert(
+			STATE_PAYLOAD_KEY.to_string(),
+			serde_json::json!({"kind": "invalid"}),
+		);
+		backend.save(&session).await.unwrap();
+
+		let result = store.consume_contextual("invalid").await;
+
+		assert!(matches!(
+			result,
+			Err(reinhardt_auth::social::SocialAuthError::Storage(_)),
+		));
+	}
+}

--- a/crates/reinhardt-rest/openapi-macros/src/lib.rs
+++ b/crates/reinhardt-rest/openapi-macros/src/lib.rs
@@ -388,8 +388,8 @@ fn generate_container_modifications(
 	if let Some(ref example) = attrs.example {
 		// Parse the example string as JSON; fall back to a JSON string if invalid
 		mods.push(quote! {
-			let example_value: serde_json::Value = serde_json::from_str(#example)
-				.unwrap_or_else(|_| serde_json::json!(#example));
+			let example_value: #openapi_crate::serde_json::Value = #openapi_crate::serde_json::from_str(#example)
+				.unwrap_or_else(|_| #openapi_crate::serde_json::json!(#example));
 			match schema {
 				Schema::Object(ref mut obj) => {
 					obj.example = Some(example_value);
@@ -497,7 +497,7 @@ fn generate_simple_enum_schema(
 		Schema::Object(
 			ObjectBuilder::new()
 				.schema_type(SchemaType::Type(Type::String))
-				.enum_values(Some(vec![#(serde_json::Value::String(#variant_names.to_string())),*]))
+				.enum_values(Some(vec![#(#openapi_crate::serde_json::Value::String(#variant_names.to_string())),*]))
 				.build()
 		)
 	}
@@ -759,8 +759,8 @@ fn build_field_schema(field_type: &syn::Type, attrs: &FieldAttributes) -> proc_m
 		modifications.push(quote! {
 			if let Schema::Object(ref mut obj) = schema {
 				obj.example = Some(
-					serde_json::from_str(#example)
-						.unwrap_or_else(|_| serde_json::json!(#example))
+					#openapi_crate::serde_json::from_str(#example)
+						.unwrap_or_else(|_| #openapi_crate::serde_json::json!(#example))
 				);
 			}
 		});
@@ -946,7 +946,7 @@ fn build_field_schema(field_type: &syn::Type, attrs: &FieldAttributes) -> proc_m
 	if let Some(ref default_value) = attrs.default_value {
 		modifications.push(quote! {
 			if let Schema::Object(ref mut obj) = schema {
-				obj.default = Some(serde_json::json!(#default_value));
+				obj.default = Some(#openapi_crate::serde_json::json!(#default_value));
 			}
 		});
 	}

--- a/crates/reinhardt-rest/openapi-macros/src/lib.rs
+++ b/crates/reinhardt-rest/openapi-macros/src/lib.rs
@@ -241,7 +241,7 @@ fn derive_struct_schema(input: &DeriveInput, data: &syn::DataStruct) -> TokenStr
 		quote! {
 			// Automatic schema registration via inventory
 			// This allows the framework to discover all schemas at compile time
-			::inventory::submit! {
+			#openapi_crate::inventory::submit! {
 				#openapi_crate::SchemaRegistration::new(
 					#struct_name,
 					#name::schema
@@ -319,7 +319,7 @@ fn derive_enum_schema(input: &DeriveInput, data: &syn::DataEnum) -> TokenStream 
 	// Generate inventory registration only for non-generic types
 	let inventory_registration = if generics.params.is_empty() {
 		quote! {
-			::inventory::submit! {
+			#openapi_crate::inventory::submit! {
 				#openapi_crate::SchemaRegistration::new(
 					#enum_name,
 					#name::schema

--- a/crates/reinhardt-rest/src/openapi.rs
+++ b/crates/reinhardt-rest/src/openapi.rs
@@ -184,6 +184,7 @@ pub use utoipa::Number;
 
 // Re-export utoipa and inventory for macro-generated code
 pub use inventory;
+pub use serde_json;
 pub use utoipa;
 
 /// Errors that can occur during OpenAPI schema operations.

--- a/deny.toml
+++ b/deny.toml
@@ -163,6 +163,7 @@ skip = [
   { crate = "linux-raw-sys@0.4.15", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "matchit@0.8.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "md-5@0.10.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "miniz_oxide:>=0.8,<0.10", reason = "backtrace and flate2 retain incompatible miniz_oxide lines in the full feature graph." },
   { crate = "nix@0.29.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "nom@7.1.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "openssl-probe@0.1.6", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `auth-session` - Session-based authentication
 //! - `auth-oauth` - OAuth2 support
 //! - `auth-social` - Social authentication providers
+//! - `social-auth` - Browser-bound social authentication state with session middleware
 //! - `auth-token` - Token authentication
 //!
 //! #### Database Backends ✅

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -19,10 +19,11 @@ reinhardt = { workspace = true, features = ["full", "openapi-router", "pages"] }
 reinhardt-apps = { workspace = true, features = ["testing"] }
 reinhardt-core = { workspace = true, features = ["exception", "messages", "negotiation", "pagination", "parsers", "security", "signals", "types", "validators"] }
 reinhardt-auth = { workspace = true, features = [
-  "argon2-hasher",
-  "jwt",
-  "sessions",
-  "token",
+	"argon2-hasher",
+	"jwt",
+	"sessions",
+	"social",
+	"token",
   "oauth",
   "database",
   "redis-sessions",
@@ -30,7 +31,7 @@ reinhardt-auth = { workspace = true, features = [
 ] }
 reinhardt-http = { workspace = true, features = ["messages"] }
 reinhardt-di = { workspace = true, features = ["macros", "params"] }
-reinhardt-middleware = { workspace = true }
+reinhardt-middleware = { workspace = true, features = ["social-auth", "session-redis"] }
 reinhardt-graphql = { workspace = true, features = ["full"] }
 reinhardt-grpc = { workspace = true }
 reinhardt-db = { workspace = true, features = ["backends", "contenttypes", "migrations", "orm", "mongodb", "nosql"] }

--- a/tests/integration/tests/sessions.rs
+++ b/tests/integration/tests/sessions.rs
@@ -24,3 +24,6 @@ mod session_security_integration;
 
 #[path = "sessions/session_security_advanced.rs"]
 mod session_security_advanced;
+
+#[path = "sessions/async_oauth_state.rs"]
+mod async_oauth_state;

--- a/tests/integration/tests/sessions/async_oauth_state.rs
+++ b/tests/integration/tests/sessions/async_oauth_state.rs
@@ -1,0 +1,91 @@
+//! Redis-backed async OAuth state integration tests.
+
+use reinhardt_auth::social::{ContextualStateData, SocialAuthError, StateData, StateStore};
+use reinhardt_middleware::session::{AsyncSessionBackend, AtomicSessionBackend, SessionData};
+use reinhardt_middleware::{AsyncSessionStateStore, RedisSessionBackend};
+use serial_test::serial;
+use std::time::Duration;
+use testcontainers::{
+	GenericImage,
+	core::{ContainerPort, WaitFor},
+	runners::AsyncRunner,
+};
+
+async fn setup_redis() -> testcontainers::ContainerAsync<GenericImage> {
+	GenericImage::new("redis", "7-alpine")
+		.with_exposed_port(ContainerPort::Tcp(6379))
+		.with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+		.start()
+		.await
+		.expect("Redis container should start")
+}
+
+async fn wait_for_redis(backend: &RedisSessionBackend) {
+	for _ in 0..20 {
+		if backend.destroy("__reinhardt_readiness__").await.is_ok() {
+			return;
+		}
+		tokio::time::sleep(Duration::from_millis(50)).await;
+	}
+	panic!("Redis did not accept connections within the readiness window");
+}
+
+#[tokio::test]
+#[serial(redis)]
+async fn contextual_state_is_consumed_once_across_redis_backends() {
+	let container = setup_redis().await;
+	let port = container.get_host_port_ipv4(6379).await.unwrap();
+	let redis_url = format!("redis://127.0.0.1:{port}/");
+	let first_backend = RedisSessionBackend::new_from_url(&redis_url).unwrap();
+	wait_for_redis(&first_backend).await;
+	let first = AsyncSessionStateStore::new(first_backend);
+	let second =
+		AsyncSessionStateStore::new(RedisSessionBackend::new_from_url(&redis_url).unwrap());
+	first
+		.store_contextual(
+			ContextualStateData::new(
+				StateData::new("shared-state".to_string(), None, None),
+				"github".to_string(),
+				b"binding",
+				b"context".to_vec(),
+			)
+			.unwrap(),
+		)
+		.await
+		.unwrap();
+
+	let (left, right) = tokio::join!(
+		first.consume_contextual("shared-state"),
+		second.consume_contextual("shared-state"),
+	);
+	let contexts: Vec<Vec<u8>> = [left, right]
+		.into_iter()
+		.filter_map(Result::ok)
+		.map(|record| record.context().to_vec())
+		.collect();
+
+	assert_eq!(contexts, vec![b"context".to_vec()]);
+	assert!(matches!(
+		first.consume_contextual("shared-state").await,
+		Err(SocialAuthError::InvalidState),
+	));
+}
+
+#[tokio::test]
+#[serial(redis)]
+async fn atomic_take_omits_expired_redis_session() {
+	let container = setup_redis().await;
+	let port = container.get_host_port_ipv4(6379).await.unwrap();
+	let redis_url = format!("redis://127.0.0.1:{port}/");
+	let backend = RedisSessionBackend::new_from_url(&redis_url).unwrap();
+	wait_for_redis(&backend).await;
+	let session = SessionData::new(Duration::from_secs(60));
+	let id = session.id.clone();
+	backend.save(&session).await.unwrap();
+	backend.touch(&id, Duration::from_secs(1)).await.unwrap();
+	tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+	let result = AtomicSessionBackend::take(&backend, &id).await.unwrap();
+
+	assert!(result.is_none());
+}

--- a/website/content/docs/feature-flags.md
+++ b/website/content/docs/feature-flags.md
@@ -264,6 +264,7 @@ features = ["database"]  # Includes: ORM, migrations, contenttypes, auth models
 | `auth-jwt` | JWT | `auth` |
 | `auth-session` | Session | `auth`, `sessions` |
 | `auth-oauth` | OAuth | `auth` |
+| `social-auth` | Browser-bound social OAuth state | `auth`, `middleware` |
 | `auth-token` | Token | `auth` |
 
 ---
@@ -304,6 +305,7 @@ reinhardt-utils = { version = "LATEST_VERSION", features = ["redis-sentinel"] }
 | `middleware-compression` | gzip/brotli |
 | `middleware-security` | Security headers |
 | `middleware-rate-limit` | Rate limiting |
+| `social-auth` | Async session-backed social OAuth state; pair with `session-redis` for Redis |
 
 ---
 
@@ -487,10 +489,10 @@ See [Task Backends Documentation](https://github.com/kent8192/reinhardt-web/blob
 |-------|------------------|--------------|
 | `reinhardt-di` | None | `params`, `dev-tools`, `generator` |
 | `reinhardt-db` | `backends`, `pool`, `postgres`, `orm`, `migrations`, `hybrid`, `associations` | `sqlite`, `mysql`, `contenttypes` |
-| `reinhardt-auth` | `params` | `jwt`, `session`, `oauth`, `token`, `argon2-hasher` |
+| `reinhardt-auth` | `params` | `jwt`, `session`, `oauth`, `social`, `token`, `argon2-hasher` |
 | `reinhardt-rest` | `serializers`, `parsers` | `pagination`, `filters`, `throttling`, `versioning` |
 | `reinhardt-utils` (cache) | None | `redis-backend`, `redis-sentinel`, `memcached-backend` |
-| `reinhardt-middleware` | None | `cors`, `compression`, `security`, `rate-limit` |
+| `reinhardt-middleware` | None | `cors`, `compression`, `security`, `rate-limit`, `social-auth`, `session-redis` |
 | `reinhardt-auth` (sessions) | None | `session-database`, `session-file`, `session-cookie`, `session-jwt` |
 | `reinhardt-test` | None | `testcontainers`, `static`, `websockets` |
 | `reinhardt-dentdelion` | None | `wasm`, `cli`, `full` |


### PR DESCRIPTION
## Summary

This PR addresses:

- Merge the current `main` branch into `develop/0.4.0`.
- Preserve the release line's `0.4.0-alpha.11` metadata and shared native/WASM DTO validation while integrating native Schema opt-in support.
- Integrate the async OAuth state, middleware session, feature-matrix, documentation, and dependency-policy updates from `main`.
- Disable rcgen's unused PEM output feature so the fresh all-feature dependency graph remains compliant with the duplicate-dependency policy.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [x] Other (please describe): Branch synchronization

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Keep the `develop/0.4.0` release line synchronized with the latest changes on `main` without losing release-line-specific behavior or metadata.

## How Was This Tested?

- `cargo make fmt-check`
- `cargo check --workspace --all --all-features`
- `cargo make clippy-check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo make feature-check`
- `cargo deny --workspace --all-features check all`
- `./scripts/validate-version-markers.sh`
- DTO macro unit, pass/fail UI, Schema parity, and WASM validation tests
- ClientForm validation integration and UI tests
- Social authentication tests
- Middleware `social-auth,session-redis` library tests
- Async OAuth state integration tests
- Self-signed TLS certificate generation test

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)

- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change
- [x] `documentation`
- [x] `dependencies`
- [x] `github-actions`

### Scope Label (select all that apply)

- [ ] `database` - Database layer, schema, migrations
- [x] `auth` - Authentication, authorization, sessions
- [x] `orm` - ORM layer, models, query builder
- [x] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

- The merge commit has both current remote tips as parents: `develop/0.4.0` at `c5fef08615afec2c48d7032254222bba7cf8ca6b` and `main` at `3102414ea0c9c5c13da14170d3cf6c7cadcb6061`.
- Existing ShellCheck findings in the feature-check workflow are present in both parent branches and are not introduced by this merge.

🤖 Generated with [Codex](https://openai.com/codex)
