### PR TITLE
fix(ci): allow current pem duplicate versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,7 @@ skip = [
   { crate = "num-bigint:>=0.5,<0.6", reason = "Redis uses the 0.5 API while current database and authentication dependencies require the incompatible 0.4 line; allow compatible patch updates without reintroducing the duplicate." },
   { crate = "phf_generator@0.11.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "phf_macros@0.11.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
+  { crate = "pem:>=3,<5", reason = "jsonwebtoken and rcgen retain incompatible pem 3 and 4 lines in the full feature graph." },
   { crate = "rand@0.7.3", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "pbkdf2@0.12.2", reason = "The encryption feature uses the 0.12 API while MongoDB requires the incompatible 0.13 line." },
   { crate = "rand:>=0.8,<0.9", reason = "Upstream dependencies still require rand 0.8 while the workspace uses rand 0.9." },


### PR DESCRIPTION
## Summary

This PR addresses:

- Unblocks `Security Audit / Check dependency policy` on `main`.
- Allows the unavoidable `pem` 3/4 duplicate in the full-feature dependency graph with one bounded PackageSpec skip.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`jsonwebtoken 10.4.0` retains `pem 3.0.6`, while `rcgen 0.14.10` retains `pem 4.0.0`. Cargo cannot unify these incompatible major lines. The `pem:>=3,<5` skip covers only the retained lines and remains valid across patch releases.

## How Was This Tested?

- `cargo deny --workspace --all-features check all` with a freshly generated ignored `Cargo.lock` — passed: advisories, bans, licenses, and sources all passed.
- `cargo make fmt-check` — passed with 0 errors.
- `git diff --check` — passed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (the policy reason documents this configuration exception)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (configuration-only change validated by cargo-deny)
- [ ] New and existing unit tests pass locally with my changes (not run; no code changed)
- [x] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (not run; no source files changed)
- [ ] I have checked the code with `cargo make clippy-check` (not run; no source files changed)

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)
- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [ ] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor priority

---

**Additional Context:**

- The change is limited to one `deny.toml` skip entry.
- The existing `license-not-encountered` warning is unchanged and is not a failure.
- `Cargo.lock` remains ignored and is not included in the PR.

🤖 Generated with [Codex](https://openai.com/codex)
