### PR TITLE
feat(pages): support date and time input bindings

### DIFF
--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -132,12 +132,9 @@ pub async fn get_fields(
 				.iter()
 				.map(|field| field.name.clone())
 				.collect::<Vec<_>>();
-			allowed_fields.extend(form.aliases.iter().filter_map(|(logical, physical)| {
-				form.fields
+			allowed_fields.extend(form.aliases.iter().filter(|&(logical, physical)| form.fields
 					.iter()
-					.any(|field| field.name == *physical)
-					.then(|| logical.clone())
-			}));
+					.any(|field| field.name == *physical)).map(|(logical, physical)| logical.clone()));
 			retain_allowed_fields(values, &allowed_fields);
 		}
 		values

--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -127,11 +127,17 @@ pub async fn get_fields(
 			.map_server_fn_error()?;
 		if let Some(values) = values.as_mut() {
 			translate_physical_field_names_to_logical(table_name, values).map_server_fn_error()?;
-			let allowed_fields = form
+			let mut allowed_fields = form
 				.fields
 				.iter()
-				.map(|field| field.name.as_str())
+				.map(|field| field.name.clone())
 				.collect::<Vec<_>>();
+			allowed_fields.extend(form.aliases.iter().filter_map(|(logical, physical)| {
+				form.fields
+					.iter()
+					.any(|field| field.name == *physical)
+					.then(|| logical.clone())
+			}));
 			retain_allowed_fields(values, &allowed_fields);
 		}
 		values

--- a/crates/reinhardt-core/src/types/page/control_binding.rs
+++ b/crates/reinhardt-core/src/types/page/control_binding.rs
@@ -8,7 +8,7 @@ use crate::reactive::{Signal, runtime::NodeId};
 /// Identifies the form control represented by a binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlKind {
-	/// A single-line or multi-line text control.
+	/// A string-valued input or multi-line text control.
 	Text,
 	/// A numeric input control.
 	Number,
@@ -38,7 +38,7 @@ impl fmt::Display for ControlKind {
 /// Cross-target value read from or written to a form control.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ControlValue {
-	/// A textual control value.
+	/// A string-valued control value.
 	Text(String),
 	/// A checked-state control value.
 	Checked(bool),
@@ -216,7 +216,7 @@ impl fmt::Debug for ControlBinding {
 }
 
 impl ControlBinding {
-	/// Creates a binding for a textual signal.
+	/// Creates a binding for a string-valued signal.
 	pub fn text(signal: Signal<String>) -> Self {
 		Self::string_value(ControlKind::Text, signal)
 	}

--- a/crates/reinhardt-manouche/src/validator/page.rs
+++ b/crates/reinhardt-manouche/src/validator/page.rs
@@ -799,8 +799,8 @@ fn classify_control_binding(
 
 /// Classifies a statically typed `<input>` binding for downstream page macros.
 ///
-/// Text-like controls share the `Text` binding semantics, while `number` and
-/// `range` share the `Number` semantics. Checkbox and radio controls retain
+/// String-valued controls share the `Text` binding semantics, while `number`
+/// and `range` share the `Number` semantics. Checkbox and radio controls retain
 /// their checked-state behavior.
 #[doc(hidden)]
 pub fn classify_input_binding(
@@ -823,9 +823,8 @@ pub fn classify_input_binding(
 	};
 
 	match input_type.to_ascii_lowercase().as_str() {
-		"text" | "search" | "tel" | "url" | "email" | "password" | "color" => {
-			Ok((TypedControlBindingKind::Text, None))
-		}
+		"text" | "search" | "tel" | "url" | "email" | "password" | "color" | "date"
+		| "datetime-local" | "month" | "week" | "time" => Ok((TypedControlBindingKind::Text, None)),
 		"number" | "range" => Ok((TypedControlBindingKind::Number, None)),
 		"checkbox" => Ok((TypedControlBindingKind::Checkbox, None)),
 		"radio" => {
@@ -2711,6 +2710,31 @@ mod tests {
 	)]
 	#[case(
 		quote!({ input { a11y: off, type: "color", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote!({ input { a11y: off, type: "date", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote!({ input { a11y: off, type: "datetime-local", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote!({ input { a11y: off, type: "month", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote!({ input { a11y: off, type: "week", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote!({ input { a11y: off, type: "time", bind: value } }),
 		TypedControlBindingKind::Text,
 		false
 	)]

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -49,7 +49,7 @@ selector whitespace.
 - **Simplified Conditional Compilation**: `cfg_aliases` integration and automatic event handler handling
 - **Action State Helpers**: `use_action_state` and `Action::dispatching*` reduce async mutation boilerplate
 - **Headless UI Primitives**: `reinhardt_pages::ui::{ActionButton, ActionResultPanel, ResourcePanel}` compose typed action and resource states without imposing visual styles
-- **Controlled Form Elements**: `bind:` synchronizes typed signals with text, checkbox, radio, numeric, and select controls
+- **Controlled Form Elements**: `bind:` synchronizes typed signals with string-valued, checkbox, radio, numeric, and select controls
 - **Model-backed Forms**: `#[model(form = true)]` supplies typed fields and one
   policy-safe payload to `form!` on native and WASM targets
 
@@ -249,10 +249,11 @@ node; removing a script cannot undo side effects that already executed.
 ### Controlled form elements
 
 Use `bind:` when a signal should own a native control after hydration. The
-control shape determines the signal type: `String` for text-like inputs
-(`text`, `search`, `tel`, `url`, `email`, `password`, and `color`), radio, and
-single-select controls; `bool` for checkboxes; a supported numeric primitive
-for `number` and `range` inputs; and `Vec<String>` for multiple selects.
+control shape determines the signal type: `String` for string-valued inputs
+(`text`, `search`, `tel`, `url`, `email`, `password`, `color`, `date`,
+`datetime-local`, `month`, `week`, and `time`), radio, and single-select
+controls; `bool` for checkboxes; a supported numeric primitive for `number`
+and `range` inputs; and `Vec<String>` for multiple selects.
 
 ```rust
 use reinhardt_pages::prelude::*;
@@ -271,10 +272,19 @@ let _controls = page!({
 });
 ```
 
-Hydration first adopts the live DOM value, preserving browser restoration and
-edits made before hydration. The adopted value also becomes the browser reset
-default, so a later form reset preserves the pre-hydration control state. Later
-signal changes update the control. See the
+Date/time bindings use the browser's serialized strings, for example
+`2026-08-31`, `2026-08-31T10:30`, `2026-08`, `2026-W36`, and `10:30`.
+The DOM-to-signal path stores the browser-normalized `HTMLInputElement.value`;
+empty, invalid, or incomplete editor values are exposed as `""` by these
+controls. Applications should write a browser-valid serialization or `""` to
+the signal. If the browser sanitizes an application-provided value, the
+binding does not silently rewrite the signal.
+
+SSR serializes the signal string into the `value` attribute. Hydration first
+adopts the live DOM property, preserving browser restoration and edits made
+before hydration. The adopted value also becomes the browser reset default, so
+a later form reset preserves the pre-hydration control state. Later signal
+changes update the existing control in place. See the
 [React migration guide](docs/react_to_reinhardt.md#controlled-and-uncontrolled-form-controls)
 for event ordering, IME, numeric-error, and low-level escape-hatch details.
 For `input[type=number]`, the binding combines `beforeinput` metadata with the

--- a/crates/reinhardt-pages/docs/react_to_reinhardt.md
+++ b/crates/reinhardt-pages/docs/react_to_reinhardt.md
@@ -247,7 +247,7 @@ a `Signal`, providing the Reinhardt equivalent of a React controlled input.
 
 | Control shape | Bound signal |
 | --- | --- |
-| `input` with no `type` or static `type: "text"`, `"search"`, `"tel"`, `"url"`, `"email"`, `"password"`, or `"color"` | `Signal<String>` |
+| `input` with no `type` or static `type: "text"`, `"search"`, `"tel"`, `"url"`, `"email"`, `"password"`, `"color"`, `"date"`, `"datetime-local"`, `"month"`, `"week"`, or `"time"` | `Signal<String>` |
 | `input` with static `type: "number"` or `"range"` | `Signal<T>` where `T: NumberValue`; optionally an error signal |
 | `input` with static `type: "checkbox"` | `Signal<bool>` |
 | `input` with static `type: "radio"` | `Signal<String>`; each radio also declares a static or dynamic `value` expression |
@@ -255,9 +255,10 @@ a `Signal`, providing the Reinhardt equivalent of a React controlled input.
 | `select` with no `multiple` or static `multiple: false` | `Signal<String>` |
 | `select` with static `multiple: true` | `Signal<Vec<String>>` |
 
-Other input types, including `file` and date/time controls, are not binding
-shapes. Bound input `type` and select `multiple` classifiers must be static so
-the macro can validate the signal type at compile time.
+Other input types, including `file`, are not binding shapes. The obsolete
+`datetime` type is not an alias for `datetime-local`. Bound input `type` and
+select `multiple` classifiers must be static so the macro can validate the
+signal type at compile time.
 
 ```rust
 use reinhardt_pages::prelude::*;
@@ -282,6 +283,14 @@ hydration instead of overwriting them with the server-time signal snapshot.
 After hydration, the signal wins: application writes update the corresponding
 DOM property. User input updates the signal before an explicit handler for the
 same event runs, so the handler observes the new signal value.
+
+Date/time inputs bind their browser serialization rather than a Rust date/time
+type. Typical values are `2026-08-31`, `2026-08-31T10:30`, `2026-08`,
+`2026-W36`, and `10:30`; `""` represents an empty control. User edits commit
+the browser-normalized `HTMLInputElement.value`, so an invalid or incomplete
+editor value is observed as `""`. Application writes should be a valid
+serialization or `""`. Browser sanitization of an application write changes
+the DOM property but does not silently rewrite the signal.
 
 Text writes are deferred while an IME composition is active. The completed
 value is committed at `compositionend`, and a duplicate final `input` event is

--- a/crates/reinhardt-pages/macros/src/page/validator.rs
+++ b/crates/reinhardt-pages/macros/src/page/validator.rs
@@ -2263,6 +2263,31 @@ mod tests {
 		false
 	)]
 	#[case(
+		quote::quote!({ input { a11y: off, type: "date", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote::quote!({ input { a11y: off, type: "datetime-local", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote::quote!({ input { a11y: off, type: "month", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote::quote!({ input { a11y: off, type: "week", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
+		quote::quote!({ input { a11y: off, type: "time", bind: value } }),
+		TypedControlBindingKind::Text,
+		false
+	)]
+	#[case(
 		quote::quote!({ input { a11y: off, type: "range", bind: value } }),
 		TypedControlBindingKind::Number,
 		false

--- a/crates/reinhardt-pages/src/control_binding.rs
+++ b/crates/reinhardt-pages/src/control_binding.rs
@@ -1,10 +1,10 @@
 //! Stable support types for controlled `page!` form elements.
 //!
 //! The `bind:` directive accepts [`Signal`](crate::reactive::Signal) values
-//! directly for text-like (`text`, `search`, `tel`, `url`, `email`, `password`,
-//! and `color`), numeric (`number` and `range`), checkbox, radio, and select
-//! controls. Numeric controls can additionally report rejected input through
-//! [`NumberParseError`].
+//! directly for string-valued (`text`, `search`, `tel`, `url`, `email`,
+//! `password`, `color`, `date`, `datetime-local`, `month`, `week`, and `time`),
+//! numeric (`number` and `range`), checkbox, radio, and select controls. Numeric
+//! controls can additionally report rejected input through [`NumberParseError`].
 //! Binding lowering passes these `Copy` signal handles by value, so generated
 //! call sites remain clean under Clippy's `clone_on_copy` lint.
 //!
@@ -19,9 +19,22 @@ pub use reinhardt_core::types::page::{
 
 #[cfg(any(wasm, test, feature = "testing"))]
 pub(crate) fn is_text_input_type(input_type: &str) -> bool {
-	["text", "search", "tel", "url", "email", "password", "color"]
-		.iter()
-		.any(|known| input_type.eq_ignore_ascii_case(known))
+	[
+		"text",
+		"search",
+		"tel",
+		"url",
+		"email",
+		"password",
+		"color",
+		"date",
+		"datetime-local",
+		"month",
+		"week",
+		"time",
+	]
+	.iter()
+	.any(|known| input_type.eq_ignore_ascii_case(known))
 }
 
 #[cfg(any(wasm, test, feature = "testing"))]

--- a/crates/reinhardt-pages/src/dom/control_binding.rs
+++ b/crates/reinhardt-pages/src/dom/control_binding.rs
@@ -1927,7 +1927,20 @@ mod tests {
 	fn text_binding_accepts_supported_input_types() {
 		let scope = ReactiveScope::new();
 		scope.enter(|| {
-			for input_type in ["text", "search", "tel", "url", "email", "password", "color"] {
+			for input_type in [
+				"text",
+				"search",
+				"tel",
+				"url",
+				"email",
+				"password",
+				"color",
+				"date",
+				"datetime-local",
+				"month",
+				"week",
+				"time",
+			] {
 				let value = if input_type == "color" {
 					"#123456"
 				} else {

--- a/crates/reinhardt-pages/src/dom/control_binding.rs
+++ b/crates/reinhardt-pages/src/dom/control_binding.rs
@@ -1927,25 +1927,20 @@ mod tests {
 	fn text_binding_accepts_supported_input_types() {
 		let scope = ReactiveScope::new();
 		scope.enter(|| {
-			for input_type in [
-				"text",
-				"search",
-				"tel",
-				"url",
-				"email",
-				"password",
-				"color",
-				"date",
-				"datetime-local",
-				"month",
-				"week",
-				"time",
+			for (input_type, value) in [
+				("text", "non-empty"),
+				("search", "non-empty"),
+				("tel", "non-empty"),
+				("url", "non-empty"),
+				("email", "non-empty"),
+				("password", "non-empty"),
+				("color", "#123456"),
+				("date", "2026-09-01"),
+				("datetime-local", "2026-09-01T12:34"),
+				("month", "2026-09"),
+				("week", "2026-W36"),
+				("time", "12:34"),
 			] {
-				let value = if input_type == "color" {
-					"#123456"
-				} else {
-					"non-empty"
-				};
 				let element = element("input");
 				let input: web_sys::HtmlInputElement =
 					element.as_web_sys().clone().unchecked_into();

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -414,10 +414,15 @@
 //! ## Controlled form elements
 //!
 //! The `bind:` directive connects native form controls to typed [`Signal`]
-//! values. Text and radio groups use `Signal<String>`, checkboxes use
-//! `Signal<bool>`, numeric inputs use a primitive implementing [`NumberValue`],
-//! and multiple selects use `Signal<Vec<String>>`. Numeric bindings may expose
-//! a [`NumberParseError`] signal that retains recoverable invalid editor text.
+//! values. String-valued inputs (`text`, `search`, `tel`, `url`, `email`,
+//! `password`, `color`, `date`, `datetime-local`, `month`, `week`, and `time`)
+//! and radio groups use `Signal<String>`, checkboxes use `Signal<bool>`, numeric
+//! inputs use a primitive implementing [`NumberValue`], and multiple selects
+//! use `Signal<Vec<String>>`. Date/time inputs use the browser's serialized
+//! value, with `""` for an empty or browser-rejected editor value. Browser
+//! sanitization of an application write does not silently rewrite the signal.
+//! Numeric bindings may expose a [`NumberParseError`] signal that retains
+//! recoverable invalid editor text.
 //! Only unmodified Arrow/Home/End keyboard moves are predicted; modifier-key
 //! commands and already-canceled key events are treated as unknown. When a
 //! pointer-positioned number edit is sanitized before its inaccessible selection

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1302,6 +1302,11 @@ fn normalize_native_control_value(
 				.trim_matches(|character: char| character.is_ascii_whitespace())
 				.to_owned();
 		}
+		if input_type.eq_ignore_ascii_case("datetime-local")
+			&& let Some((date, time)) = normalized.split_once(' ')
+		{
+			normalized = format!("{date}T{time}");
+		}
 		if is_temporal_input_type(input_type)
 			&& !is_valid_temporal_input_value(input_type, &normalized)
 		{
@@ -1386,6 +1391,7 @@ fn is_valid_temporal_input_value(input_type: &str, value: &str) -> bool {
 	} else if input_type.eq_ignore_ascii_case("datetime-local") {
 		value
 			.split_once('T')
+			.or_else(|| value.split_once(' '))
 			.is_some_and(|(date, time)| is_valid_html_date(date) && is_valid_html_time(time))
 	} else if input_type.eq_ignore_ascii_case("month") {
 		is_valid_html_month(value)
@@ -1414,7 +1420,7 @@ fn is_valid_html_date(value: &str) -> bool {
 	let Some(day) = parse_fixed_decimal(day, 2) else {
 		return false;
 	};
-	month <= 12 && day > 0 && day <= days_in_month(year, month)
+	(1..=12).contains(&month) && day > 0 && day <= days_in_month(year, month)
 }
 
 fn is_valid_html_month(value: &str) -> bool {
@@ -1436,7 +1442,7 @@ fn is_valid_html_week(value: &str) -> bool {
 	let Some(week) = parse_fixed_decimal(week, 2) else {
 		return false;
 	};
-	week > 0 && (week < 53 || has_iso_week_53(year))
+	(1..=53).contains(&week) && (week < 53 || has_iso_week_53(year))
 }
 
 fn is_valid_html_time(value: &str) -> bool {
@@ -1468,7 +1474,7 @@ fn is_valid_html_time(value: &str) -> bool {
 	};
 	second <= 59
 		&& fraction.is_none_or(|fraction| {
-			!fraction.is_empty() && fraction.bytes().all(|byte| byte.is_ascii_digit())
+			(1..=3).contains(&fraction.len()) && fraction.bytes().all(|byte| byte.is_ascii_digit())
 		})
 }
 
@@ -1683,6 +1689,13 @@ mod case_normalization_tests {
 				ControlValue::Text("4".to_owned())
 			);
 		});
+	}
+
+	#[test]
+	fn native_temporal_validation_rejects_zero_month_extra_week_and_long_fraction() {
+		assert!(!is_valid_html_date("2026-00-01"));
+		assert!(!is_valid_html_week("2026-W54"));
+		assert!(!is_valid_html_time("10:30:00.1234"));
 	}
 
 	#[test]

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1749,13 +1749,6 @@ mod case_normalization_tests {
 	}
 
 	#[test]
-	fn native_temporal_validation_rejects_zero_month_extra_week_and_long_fraction() {
-		assert!(!is_valid_html_date("2026-00-01"));
-		assert!(!is_valid_html_week("2026-W54"));
-		assert!(!is_valid_html_time("10:30:00.1234"));
-	}
-
-	#[test]
 	fn native_range_rejection_keeps_the_signal_and_control_aligned() {
 		ReactiveScope::run(|| {
 			let value = Signal::new(100_u8);

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1302,6 +1302,11 @@ fn normalize_native_control_value(
 				.trim_matches(|character: char| character.is_ascii_whitespace())
 				.to_owned();
 		}
+		if is_temporal_input_type(input_type)
+			&& !is_valid_temporal_input_value(input_type, &normalized)
+		{
+			normalized.clear();
+		}
 		return ControlValue::Text(normalized);
 	}
 	if binding.kind() != ControlKind::Number || !input_type.eq_ignore_ascii_case("range") {
@@ -1366,6 +1371,145 @@ fn normalize_native_control_value(
 		ControlValue::Text(raw)
 	} else {
 		ControlValue::Text(normalized)
+	}
+}
+
+fn is_temporal_input_type(input_type: &str) -> bool {
+	["date", "datetime-local", "month", "time", "week"]
+		.iter()
+		.any(|known| input_type.eq_ignore_ascii_case(known))
+}
+
+fn is_valid_temporal_input_value(input_type: &str, value: &str) -> bool {
+	if input_type.eq_ignore_ascii_case("date") {
+		is_valid_html_date(value)
+	} else if input_type.eq_ignore_ascii_case("datetime-local") {
+		value
+			.split_once('T')
+			.is_some_and(|(date, time)| is_valid_html_date(date) && is_valid_html_time(time))
+	} else if input_type.eq_ignore_ascii_case("month") {
+		is_valid_html_month(value)
+	} else if input_type.eq_ignore_ascii_case("time") {
+		is_valid_html_time(value)
+	} else if input_type.eq_ignore_ascii_case("week") {
+		is_valid_html_week(value)
+	} else {
+		true
+	}
+}
+
+fn is_valid_html_date(value: &str) -> bool {
+	let Some((year, month_day)) = value.split_once('-') else {
+		return false;
+	};
+	let Some((month, day)) = month_day.split_once('-') else {
+		return false;
+	};
+	let Some(year) = parse_html_year(year) else {
+		return false;
+	};
+	let Some(month) = parse_fixed_decimal(month, 2) else {
+		return false;
+	};
+	let Some(day) = parse_fixed_decimal(day, 2) else {
+		return false;
+	};
+	month <= 12 && day > 0 && day <= days_in_month(year, month)
+}
+
+fn is_valid_html_month(value: &str) -> bool {
+	let Some((year, month)) = value.split_once('-') else {
+		return false;
+	};
+	parse_html_year(year).is_some_and(|_| {
+		parse_fixed_decimal(month, 2).is_some_and(|month| (1..=12).contains(&month))
+	})
+}
+
+fn is_valid_html_week(value: &str) -> bool {
+	let Some((year, week)) = value.split_once("-W") else {
+		return false;
+	};
+	let Some(year) = parse_html_year(year) else {
+		return false;
+	};
+	let Some(week) = parse_fixed_decimal(week, 2) else {
+		return false;
+	};
+	week > 0 && (week < 53 || has_iso_week_53(year))
+}
+
+fn is_valid_html_time(value: &str) -> bool {
+	let Some((hour, minute_and_seconds)) = value.split_once(':') else {
+		return false;
+	};
+	let Some(hour) = parse_fixed_decimal(hour, 2) else {
+		return false;
+	};
+	let (minute, seconds) = match minute_and_seconds.split_once(':') {
+		Some((minute, seconds)) => (minute, Some(seconds)),
+		None => (minute_and_seconds, None),
+	};
+	let Some(minute) = parse_fixed_decimal(minute, 2) else {
+		return false;
+	};
+	if hour > 23 || minute > 59 {
+		return false;
+	}
+	let Some(seconds) = seconds else {
+		return true;
+	};
+	let (second, fraction) = match seconds.split_once('.') {
+		Some((second, fraction)) => (second, Some(fraction)),
+		None => (seconds, None),
+	};
+	let Some(second) = parse_fixed_decimal(second, 2) else {
+		return false;
+	};
+	second <= 59
+		&& fraction.is_none_or(|fraction| {
+			!fraction.is_empty() && fraction.bytes().all(|byte| byte.is_ascii_digit())
+		})
+}
+
+fn parse_html_year(value: &str) -> Option<u32> {
+	(value.len() >= 4 && value.bytes().all(|byte| byte.is_ascii_digit()))
+		.then(|| value.parse::<u32>().ok())
+		.flatten()
+		.filter(|year| *year > 0)
+}
+
+fn parse_fixed_decimal(value: &str, width: usize) -> Option<u32> {
+	(value.len() == width && value.bytes().all(|byte| byte.is_ascii_digit()))
+		.then(|| value.parse::<u32>().ok())
+		.flatten()
+}
+
+fn days_in_month(year: u32, month: u32) -> u32 {
+	match month {
+		2 if is_leap_year(year) => 29,
+		2 => 28,
+		4 | 6 | 9 | 11 => 30,
+		_ => 31,
+	}
+}
+
+fn is_leap_year(year: u32) -> bool {
+	(year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+fn has_iso_week_53(year: u32) -> bool {
+	let weekday = weekday_of_january_first(year);
+	weekday == 4 || (weekday == 3 && is_leap_year(year))
+}
+
+fn weekday_of_january_first(year: u32) -> u32 {
+	let year = i64::from(year) - 1;
+	let weekday_sunday_zero = (year + year / 4 - year / 100 + year / 400 + 1) % 7;
+	if weekday_sunday_zero == 0 {
+		7
+	} else {
+		weekday_sunday_zero as u32
 	}
 }
 

--- a/crates/reinhardt-pages/src/testing/component/tree.rs
+++ b/crates/reinhardt-pages/src/testing/component/tree.rs
@@ -1289,7 +1289,11 @@ fn normalize_native_control_value(
 	}
 	if binding.kind() == ControlKind::Text && crate::control_binding::is_text_input_type(input_type)
 	{
-		let mut normalized = raw.replace(['\r', '\n'], "");
+		let mut normalized = if input_type_removes_line_breaks(input_type) {
+			raw.replace(['\r', '\n'], "")
+		} else {
+			raw
+		};
 		if ["url", "email"]
 			.iter()
 			.any(|known| input_type.eq_ignore_ascii_case(known))
@@ -1303,10 +1307,12 @@ fn normalize_native_control_value(
 		{
 			normalized = format!("{date}T{time}");
 		}
-		if is_temporal_input_type(input_type)
-			&& !is_valid_temporal_input_value(input_type, &normalized)
-		{
-			normalized.clear();
+		if is_temporal_input_type(input_type) {
+			if !is_valid_temporal_input_value(input_type, &normalized) {
+				normalized.clear();
+			} else if input_type.eq_ignore_ascii_case("datetime-local") {
+				normalized = normalize_datetime_local_value(&normalized);
+			}
 		}
 		return ControlValue::Text(normalized);
 	}
@@ -1372,6 +1378,33 @@ fn normalize_native_control_value(
 		ControlValue::Text(raw)
 	} else {
 		ControlValue::Text(normalized)
+	}
+}
+
+fn input_type_removes_line_breaks(input_type: &str) -> bool {
+	["text", "search", "tel", "url", "email", "password"]
+		.iter()
+		.any(|known| input_type.eq_ignore_ascii_case(known))
+}
+
+fn normalize_datetime_local_value(value: &str) -> String {
+	let Some((date, time)) = value.split_once('T').or_else(|| value.split_once(' ')) else {
+		return value.to_owned();
+	};
+	let Some((hour, minute_and_seconds)) = time.split_once(':') else {
+		return format!("{date}T{time}");
+	};
+	let Some((minute, seconds)) = minute_and_seconds.split_once(':') else {
+		return format!("{date}T{hour}:{minute_and_seconds}");
+	};
+	let (second, fraction) = seconds.split_once('.').unwrap_or((seconds, ""));
+	let fraction = fraction.trim_end_matches('0');
+	if second == "00" && fraction.is_empty() {
+		format!("{date}T{hour}:{minute}")
+	} else if fraction.is_empty() {
+		format!("{date}T{hour}:{minute}:{second}")
+	} else {
+		format!("{date}T{hour}:{minute}:{second}.{fraction}")
 	}
 }
 

--- a/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
@@ -1084,6 +1084,11 @@ fn text_binding_accepts_exact_text_controls(
 #[case("email")]
 #[case("password")]
 #[case("color")]
+#[case("date")]
+#[case("datetime-local")]
+#[case("month")]
+#[case("week")]
+#[case("time")]
 fn text_binding_accepts_supported_input_types(
 	#[case] input_type: &str,
 	reactive_scope: ReactiveScope,

--- a/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
@@ -1164,6 +1164,7 @@ fn native_text_binding_applies_browser_value_sanitization(reactive_scope: Reacti
 #[case("month", "2026-02", "2026-00")]
 #[case("week", "2026-W53", "2026-W54")]
 #[case("time", "10:30:00", "10:30:00.1234")]
+#[case("date", "2026-01-01", "2026-\n08-31")]
 fn native_temporal_binding_sanitizes_invalid_values(
 	#[case] input_type: &str,
 	#[case] initial: &str,
@@ -1206,6 +1207,33 @@ fn native_datetime_local_normalizes_a_space_separator(reactive_scope: ReactiveSc
 	assert_eq!(
 		screen.get_by_label("Datetime target").value().as_deref(),
 		Some("2026-08-31T10:30")
+	);
+}
+
+#[rstest]
+#[case("2026-08-31 10:30:00", "2026-08-31T10:30")]
+#[case("2026-08-31 10:30:00.010", "2026-08-31T10:30:00.01")]
+fn native_datetime_local_uses_browser_shortest_serialization(
+	#[case] initial: &str,
+	#[case] expected: &str,
+	reactive_scope: ReactiveScope,
+) {
+	// Arrange
+	let value = signal_in_scope(&reactive_scope, initial.to_owned());
+
+	// Act
+	let screen = render(
+		PageElement::new("input")
+			.attr("aria-label", "Datetime target")
+			.attr("type", "datetime-local")
+			.control_binding(ControlBinding::text(value.clone())),
+	);
+
+	// Assert
+	assert_eq!(value.get(), expected);
+	assert_eq!(
+		screen.get_by_label("Datetime target").value().as_deref(),
+		Some(expected)
 	);
 }
 

--- a/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
@@ -1160,6 +1160,10 @@ fn native_text_binding_applies_browser_value_sanitization(reactive_scope: Reacti
 #[case("month", "2026-02", "2026-13")]
 #[case("week", "2025-W52", "2025-W53")]
 #[case("time", "10:30", "24:00")]
+#[case("date", "2026-01-01", "2026-00-01")]
+#[case("month", "2026-02", "2026-00")]
+#[case("week", "2026-W53", "2026-W54")]
+#[case("time", "10:30:00", "10:30:00.1234")]
 fn native_temporal_binding_sanitizes_invalid_values(
 	#[case] input_type: &str,
 	#[case] initial: &str,
@@ -1182,6 +1186,27 @@ fn native_temporal_binding_sanitizes_invalid_values(
 	// Assert
 	assert_eq!(value.get(), "");
 	assert_eq!(input.value().as_deref(), Some(""));
+}
+
+#[rstest]
+fn native_datetime_local_normalizes_a_space_separator(reactive_scope: ReactiveScope) {
+	// Arrange
+	let value = signal_in_scope(&reactive_scope, "2026-08-31 10:30".to_owned());
+
+	// Act
+	let screen = render(
+		PageElement::new("input")
+			.attr("aria-label", "Datetime target")
+			.attr("type", "datetime-local")
+			.control_binding(ControlBinding::text(value.clone())),
+	);
+
+	// Assert
+	assert_eq!(value.get(), "2026-08-31T10:30");
+	assert_eq!(
+		screen.get_by_label("Datetime target").value().as_deref(),
+		Some("2026-08-31T10:30")
+	);
 }
 
 #[rstest]

--- a/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_native.rs
@@ -1155,6 +1155,36 @@ fn native_text_binding_applies_browser_value_sanitization(reactive_scope: Reacti
 }
 
 #[rstest]
+#[case("date", "2026-02-28", "2026-02-30")]
+#[case("datetime-local", "2026-02-28T10:30", "2026-02-30T10:30")]
+#[case("month", "2026-02", "2026-13")]
+#[case("week", "2025-W52", "2025-W53")]
+#[case("time", "10:30", "24:00")]
+fn native_temporal_binding_sanitizes_invalid_values(
+	#[case] input_type: &str,
+	#[case] initial: &str,
+	#[case] edited: &str,
+	reactive_scope: ReactiveScope,
+) {
+	// Arrange
+	let value = signal_in_scope(&reactive_scope, initial.to_owned());
+	let screen = render(
+		PageElement::new("input")
+			.attr("aria-label", "Temporal target")
+			.attr("type", input_type.to_owned())
+			.control_binding(ControlBinding::text(value.clone())),
+	);
+	let input = screen.get_by_label("Temporal target");
+
+	// Act
+	input.input(edited);
+
+	// Assert
+	assert_eq!(value.get(), "");
+	assert_eq!(input.value().as_deref(), Some(""));
+}
+
+#[rstest]
 fn native_range_binding_applies_declared_step(reactive_scope: ReactiveScope) {
 	// Arrange
 	let value = signal_in_scope(&reactive_scope, 3_i32);

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -311,11 +311,6 @@ fn public_page_mount_supports_all_additional_bound_input_types() {
 		check_text("month", &month, "2026-09", "");
 		check_text("week", &week, "2026-W36", "");
 		check_text("time", &time, "10:30", "");
-		check_text("date", &date, "2026-08-31", "");
-		check_text("datetime-local", &datetime_local, "2026-08-31T10:30", "");
-		check_text("month", &month, "2026-09", "");
-		check_text("week", &week, "2026-W36", "");
-		check_text("time", &time, "10:30", "");
 
 		let input: web_sys::HtmlInputElement = root
 			.as_web_sys()

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -99,6 +99,11 @@ fn public_page_mount_supports_all_additional_bound_input_types() {
 		let email = Signal::new("old@example.test".to_owned());
 		let password = Signal::new("old-secret".to_owned());
 		let color = Signal::new("#112233".to_owned());
+		let date = Signal::new("2026-08-30".to_owned());
+		let datetime_local = Signal::new("2026-08-30T09:15".to_owned());
+		let month = Signal::new("2026-08".to_owned());
+		let week = Signal::new("2026-W35".to_owned());
+		let time = Signal::new("09:15".to_owned());
 		let range = Signal::new(10_i32);
 
 		page!({
@@ -140,6 +145,36 @@ fn public_page_mount_supports_all_additional_bound_input_types() {
 			}
 			input {
 				a11y: off,
+				id: "date",
+				type: "date",
+				bind: date
+			}
+			input {
+				a11y: off,
+				id: "datetime-local",
+				type: "datetime-local",
+				bind: datetime_local
+			}
+			input {
+				a11y: off,
+				id: "month",
+				type: "month",
+				bind: month
+			}
+			input {
+				a11y: off,
+				id: "week",
+				type: "week",
+				bind: week
+			}
+			input {
+				a11y: off,
+				id: "time",
+				type: "time",
+				bind: time
+			}
+			input {
+				a11y: off,
 				id: "range",
 				type: "range",
 				bind: range
@@ -148,7 +183,7 @@ fn public_page_mount_supports_all_additional_bound_input_types() {
 		.mount(&root)
 		.expect("mount");
 
-		let check_text = |id: &str, signal: &Signal<String>, next: &str| {
+		let check_text = |id: &str, signal: &Signal<String>, next: &str, empty: &str| {
 			let input: web_sys::HtmlInputElement = root
 				.as_web_sys()
 				.query_selector(&format!("#{id}"))
@@ -174,14 +209,59 @@ fn public_page_mount_supports_all_additional_bound_input_types() {
 					.active_element()
 					.is_some_and(|active| active.is_same_node(Some(&element)))
 			);
+
+			input.set_value("");
+			input
+				.dispatch_event(&web_sys::InputEvent::new("input").expect("event"))
+				.expect("dispatch");
+			assert_eq!(signal.get(), empty);
+			let current = root
+				.as_web_sys()
+				.query_selector(&format!("#{id}"))
+				.expect("query")
+				.expect("current input");
+			assert!(element.is_same_node(Some(&current)));
+			assert!(
+				document
+					.active_element()
+					.is_some_and(|active| active.is_same_node(Some(&element)))
+			);
 		};
 
-		check_text("search", &search, "next search");
-		check_text("tel", &tel, "+81-3-9876-5432");
-		check_text("url", &url, "https://next.example.test");
-		check_text("email", &email, "next@example.test");
-		check_text("password", &password, "next-secret");
-		check_text("color", &color, "#abcdef");
+		check_text("search", &search, "next search", "");
+		check_text("tel", &tel, "+81-3-9876-5432", "");
+		check_text("url", &url, "https://next.example.test", "");
+		check_text("email", &email, "next@example.test", "");
+		check_text("password", &password, "next-secret", "");
+		check_text("color", &color, "#abcdef", "#000000");
+		check_text("date", &date, "2026-08-31", "");
+		check_text("datetime-local", &datetime_local, "2026-08-31T10:30", "");
+		check_text("month", &month, "2026-09", "");
+		check_text("week", &week, "2026-W36", "");
+		check_text("time", &time, "10:30", "");
+
+		let input: web_sys::HtmlInputElement = root
+			.as_web_sys()
+			.query_selector("#date")
+			.expect("query")
+			.expect("date input")
+			.unchecked_into();
+		let element: web_sys::Element = input.clone().unchecked_into();
+		input.focus().expect("focus");
+		date.set("not-a-date".to_owned());
+		assert_eq!(date.get(), "not-a-date");
+		assert_eq!(input.value(), "");
+		let current = root
+			.as_web_sys()
+			.query_selector("#date")
+			.expect("query")
+			.expect("current date input");
+		assert!(element.is_same_node(Some(&current)));
+		assert!(
+			document
+				.active_element()
+				.is_some_and(|active| active.is_same_node(Some(&element)))
+		);
 
 		let input: web_sys::HtmlInputElement = root
 			.as_web_sys()
@@ -1453,6 +1533,26 @@ struct HydratedInput {
 	observed: Rc<RefCell<String>>,
 }
 
+struct HydratedDateTimeInput {
+	value: Signal<String>,
+}
+
+impl Component for HydratedDateTimeInput {
+	fn name() -> &'static str {
+		"HydratedDateTimeInput"
+	}
+
+	fn render(&self) -> Page {
+		PageElement::new("div")
+			.child(
+				PageElement::new("input")
+					.attr("type", "datetime-local")
+					.control_binding(ControlBinding::text(self.value.clone())),
+			)
+			.into_page()
+	}
+}
+
 struct HydratedInputAfterText {
 	value: Signal<String>,
 }
@@ -1788,6 +1888,44 @@ fn public_hydration_adopts_the_live_dom_property() {
 			.expect("dispatch");
 		assert_eq!(value.get(), "edited");
 		assert_eq!(&*observed.borrow(), "edited");
+		reinhardt_pages::cleanup_reactive_nodes();
+	});
+}
+
+#[wasm_bindgen_test]
+fn public_hydration_adopts_datetime_local_input_value() {
+	ReactiveScope::run(|| {
+		let document = web_sys::window()
+			.expect("window")
+			.document()
+			.expect("document");
+		let raw_root = document.create_element("div").expect("root");
+		let raw_input = document.create_element("input").expect("input");
+		raw_input
+			.set_attribute("type", "datetime-local")
+			.expect("input type");
+		let input: web_sys::HtmlInputElement = raw_input.clone().unchecked_into();
+		input.set_value("2026-08-31T10:30");
+		raw_root.append_child(&raw_input).expect("input append");
+		let root = Element::new(raw_root);
+		let value = Signal::new("server datetime".to_owned());
+		let _state = SsrStateElement::install(&document);
+
+		reinhardt_pages::hydration::hydrate(
+			&HydratedDateTimeInput {
+				value: value.clone(),
+			},
+			&root,
+		)
+		.expect("hydrate datetime-local input");
+
+		assert_eq!(value.get(), "2026-08-31T10:30");
+		assert!(raw_input.is_same_node(root.as_web_sys().first_element_child().as_deref()));
+		input.set_value("2026-08-31T11:45");
+		input
+			.dispatch_event(&web_sys::InputEvent::new("input").expect("event"))
+			.expect("dispatch");
+		assert_eq!(value.get(), "2026-08-31T11:45");
 		reinhardt_pages::cleanup_reactive_nodes();
 	});
 }

--- a/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
+++ b/crates/reinhardt-pages/tests/ssr_renderer_integration_tests.rs
@@ -718,6 +718,11 @@ fn ssr_query_retry_builder_order_preserves_the_same_nested_defaults() {
 
 fn controlled_bindings_page(scope: &ReactiveScope) -> Page {
 	let text = signal_in_scope(scope, "A&B".to_owned());
+	let date = signal_in_scope(scope, "2026-08-31".to_owned());
+	let datetime_local = signal_in_scope(scope, "2026-08-31T10:30".to_owned());
+	let month = signal_in_scope(scope, "2026-08".to_owned());
+	let week = signal_in_scope(scope, "2026-W36".to_owned());
+	let time = signal_in_scope(scope, String::new());
 	let checked = signal_in_scope(scope, true);
 	let selected = signal_in_scope(scope, vec!["rust".to_owned(), "wasm".to_owned()]);
 
@@ -729,6 +734,31 @@ fn controlled_bindings_page(scope: &ReactiveScope) -> Page {
 		textarea {
 			a11y: off,
 			bind: text
+		}
+		input {
+			a11y: off,
+			type: "date",
+			bind: date
+		}
+		input {
+			a11y: off,
+			type: "datetime-local",
+			bind: datetime_local
+		}
+		input {
+			a11y: off,
+			type: "month",
+			bind: month
+		}
+		input {
+			a11y: off,
+			type: "week",
+			bind: week
+		}
+		input {
+			a11y: off,
+			type: "time",
+			bind: time
 		}
 		input {
 			a11y: off,
@@ -781,6 +811,11 @@ async fn controlled_bindings_render_html_initial_state() {
 		concat!(
 			"<input value=\"A&amp;B\" />",
 			"<textarea>A&amp;B</textarea>",
+			"<input type=\"date\" value=\"2026-08-31\" />",
+			"<input type=\"datetime-local\" value=\"2026-08-31T10:30\" />",
+			"<input type=\"month\" value=\"2026-08\" />",
+			"<input type=\"week\" value=\"2026-W36\" />",
+			"<input type=\"time\" value=\"\" />",
 			"<input type=\"checkbox\" checked=\"checked\" />",
 			"<select multiple=\"multiple\"><optgroup>",
 			"<option value=\"rust\" selected=\"selected\">Rust</option>",

--- a/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_unsupported_datetime.rs
+++ b/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_unsupported_datetime.rs
@@ -1,0 +1,11 @@
+use reinhardt_pages::page;
+
+fn main() {
+	page!(|| {
+		input {
+			a11y: off,
+			type: "datetime",
+			bind: (),
+		}
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_unsupported_datetime.stderr
+++ b/crates/reinhardt-pages/tests/ui/page/fail/controlled_bind_unsupported_datetime.stderr
@@ -1,0 +1,5 @@
+error: `bind:` does not support input type `datetime`
+ --> tests/ui/page/fail/controlled_bind_unsupported_datetime.rs:8:10
+  |
+8 |             bind: (),
+  |                   ^^

--- a/crates/reinhardt-pages/tests/ui/page/pass/controlled_bindings.rs
+++ b/crates/reinhardt-pages/tests/ui/page/pass/controlled_bindings.rs
@@ -83,6 +83,31 @@ fn main() {
 			}
 			input {
 				a11y: off,
+				type: "date",
+				bind: text
+			}
+			input {
+				a11y: off,
+				type: "datetime-local",
+				bind: text
+			}
+			input {
+				a11y: off,
+				type: "month",
+				bind: text
+			}
+			input {
+				a11y: off,
+				type: "week",
+				bind: text
+			}
+			input {
+				a11y: off,
+				type: "time",
+				bind: text
+			}
+			input {
+				a11y: off,
 				type: "range",
 				bind: number
 			}


### PR DESCRIPTION
## Summary

This PR addresses:

- Add `bind:` support for standardized `date`, `datetime-local`, `month`, `week`, and `time` inputs through the existing `Signal<String>` binding path.
- Preserve browser-normalized values, empty-state behavior, DOM node identity, and focus across mount and hydration.
- Document serialized string semantics and keep obsolete `datetime` input types unsupported.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

`page!` currently rejects controlled bindings for the standardized date/time input types even though browsers expose their values as serialized strings. This PR reuses the existing string binding path and keeps DOM normalization and sanitization explicit.

Fixes #6216

Related to: #6226

## How Was This Tested?

- `cargo nextest run -p reinhardt-manouche controlled_binding_accepts_supported_structure --no-fail-fast`
- `cargo nextest run -p reinhardt-pages-macros controlled_binding_accepts_supported_structure --no-fail-fast`
- `cargo nextest run -p reinhardt-pages --all-features --test controlled_input_binding_native --test ssr_renderer_integration_tests`
- `cargo test -p reinhardt-pages --all-features --test ui test_page_macro_pass -- --exact --nocapture`
- `cargo test -p reinhardt-pages --all-features --test ui test_page_macro_fail -- --exact --nocapture`
- `cargo test -p reinhardt-pages --target wasm32-unknown-unknown --features testing --test controlled_input_binding_wasm_test public_page_mount_supports_all_additional_bound_input_types -- --exact --nocapture`
- `cargo test -p reinhardt-pages --target wasm32-unknown-unknown --features testing --test controlled_input_binding_wasm_test public_hydration_adopts_datetime_local_input_value -- --exact --nocapture`
- `cargo check -p reinhardt-pages --all-features`
- `cargo make fmt-check`
- `semgrep scan --config .semgrep/placeholder-check.yml --error --metrics off .`

## Performance Impact

- Not applicable.

## Breaking Changes

- Not applicable.

**Migration Guide:**

- Not applicable.

## Screenshots

- Not applicable; this is a framework binding and serialization change.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6216 — standardized date/time input binding
- #6226 — parent semantic input binding support

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [x] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Date/time controls use browser-serialized strings. DOM to Signal reads the normalized live value, while Signal to DOM accepts valid serialized strings or `""`; browser sanitization does not silently rewrite the Signal. The PR is based on the current #6226 head and should be merged after that parent PR.

The targeted suites pass. The full all-target Clippy command still reports unrelated pre-existing warnings outside this change, and the full WASM binding suite retains three baseline failures documented during verification.

🤖 Generated with [Codex](https://openai.com/codex)