### PR TITLE
feat(db): expose structured constraint violations and form mapping

### DIFF
--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -166,6 +166,34 @@ fn validate_user(authenticated: bool, authorized: bool) -> Result<()> {
 }
 ```
 
+### Database Constraint Metadata
+
+`DatabaseError::code()` is a driver or database error code. Constraint
+violations can additionally retain structured object metadata through
+`constraint()`, `table()`, and `columns()`:
+
+```rust
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
+
+let error = DatabaseError::new(
+	DatabaseErrorKind::UniqueViolation,
+	"duplicate key",
+)
+.with_code("23505")
+.with_constraint("users_email_key")
+.with_table("users")
+.with_columns(["email"]);
+
+assert_eq!(error.constraint(), Some("users_email_key"));
+assert_eq!(error.table(), Some("users"));
+assert_eq!(error.columns(), ["email"]);
+```
+
+The message is diagnostic-only. Do not parse SQLx messages to discover a
+constraint, table, or column, and do not expose them to clients. PostgreSQL
+currently supplies these object identifiers; MySQL and SQLite normally expose
+only the portable error kind through SQLx.
+
 ### Application HTTP Errors
 
 Application error enums can implement `HttpError` with `#[derive(HttpError)]`.

--- a/crates/reinhardt-core/macros/src/model_derive.rs
+++ b/crates/reinhardt-core/macros/src/model_derive.rs
@@ -5806,6 +5806,76 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 			}
 		}
 	};
+	let check_constraint_field_arms = check_constraint_names.iter().map(|name| {
+		quote! { #name => return Some(Vec::new()), }
+	});
+	let declared_unique_constraint_field_arms = unique_constraint_names
+		.iter()
+		.zip(unique_constraint_logical_field_lists.iter())
+		.map(|(name, fields)| {
+			quote! { #name => return Some(vec![#(#fields),*]), }
+		});
+	let declared_constraint_names = check_constraint_names
+		.iter()
+		.chain(unique_constraint_names.iter())
+		.collect::<Vec<_>>();
+	let generated_foreign_key_names = fk_field_infos.iter().map(|fk_info| {
+		let column = &fk_info.id_column_name;
+		quote! {
+			#orm_crate::naming::foreign_key_constraint_name(Self::table_name(), #column)
+		}
+	});
+	let foreign_key_constraint_lookups = fk_field_infos.iter().map(|fk_info| {
+		let column = &fk_info.id_column_name;
+		let logical_field = format!("{}_id", fk_info.field_name);
+		quote! {
+			if constraint == #orm_crate::naming::foreign_key_constraint_name(Self::table_name(), #column) {
+				return Some(vec![#logical_field]);
+			}
+		}
+	});
+	let generated_unique_fields = field_infos
+		.iter()
+		.filter(|field| is_regular_persisted_field(field) && field.config.unique == Some(true))
+		.map(|field| {
+			(
+				field
+					.config
+					.db_column
+					.clone()
+					.unwrap_or_else(|| field.name.to_string()),
+				field.name.to_string(),
+			)
+		})
+		.chain(
+			fk_field_infos
+				.iter()
+				.filter(|fk_info| fk_info.is_one_to_one)
+				.map(|fk_info| {
+					(
+						fk_info.id_column_name.clone(),
+						format!("{}_id", fk_info.field_name),
+					)
+				}),
+		)
+		.filter(|(column, _)| {
+			!unique_constraints.iter().any(|constraint| {
+				constraint.column_names.len() == 1 && constraint.column_names[0] == *column
+			})
+		})
+		.collect::<Vec<_>>();
+	let generated_unique_physical_columns =
+		generated_unique_fields.iter().map(|(column, _)| column);
+	let generated_unique_constraint_lookups =
+		generated_unique_fields.iter().map(|(column, field)| {
+			quote! {
+				if generated.iter().any(|(name, generated_column)| {
+					name == constraint && generated_column == #column
+				}) {
+					return Some(vec![#field]);
+				}
+			}
+		});
 
 	// Generate the Model implementation
 	let expanded = quote! {
@@ -5986,6 +6056,37 @@ pub(crate) fn model_derive_impl(mut input: DeriveInput) -> Result<TokenStream> {
 					});
 				)*
 				constraints
+			}
+
+			fn constraint_fields(constraint: &str) -> Option<Vec<&'static str>> {
+				match constraint {
+					#(#check_constraint_field_arms)*
+					#(#declared_unique_constraint_field_arms)*
+					_ => {}
+				}
+
+				#(#foreign_key_constraint_lookups)*
+
+				let unique_columns = vec![#(#generated_unique_physical_columns.to_string()),*];
+				let mut reserved = vec![#(#declared_constraint_names.to_string()),*];
+				reserved.extend([#(#generated_foreign_key_names),*]);
+				reserved.extend(
+					Self::field_metadata()
+						.into_iter()
+						.filter(|field| field.domain.is_some())
+						.map(|field| #orm_crate::naming::enum_domain_constraint_name(
+							Self::table_name(),
+							field.db_column.as_deref().unwrap_or(&field.name),
+						)),
+				);
+				let generated = #orm_crate::naming::generated_unique_constraint_names(
+					Self::table_name(),
+					&unique_columns,
+					&reserved,
+				);
+				#(#generated_unique_constraint_lookups)*
+
+				None
 			}
 
 			fn generated_field_names() -> &'static [&'static str] {
@@ -6916,7 +7017,13 @@ fn generate_field_metadata(
 
 	// Generate _id field metadata for ForeignKeyField and OneToOneField
 	for fk_info in fk_field_infos {
-		let name = &fk_info.id_column_name;
+		let name = format!("{}_id", fk_info.field_name);
+		let db_column = if name == fk_info.id_column_name {
+			quote! { None }
+		} else {
+			let column = &fk_info.id_column_name;
+			quote! { Some(#column.to_string()) }
+		};
 		let target_type = &fk_info.target_type;
 		let nullable = fk_info.rel_attr.null.unwrap_or(false);
 		let unique = fk_info.is_one_to_one; // OneToOne fields have UNIQUE constraint
@@ -6958,7 +7065,7 @@ fn generate_field_metadata(
 					editable: true,
 					default: None,
 					db_default: None,
-					db_column: None,
+					db_column: #db_column,
 					choices: None,
 					attributes,
 				}
@@ -7385,6 +7492,7 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 	for fk_info in fk_field_infos {
 		let id_column_name = &fk_info.id_column_name;
 		let rust_field_name = fk_info.field_name.to_string();
+		let logical_field_name = format!("{}_id", fk_info.field_name);
 		let nullable = fk_info.rel_attr.null.unwrap_or(false);
 		let unique = fk_info.is_one_to_one; // OneToOne fields have UNIQUE constraint
 		let db_index = fk_info.rel_attr.db_index.unwrap_or(true); // FK fields are indexed by default
@@ -7538,7 +7646,8 @@ fn generate_registration_code(input: RegistrationCodeInput<'_>) -> Result<TokenS
 					.with_param("not_null", #not_null_str)
 					.with_param("unique", #unique_str)
 					.with_param("db_index", #db_index_str)
-					.with_param("logical_name", #id_column_name)
+					.with_param("logical_name", #logical_field_name)
+					.with_param("db_column", #id_column_name)
 					#skip_info
 					.with_param("fk_target", #target_model_name)
 					.with_param("fk_target_column", #fk_target_column)

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -375,6 +375,27 @@ pub mod db {
 		pub use super::associations::ManyToManyAccessor;
 		pub use serde;
 
+		pub mod naming {
+			pub fn generated_unique_constraint_names(
+				table: &str,
+				fields: &[String],
+				_reserved: &[String],
+			) -> Vec<(String, String)> {
+				fields
+					.iter()
+					.map(|field| (format!("{table}_{field}_uniq"), field.clone()))
+					.collect()
+			}
+
+			pub fn foreign_key_constraint_name(table: &str, column: &str) -> String {
+				format!("fk_{table}_{column}")
+			}
+
+			pub fn enum_domain_constraint_name(table: &str, column: &str) -> String {
+				format!("{table}_{column}_model_enum_check")
+			}
+		}
+
 		pub type FixtureFields = serde_json::Map<String, serde_json::Value>;
 		pub type FixtureValue = serde_json::Value;
 

--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -483,6 +483,9 @@ pub mod db {
 			fn field_metadata() -> Vec<inspection::FieldInfo>;
 			fn index_metadata() -> Vec<inspection::IndexInfo>;
 			fn constraint_metadata() -> Vec<inspection::ConstraintInfo>;
+			fn constraint_fields(_constraint: &str) -> Option<Vec<&'static str>> {
+				None
+			}
 			fn relationship_metadata() -> Vec<inspection::RelationInfo>;
 			fn generated_field_names() -> &'static [&'static str];
 			fn primary_key_uses_zero_sentinel() -> bool {

--- a/crates/reinhardt-core/src/exception/database.rs
+++ b/crates/reinhardt-core/src/exception/database.rs
@@ -42,6 +42,9 @@ pub struct DatabaseError {
 	kind: DatabaseErrorKind,
 	message: String,
 	code: Option<String>,
+	constraint: Option<String>,
+	table: Option<String>,
+	columns: Vec<String>,
 	source: Option<Arc<dyn std::error::Error + Send + Sync>>,
 }
 
@@ -52,6 +55,9 @@ impl DatabaseError {
 			kind,
 			message: message.into(),
 			code: None,
+			constraint: None,
+			table: None,
+			columns: Vec::new(),
 			source: None,
 		}
 	}
@@ -59,6 +65,28 @@ impl DatabaseError {
 	/// Associates a driver- or database-specific error code with this error.
 	pub fn with_code(mut self, code: impl Into<String>) -> Self {
 		self.code = Some(code.into());
+		self
+	}
+
+	/// Associates the physical constraint name reported by the database.
+	pub fn with_constraint(mut self, constraint: impl Into<String>) -> Self {
+		self.constraint = Some(constraint.into());
+		self
+	}
+
+	/// Associates the physical table name reported by the database.
+	pub fn with_table(mut self, table: impl Into<String>) -> Self {
+		self.table = Some(table.into());
+		self
+	}
+
+	/// Replaces the ordered physical columns reported by the database.
+	pub fn with_columns<I, S>(mut self, columns: I) -> Self
+	where
+		I: IntoIterator<Item = S>,
+		S: Into<String>,
+	{
+		self.columns = columns.into_iter().map(Into::into).collect();
 		self
 	}
 
@@ -94,6 +122,21 @@ impl DatabaseError {
 	pub fn code(&self) -> Option<&str> {
 		self.code.as_deref()
 	}
+
+	/// Returns the physical constraint name, when supplied by the backend.
+	pub fn constraint(&self) -> Option<&str> {
+		self.constraint.as_deref()
+	}
+
+	/// Returns the physical table name, when supplied by the backend.
+	pub fn table(&self) -> Option<&str> {
+		self.table.as_deref()
+	}
+
+	/// Returns the ordered physical columns supplied by the backend.
+	pub fn columns(&self) -> &[String] {
+		&self.columns
+	}
 }
 
 impl std::fmt::Debug for DatabaseError {
@@ -103,6 +146,9 @@ impl std::fmt::Debug for DatabaseError {
 			.field("kind", &self.kind)
 			.field("message", &self.message)
 			.field("code", &self.code)
+			.field("constraint", &self.constraint)
+			.field("table", &self.table)
+			.field("columns", &self.columns)
 			.field("source", &self.source)
 			.finish()
 	}
@@ -124,7 +170,12 @@ impl std::error::Error for DatabaseError {
 
 impl PartialEq for DatabaseError {
 	fn eq(&self, other: &Self) -> bool {
-		self.kind == other.kind && self.message == other.message && self.code == other.code
+		self.kind == other.kind
+			&& self.message == other.message
+			&& self.code == other.code
+			&& self.constraint == other.constraint
+			&& self.table == other.table
+			&& self.columns == other.columns
 	}
 }
 
@@ -165,5 +216,55 @@ mod tests {
 				.and_then(|source| source.downcast_ref::<io::Error>())
 				.is_some()
 		);
+	}
+
+	#[test]
+	fn database_error_retains_structured_object_metadata() {
+		let error = DatabaseError::new(DatabaseErrorKind::UniqueViolation, "duplicate")
+			.with_constraint("users_email_key")
+			.with_table("users")
+			.with_columns(["email", "tenant_id"]);
+
+		assert_eq!(error.constraint(), Some("users_email_key"));
+		assert_eq!(error.table(), Some("users"));
+		assert_eq!(error.columns(), ["email", "tenant_id"]);
+		assert!(format!("{error:?}").contains("users_email_key"));
+	}
+
+	#[test]
+	fn cloned_database_error_retains_metadata_and_source() {
+		let error = DatabaseError::new(DatabaseErrorKind::NotNullViolation, "missing")
+			.with_table("users")
+			.with_columns(["email"])
+			.with_source(io::Error::other("driver failure"));
+
+		let cloned = error.clone();
+
+		assert_eq!(cloned.table(), Some("users"));
+		assert_eq!(cloned.columns(), ["email"]);
+		assert!(
+			cloned
+				.source()
+				.and_then(|source| source.downcast_ref::<io::Error>())
+				.is_some()
+		);
+	}
+
+	#[test]
+	fn database_error_equality_includes_metadata_but_not_source_identity() {
+		let left = DatabaseError::new(DatabaseErrorKind::UniqueViolation, "duplicate")
+			.with_constraint("users_email_key")
+			.with_columns(["email"])
+			.with_source(io::Error::other("left"));
+		let same = DatabaseError::new(DatabaseErrorKind::UniqueViolation, "duplicate")
+			.with_constraint("users_email_key")
+			.with_columns(["email"])
+			.with_source(io::Error::other("right"));
+		let different = DatabaseError::new(DatabaseErrorKind::UniqueViolation, "duplicate")
+			.with_constraint("users_username_key")
+			.with_columns(["username"]);
+
+		assert_eq!(left, same);
+		assert_ne!(left, different);
 	}
 }

--- a/crates/reinhardt-core/src/exception/database.rs
+++ b/crates/reinhardt-core/src/exception/database.rs
@@ -42,10 +42,15 @@ pub struct DatabaseError {
 	kind: DatabaseErrorKind,
 	message: String,
 	code: Option<String>,
+	metadata: Option<Box<DatabaseErrorMetadata>>,
+	source: Option<Arc<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Clone, Default)]
+struct DatabaseErrorMetadata {
 	constraint: Option<String>,
 	table: Option<String>,
 	columns: Vec<String>,
-	source: Option<Arc<dyn std::error::Error + Send + Sync>>,
 }
 
 impl DatabaseError {
@@ -55,9 +60,7 @@ impl DatabaseError {
 			kind,
 			message: message.into(),
 			code: None,
-			constraint: None,
-			table: None,
-			columns: Vec::new(),
+			metadata: None,
 			source: None,
 		}
 	}
@@ -70,13 +73,13 @@ impl DatabaseError {
 
 	/// Associates the physical constraint name reported by the database.
 	pub fn with_constraint(mut self, constraint: impl Into<String>) -> Self {
-		self.constraint = Some(constraint.into());
+		self.metadata_mut().constraint = Some(constraint.into());
 		self
 	}
 
 	/// Associates the physical table name reported by the database.
 	pub fn with_table(mut self, table: impl Into<String>) -> Self {
-		self.table = Some(table.into());
+		self.metadata_mut().table = Some(table.into());
 		self
 	}
 
@@ -86,7 +89,7 @@ impl DatabaseError {
 		I: IntoIterator<Item = S>,
 		S: Into<String>,
 	{
-		self.columns = columns.into_iter().map(Into::into).collect();
+		self.metadata_mut().columns = columns.into_iter().map(Into::into).collect();
 		self
 	}
 
@@ -125,17 +128,28 @@ impl DatabaseError {
 
 	/// Returns the physical constraint name, when supplied by the backend.
 	pub fn constraint(&self) -> Option<&str> {
-		self.constraint.as_deref()
+		self.metadata
+			.as_deref()
+			.and_then(|metadata| metadata.constraint.as_deref())
 	}
 
 	/// Returns the physical table name, when supplied by the backend.
 	pub fn table(&self) -> Option<&str> {
-		self.table.as_deref()
+		self.metadata
+			.as_deref()
+			.and_then(|metadata| metadata.table.as_deref())
 	}
 
 	/// Returns the ordered physical columns supplied by the backend.
 	pub fn columns(&self) -> &[String] {
-		&self.columns
+		self.metadata
+			.as_deref()
+			.map_or(&[], |metadata| metadata.columns.as_slice())
+	}
+
+	fn metadata_mut(&mut self) -> &mut DatabaseErrorMetadata {
+		self.metadata
+			.get_or_insert_with(|| Box::new(DatabaseErrorMetadata::default()))
 	}
 }
 
@@ -146,9 +160,9 @@ impl std::fmt::Debug for DatabaseError {
 			.field("kind", &self.kind)
 			.field("message", &self.message)
 			.field("code", &self.code)
-			.field("constraint", &self.constraint)
-			.field("table", &self.table)
-			.field("columns", &self.columns)
+			.field("constraint", &self.constraint())
+			.field("table", &self.table())
+			.field("columns", &self.columns())
 			.field("source", &self.source)
 			.finish()
 	}
@@ -173,9 +187,9 @@ impl PartialEq for DatabaseError {
 		self.kind == other.kind
 			&& self.message == other.message
 			&& self.code == other.code
-			&& self.constraint == other.constraint
-			&& self.table == other.table
-			&& self.columns == other.columns
+			&& self.constraint() == other.constraint()
+			&& self.table() == other.table()
+			&& self.columns() == other.columns()
 	}
 }
 
@@ -185,6 +199,7 @@ impl Eq for DatabaseError {}
 mod tests {
 	use std::error::Error as _;
 	use std::io;
+	use std::mem::size_of;
 
 	use super::{DatabaseError, DatabaseErrorKind};
 
@@ -229,6 +244,11 @@ mod tests {
 		assert_eq!(error.table(), Some("users"));
 		assert_eq!(error.columns(), ["email", "tenant_id"]);
 		assert!(format!("{error:?}").contains("users_email_key"));
+	}
+
+	#[test]
+	fn database_error_remains_small_enough_for_result_values() {
+		assert!(size_of::<DatabaseError>() < 128);
 	}
 
 	#[test]

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -1184,6 +1184,35 @@ migrate to `Q::from_raw_sql`. Unsupported operators and unrecognized SQL now
 fail closed; runtime values must be expressed with `Q::new` so they remain
 bound parameters.
 
+### Constraint Violation Metadata
+
+`DatabaseError::code()` retains a driver or database code. `constraint()`,
+`table()`, and `columns()` retain structured database object metadata when the
+backend supplies it:
+
+```rust
+use reinhardt_core::exception::DatabaseErrorKind;
+use reinhardt_db::DatabaseError;
+
+let error = DatabaseError::new(
+	DatabaseErrorKind::UniqueViolation,
+	"duplicate key",
+)
+.with_code("23505")
+.with_constraint("users_email_key")
+.with_table("users")
+.with_columns(["email"]);
+
+assert_eq!(error.constraint(), Some("users_email_key"));
+assert_eq!(error.table(), Some("users"));
+assert_eq!(error.columns(), ["email"]);
+```
+
+SQLx messages are diagnostics only and must never be parsed for this metadata.
+PostgreSQL currently supplies object identifiers. MySQL and SQLite normally
+expose only the portable violation kind through SQLx, so callers must handle
+missing metadata without guessing from a message.
+
 ### Scoped N+1 Query Detection
 
 Use `NPlusOneScope` around development diagnostics or focused tests to detect

--- a/crates/reinhardt-db/src/backends/error.rs
+++ b/crates/reinhardt-db/src/backends/error.rs
@@ -159,6 +159,20 @@ fn parse_postgres_qualified_identifier(identifier: &str) -> Option<Vec<String>> 
 	Some(segments)
 }
 
+#[doc(hidden)]
+pub fn database_table_matches_model(model_table: &str, database_table: &str) -> bool {
+	if model_table.is_empty() || model_table.contains('\0') {
+		return false;
+	}
+	if !model_table.contains(['.', '"']) {
+		return model_table == database_table;
+	}
+
+	parse_postgres_qualified_identifier(model_table)
+		.and_then(|segments| segments.into_iter().last())
+		.is_some_and(|table| table == database_table)
+}
+
 fn postgres_display_name_final_segment_is(display_name: &str, expected: &str) -> bool {
 	// PostgreSQL's TypeNameToString and NameListToString join parsed name components with dots
 	// before the diagnostic adds its outer quotes. A quoted identifier containing a dot is
@@ -372,11 +386,23 @@ fn map_sqlx_database_error(error: &(dyn sqlx::error::DatabaseError + 'static)) -
 			_ => DatabaseErrorKind::Query,
 		},
 	};
-	let database_error = DatabaseError::new(kind, error.message());
-	match code {
-		Some(code) => database_error.with_code(code),
-		None => database_error,
+	let mut database_error = DatabaseError::new(kind, error.message());
+	if let Some(code) = code {
+		database_error = database_error.with_code(code);
 	}
+	if let Some(constraint) = error.constraint() {
+		database_error = database_error.with_constraint(constraint);
+	}
+	if let Some(table) = error.table() {
+		database_error = database_error.with_table(table);
+	}
+	if let Some(column) = error
+		.try_downcast_ref::<sqlx::postgres::PgDatabaseError>()
+		.and_then(sqlx::postgres::PgDatabaseError::column)
+	{
+		database_error = database_error.with_columns([column]);
+	}
+	database_error
 }
 
 #[cfg(any(
@@ -387,7 +413,8 @@ fn map_sqlx_database_error(error: &(dyn sqlx::error::DatabaseError + 'static)) -
 	test
 ))]
 pub(crate) fn map_sqlx_error(error: sqlx::Error) -> DatabaseError {
-	map_sqlx_error_ref(&error)
+	let database_error = map_sqlx_error_ref(&error);
+	database_error.with_source(error)
 }
 
 fn map_sqlx_error_ref(error: &sqlx::Error) -> DatabaseError {
@@ -471,8 +498,8 @@ mod tests {
 	use sqlx::error::{DatabaseError as SqlxDatabaseError, ErrorKind};
 
 	use super::{
-		DatabaseError, DatabaseErrorKind, PgvectorOperationKind, map_sqlx_error,
-		map_sqlx_error_with_pgvector_context,
+		DatabaseError, DatabaseErrorKind, PgvectorOperationKind, database_table_matches_model,
+		map_sqlx_error, map_sqlx_error_with_pgvector_context,
 	};
 
 	const DATABASE_MESSAGE: &str = "database operation failed";
@@ -572,11 +599,34 @@ mod tests {
 		// Assert
 		assert_eq!(
 			error,
-			DatabaseError::new(expected_kind, DATABASE_MESSAGE).with_code(DATABASE_CODE)
+			DatabaseError::new(expected_kind, DATABASE_MESSAGE)
+				.with_code(DATABASE_CODE)
+				.with_constraint(CONSTRAINT_NAME)
+				.with_table(TABLE_NAME)
 		);
 		assert_eq!(error.message(), DATABASE_MESSAGE);
 		assert_eq!(error.code(), Some(DATABASE_CODE));
+		assert_eq!(error.constraint(), Some(CONSTRAINT_NAME));
+		assert_eq!(error.table(), Some(TABLE_NAME));
+		assert_eq!(error.columns(), []);
+		assert!(
+			error
+				.source()
+				.and_then(|source| source.downcast_ref::<sqlx::Error>())
+				.is_some()
+		);
 		assert_eq!(error.to_string(), DATABASE_MESSAGE);
+	}
+
+	#[test]
+	fn database_table_match_distinguishes_qualified_and_quoted_dotted_names() {
+		assert!(database_table_matches_model("public.users", "users"));
+		assert!(!database_table_matches_model(r#""public.users""#, "users"));
+		assert!(database_table_matches_model(
+			r#""public.users""#,
+			"public.users"
+		));
+		assert!(!database_table_matches_model("public..users", "users"));
 	}
 
 	#[test]

--- a/crates/reinhardt-db/src/backends/error.rs
+++ b/crates/reinhardt-db/src/backends/error.rs
@@ -608,7 +608,7 @@ mod tests {
 		assert_eq!(error.code(), Some(DATABASE_CODE));
 		assert_eq!(error.constraint(), Some(CONSTRAINT_NAME));
 		assert_eq!(error.table(), Some(TABLE_NAME));
-		assert_eq!(error.columns(), []);
+		assert_eq!(error.columns(), &[] as &[String]);
 		assert!(
 			error
 				.source()

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -13,6 +13,35 @@
 //!
 //! Equivalent to Django's `django.db` package.
 //!
+//! ## Constraint violation metadata
+//!
+//! [`DatabaseError::code`] retains a driver or database code. When a backend
+//! supplies object identifiers, [`DatabaseError::constraint`],
+//! [`DatabaseError::table`], and [`DatabaseError::columns`] retain them without
+//! parsing diagnostic text:
+//!
+//! ```rust
+//! use reinhardt_core::exception::DatabaseErrorKind;
+//! use reinhardt_db::DatabaseError;
+//!
+//! let error = DatabaseError::new(
+//! 	DatabaseErrorKind::UniqueViolation,
+//! 	"duplicate key",
+//! )
+//! .with_code("23505")
+//! .with_constraint("users_email_key")
+//! .with_table("users")
+//! .with_columns(["email"]);
+//!
+//! assert_eq!(error.constraint(), Some("users_email_key"));
+//! assert_eq!(error.table(), Some("users"));
+//! assert_eq!(error.columns(), ["email"]);
+//! ```
+//!
+//! SQLx messages are diagnostic only and must never be parsed for object
+//! metadata. PostgreSQL currently supplies object identifiers; MySQL and
+//! SQLite normally expose only the portable error kind through SQLx.
+//!
 //! ## Features
 //!
 //! ### Database Backends (`backends` module)

--- a/crates/reinhardt-db/src/lib.rs
+++ b/crates/reinhardt-db/src/lib.rs
@@ -25,8 +25,8 @@
 //! use reinhardt_db::DatabaseError;
 //!
 //! let error = DatabaseError::new(
-//! 	DatabaseErrorKind::UniqueViolation,
-//! 	"duplicate key",
+//!     DatabaseErrorKind::UniqueViolation,
+//!     "duplicate key",
 //! )
 //! .with_code("23505")
 //! .with_constraint("users_email_key")

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -850,7 +850,7 @@ impl ModelState {
 			&& let Some(ref fk_info) = field.foreign_key
 		{
 			let constraint = ConstraintDefinition {
-				name: format!("fk_{}_{}", self.table_name, field_name),
+				name: crate::naming::foreign_key_constraint_name(&self.table_name, field_name),
 				constraint_type: "foreign_key".to_string(),
 				fields: vec![field_name.to_string()],
 				expression: None,
@@ -7291,7 +7291,7 @@ impl MigrationAutodetector {
 		let constraints = vec![
 			// Foreign key to source table
 			super::Constraint::ForeignKey {
-				name: format!("fk_{}_{}", table_name, source_column),
+				name: crate::naming::foreign_key_constraint_name(&table_name, &source_column),
 				columns: vec![source_column.clone()],
 				referenced_table: source_table.clone(),
 				referenced_columns: vec!["id".to_string()],
@@ -7301,7 +7301,7 @@ impl MigrationAutodetector {
 			},
 			// Foreign key to target table
 			super::Constraint::ForeignKey {
-				name: format!("fk_{}_{}", table_name, target_column),
+				name: crate::naming::foreign_key_constraint_name(&table_name, &target_column),
 				columns: vec![target_column.clone()],
 				referenced_table: target_table.clone(),
 				referenced_columns: vec!["id".to_string()],
@@ -8901,7 +8901,10 @@ impl MigrationAutodetector {
 			// Create FK constraints for the intermediate table
 			let constraints = vec![
 				super::operations::Constraint::ForeignKey {
-					name: format!("fk_{}_{}", through_table, source_column),
+					name: crate::naming::foreign_key_constraint_name(
+						&through_table,
+						&source_column,
+					),
 					columns: vec![source_column.clone()],
 					referenced_table: source_table.clone(),
 					referenced_columns: vec!["id".to_string()],
@@ -8910,7 +8913,10 @@ impl MigrationAutodetector {
 					deferrable: None,
 				},
 				super::operations::Constraint::ForeignKey {
-					name: format!("fk_{}_{}", through_table, target_column),
+					name: crate::naming::foreign_key_constraint_name(
+						&through_table,
+						&target_column,
+					),
 					columns: vec![target_column.clone()],
 					referenced_table: target_table,
 					referenced_columns: vec!["id".to_string()],
@@ -9236,8 +9242,8 @@ impl MigrationAutodetector {
 		new_column: &str,
 	) -> bool {
 		[
-			format!("fk_{}_{}", rename.old_table, old_column),
-			format!("fk_{}_{}", rename.new_table, new_column),
+			crate::naming::foreign_key_constraint_name(&rename.old_table, old_column),
+			crate::naming::foreign_key_constraint_name(&rename.new_table, new_column),
 			format!("{}_unique", rename.old_table),
 			format!("{}_unique", rename.new_table),
 		]

--- a/crates/reinhardt-db/src/migrations/autodetector.rs
+++ b/crates/reinhardt-db/src/migrations/autodetector.rs
@@ -8902,7 +8902,7 @@ impl MigrationAutodetector {
 			let constraints = vec![
 				super::operations::Constraint::ForeignKey {
 					name: crate::naming::foreign_key_constraint_name(
-						&through_table,
+						through_table,
 						&source_column,
 					),
 					columns: vec![source_column.clone()],
@@ -8914,7 +8914,7 @@ impl MigrationAutodetector {
 				},
 				super::operations::Constraint::ForeignKey {
 					name: crate::naming::foreign_key_constraint_name(
-						&through_table,
+						through_table,
 						&target_column,
 					),
 					columns: vec![target_column.clone()],

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -17,7 +17,8 @@ use super::autodetector::{
 };
 use super::{ConstraintDefinition, GeneratedColumnDefinition};
 use crate::field_domain::FieldDomain;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use crate::naming::{enum_domain_constraint_name, generated_unique_constraint_names};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -78,8 +79,6 @@ pub struct ModelMetadata {
 }
 
 impl ModelMetadata {
-	const MAX_CONSTRAINT_IDENTIFIER_BYTES: usize = 63;
-
 	/// Creates a new instance.
 	pub fn new(
 		app_label: impl Into<String>,
@@ -121,56 +120,9 @@ impl ModelMetadata {
 
 	/// Adds the typed enum-domain constraint for a database column.
 	pub fn add_enum_domain_constraint(&mut self, column: &str, domain: FieldDomain) {
-		let name = super::operations::truncate_identifier_with_hash(&format!(
-			"{}_{}_model_enum_check",
-			self.table_name, column
-		));
+		let name = enum_domain_constraint_name(&self.table_name, column);
 		self.constraints
 			.push(ConstraintDefinition::enum_domain(name, column, domain));
-	}
-
-	fn synthesized_unique_constraint_name(
-		&self,
-		field_name: &str,
-		generated_names: &HashSet<String>,
-		existing_constraints: &[ConstraintDefinition],
-	) -> String {
-		// The raw tuple digest is required because concatenated safe fragments do
-		// not preserve table/field boundaries and normalized field names can
-		// collide. It also makes the name independent of field iteration order.
-		let tuple_digest =
-			stable_constraint_name_hash(&format!("{}\0{}", self.table_name, field_name));
-		let base_name = bounded_constraint_identifier(&format!(
-			"{}_{}_uniq_{tuple_digest:08x}",
-			safe_constraint_table_fragment(&self.table_name),
-			safe_constraint_name_fragment(field_name)
-		));
-		let is_taken = |candidate: &str| {
-			self.constraints
-				.iter()
-				.any(|constraint| constraint.name.eq_ignore_ascii_case(candidate))
-				|| existing_constraints
-					.iter()
-					.any(|constraint| constraint.name.eq_ignore_ascii_case(candidate))
-				|| generated_names
-					.iter()
-					.any(|name| name.eq_ignore_ascii_case(candidate))
-		};
-		if !is_taken(&base_name) {
-			return base_name;
-		}
-
-		let field_digest = stable_constraint_name_hash(field_name);
-		let mut candidate =
-			bounded_constraint_identifier(&format!("{base_name}_field_{field_digest:08x}"));
-		let mut suffix = 2;
-		while is_taken(&candidate) {
-			candidate = bounded_constraint_identifier(&format!(
-				"{base_name}_field_{field_digest:08x}_{suffix}"
-			));
-			suffix += 1;
-		}
-		candidate
 	}
 
 	/// Returns constraints registered by the `#[model(...)]` macro, such as
@@ -324,45 +276,47 @@ impl ModelMetadata {
 		// Generate named Unique constraints from field params. The field-level
 		// `unique` flag is consumed above so the same declaration cannot be
 		// emitted both inline and as a table constraint.
-		let mut generated_unique_constraint_names = HashSet::new();
-		let mut unique_fields = self
+		let unique_columns = self
 			.fields
 			.iter()
-			.filter(|(_, field_meta)| {
-				field_meta.params.get("unique").map(String::as_str) == Some("true")
+			.filter_map(|(field_name, field_meta)| {
+				(field_meta.params.get("unique").map(String::as_str) == Some("true")).then(|| {
+					field_meta
+						.params
+						.get("db_column")
+						.cloned()
+						.unwrap_or_else(|| field_name.clone())
+				})
 			})
-			.collect::<Vec<_>>();
-		unique_fields.sort_unstable_by_key(|(left, _)| *left);
-		for (field_name, field_meta) in unique_fields {
-			if field_meta.params.get("unique").map(String::as_str) == Some("true") {
-				let column_name = field_meta
-					.params
-					.get("db_column")
-					.map_or(field_name, |name| name);
-				// Prefer a model-level declaration when it explicitly names the
-				// single-column constraint. This keeps one physical constraint and
-				// preserves the declared name.
-				if self.constraints.iter().any(|constraint| {
+			.filter(|column_name| {
+				!self.constraints.iter().any(|constraint| {
 					constraint.constraint_type.eq_ignore_ascii_case("unique")
 						&& constraint.fields.len() == 1
-						&& constraint.fields[0].as_str() == column_name.as_str()
-				}) {
-					continue;
-				}
-				let constraint = ConstraintDefinition {
-					name: self.synthesized_unique_constraint_name(
-						column_name,
-						&generated_unique_constraint_names,
-						&model_state.constraints,
-					),
-					constraint_type: "unique".to_string(),
-					fields: vec![column_name.clone()],
-					expression: None,
-					foreign_key_info: None,
-				};
-				generated_unique_constraint_names.insert(constraint.name.clone());
-				model_state.constraints.push(constraint);
-			}
+						&& constraint.fields[0] == *column_name
+				})
+			})
+			.collect::<Vec<_>>();
+		let reserved = self
+			.constraints
+			.iter()
+			.map(|constraint| constraint.name.clone())
+			.chain(
+				model_state
+					.constraints
+					.iter()
+					.map(|constraint| constraint.name.clone()),
+			)
+			.collect::<Vec<_>>();
+		for (name, column_name) in
+			generated_unique_constraint_names(&self.table_name, &unique_columns, &reserved)
+		{
+			model_state.constraints.push(ConstraintDefinition {
+				name,
+				constraint_type: "unique".to_string(),
+				fields: vec![column_name],
+				expression: None,
+				foreign_key_info: None,
+			});
 		}
 
 		// Copy model-level constraints declared via #[model(unique_together = ...)]
@@ -381,10 +335,7 @@ impl ModelMetadata {
 				.get("db_column")
 				.map(String::as_str)
 				.unwrap_or(name);
-			let constraint_name = super::operations::truncate_identifier_with_hash(&format!(
-				"{}_{}_model_enum_check",
-				self.table_name, column
-			));
+			let constraint_name = enum_domain_constraint_name(&self.table_name, column);
 			if !model_state
 				.constraints
 				.iter()
@@ -402,59 +353,6 @@ impl ModelMetadata {
 
 		model_state
 	}
-}
-
-fn safe_constraint_name_fragment(value: &str) -> String {
-	let mut fragment = String::with_capacity(value.len());
-	for character in value.chars() {
-		if character.is_ascii_alphanumeric() || character == '_' {
-			fragment.push(character.to_ascii_lowercase());
-		} else {
-			fragment.push('_');
-		}
-	}
-
-	if fragment.is_empty() {
-		fragment.push_str("table");
-	} else if fragment
-		.as_bytes()
-		.first()
-		.is_some_and(|character| character.is_ascii_digit())
-	{
-		fragment.insert_str(0, "table_");
-	}
-	fragment
-}
-
-fn safe_constraint_table_fragment(value: &str) -> String {
-	let fragment = safe_constraint_name_fragment(value);
-	if fragment == value {
-		return fragment;
-	}
-	format!("{fragment}_{:08x}", stable_constraint_name_hash(value))
-}
-
-fn stable_constraint_name_hash(value: &str) -> u32 {
-	let mut hash = 0x811c9dc5_u32;
-	for byte in value.bytes() {
-		hash ^= u32::from(byte);
-		hash = hash.wrapping_mul(0x01000193);
-	}
-	hash
-}
-
-fn bounded_constraint_identifier(value: &str) -> String {
-	if value.len() <= ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES {
-		return value.to_owned();
-	}
-
-	let suffix = format!("_{:08x}", stable_constraint_name_hash(value));
-	let prefix_len = ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES - suffix.len();
-	let mut end = prefix_len;
-	while !value.is_char_boundary(end) {
-		end -= 1;
-	}
-	format!("{}{}", &value[..end], suffix)
 }
 
 /// Field metadata for registration
@@ -1019,6 +917,7 @@ mod tests {
 	use crate::migrations::autodetector::{ForeignKeyInfo, MigrationAutodetector, ProjectState};
 	use crate::migrations::operations::{Constraint, Operation, SqlDialect};
 	use crate::migrations::{FieldType, GeneratedStorage, SchemaExpr};
+	use crate::naming::stable_constraint_name_hash;
 	use rstest::rstest;
 
 	#[test]
@@ -1805,9 +1704,11 @@ mod tests {
 
 		// Assert
 		assert_eq!(constraints.len(), 2);
-		assert!(constraints.iter().all(|constraint| {
-			constraint.name.len() <= ModelMetadata::MAX_CONSTRAINT_IDENTIFIER_BYTES
-		}));
+		assert!(
+			constraints
+				.iter()
+				.all(|constraint| constraint.name.len() <= 63)
+		);
 		assert_ne!(constraints[0].name, constraints[1].name);
 	}
 

--- a/crates/reinhardt-db/src/migrations/model_registry.rs
+++ b/crates/reinhardt-db/src/migrations/model_registry.rs
@@ -279,15 +279,11 @@ impl ModelMetadata {
 		let unique_columns = self
 			.fields
 			.iter()
-			.filter_map(|(field_name, field_meta)| {
-				(field_meta.params.get("unique").map(String::as_str) == Some("true")).then(|| {
-					field_meta
+			.filter(|&(field_name, field_meta)| (field_meta.params.get("unique").map(String::as_str) == Some("true"))).map(|(field_name, field_meta)| field_meta
 						.params
 						.get("db_column")
 						.cloned()
-						.unwrap_or_else(|| field_name.clone())
-				})
-			})
+						.unwrap_or_else(|| field_name.clone()))
 			.filter(|column_name| {
 				!self.constraints.iter().any(|constraint| {
 					constraint.constraint_type.eq_ignore_ascii_case("unique")

--- a/crates/reinhardt-db/src/migrations/operations.rs
+++ b/crates/reinhardt-db/src/migrations/operations.rs
@@ -54,6 +54,7 @@ pub use special::{RunCode, RunSQL, StateOperation};
 // These are maintained from the original operations.rs
 use super::IndexDefinition;
 use super::{ConstraintDefinition, FieldState, FieldType, ModelState, ProjectState};
+pub use crate::naming::truncate_identifier_with_hash;
 use pg_escape::{quote_identifier, quote_literal};
 use reinhardt_query::prelude::{
 	Alias, AlterTableStatement, CockroachDBQueryBuilder, ColumnDef, ColumnType as QueryColumnType,
@@ -5166,32 +5167,6 @@ impl ColumnDefinition {
 			domain: field_state.domain.clone(),
 		}
 	}
-}
-
-/// Truncate a database identifier to PostgreSQL's 63-byte limit with a stable hash suffix.
-pub fn truncate_identifier_with_hash(logical_name: &str) -> String {
-	const MAX_IDENTIFIER_LENGTH: usize = 63;
-	const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-	const FNV_PRIME: u64 = 0x00000100000001b3;
-	if logical_name.len() <= MAX_IDENTIFIER_LENGTH {
-		return logical_name.to_string();
-	}
-
-	let hash = logical_name
-		.as_bytes()
-		.iter()
-		.fold(FNV_OFFSET_BASIS, |hash, byte| {
-			(hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
-		});
-	let hash = format!("{hash:016x}");
-	let prefix_len = MAX_IDENTIFIER_LENGTH - hash.len() - 1;
-	let boundary = logical_name
-		.char_indices()
-		.map(|(index, _)| index)
-		.take_while(|index| *index <= prefix_len)
-		.last()
-		.unwrap_or(0);
-	format!("{}_{}", &logical_name[..boundary], hash)
 }
 
 /// Generate the physical name used for a legacy table/column index operation.

--- a/crates/reinhardt-db/src/naming.rs
+++ b/crates/reinhardt-db/src/naming.rs
@@ -66,3 +66,176 @@ pub fn to_snake_case(name: &str) -> String {
 
 	result
 }
+
+/// Truncate a database identifier to PostgreSQL's 63-byte limit with a stable hash suffix.
+#[doc(hidden)]
+pub fn truncate_identifier_with_hash(logical_name: &str) -> String {
+	const MAX_IDENTIFIER_LENGTH: usize = 63;
+	const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+	const FNV_PRIME: u64 = 0x00000100000001b3;
+	if logical_name.len() <= MAX_IDENTIFIER_LENGTH {
+		return logical_name.to_string();
+	}
+
+	let hash = logical_name
+		.as_bytes()
+		.iter()
+		.fold(FNV_OFFSET_BASIS, |hash, byte| {
+			(hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+		});
+	let hash = format!("{hash:016x}");
+	let prefix_len = MAX_IDENTIFIER_LENGTH - hash.len() - 1;
+	let boundary = logical_name
+		.char_indices()
+		.map(|(index, _)| index)
+		.take_while(|index| *index <= prefix_len)
+		.last()
+		.unwrap_or(0);
+	format!("{}_{}", &logical_name[..boundary], hash)
+}
+
+#[doc(hidden)]
+pub fn generated_unique_constraint_names(
+	table: &str,
+	fields: &[String],
+	reserved: &[String],
+) -> Vec<(String, String)> {
+	let mut fields = fields.to_vec();
+	fields.sort_unstable();
+	let mut generated = Vec::with_capacity(fields.len());
+
+	for field in fields {
+		let tuple_digest = stable_constraint_name_hash(&format!("{table}\0{field}"));
+		let base_name = bounded_constraint_identifier(&format!(
+			"{}_{}_uniq_{tuple_digest:08x}",
+			safe_constraint_table_fragment(table),
+			safe_constraint_name_fragment(&field)
+		));
+		let is_taken = |candidate: &str| {
+			reserved
+				.iter()
+				.chain(generated.iter().map(|(name, _)| name))
+				.any(|name| name.eq_ignore_ascii_case(candidate))
+		};
+		let name = if !is_taken(&base_name) {
+			base_name
+		} else {
+			let field_digest = stable_constraint_name_hash(&field);
+			let mut candidate =
+				bounded_constraint_identifier(&format!("{base_name}_field_{field_digest:08x}"));
+			let mut suffix = 2;
+			while is_taken(&candidate) {
+				candidate = bounded_constraint_identifier(&format!(
+					"{base_name}_field_{field_digest:08x}_{suffix}"
+				));
+				suffix += 1;
+			}
+			candidate
+		};
+		generated.push((name, field));
+	}
+
+	generated
+}
+
+#[doc(hidden)]
+pub fn foreign_key_constraint_name(table: &str, column: &str) -> String {
+	format!("fk_{table}_{column}")
+}
+
+#[doc(hidden)]
+pub fn enum_domain_constraint_name(table: &str, column: &str) -> String {
+	truncate_identifier_with_hash(&format!("{table}_{column}_model_enum_check"))
+}
+
+fn safe_constraint_name_fragment(value: &str) -> String {
+	let mut fragment = String::with_capacity(value.len());
+	for character in value.chars() {
+		if character.is_ascii_alphanumeric() || character == '_' {
+			fragment.push(character.to_ascii_lowercase());
+		} else {
+			fragment.push('_');
+		}
+	}
+
+	if fragment.is_empty() {
+		fragment.push_str("table");
+	} else if fragment
+		.as_bytes()
+		.first()
+		.is_some_and(|character| character.is_ascii_digit())
+	{
+		fragment.insert_str(0, "table_");
+	}
+	fragment
+}
+
+fn safe_constraint_table_fragment(value: &str) -> String {
+	let fragment = safe_constraint_name_fragment(value);
+	if fragment == value {
+		return fragment;
+	}
+	format!("{fragment}_{:08x}", stable_constraint_name_hash(value))
+}
+
+pub(crate) fn stable_constraint_name_hash(value: &str) -> u32 {
+	let mut hash = 0x811c9dc5_u32;
+	for byte in value.bytes() {
+		hash ^= u32::from(byte);
+		hash = hash.wrapping_mul(0x01000193);
+	}
+	hash
+}
+
+fn bounded_constraint_identifier(value: &str) -> String {
+	const MAX_CONSTRAINT_IDENTIFIER_BYTES: usize = 63;
+	if value.len() <= MAX_CONSTRAINT_IDENTIFIER_BYTES {
+		return value.to_owned();
+	}
+
+	let suffix = format!("_{:08x}", stable_constraint_name_hash(value));
+	let prefix_len = MAX_CONSTRAINT_IDENTIFIER_BYTES - suffix.len();
+	let mut end = prefix_len;
+	while !value.is_char_boundary(end) {
+		end -= 1;
+	}
+	format!("{}{}", &value[..end], suffix)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		enum_domain_constraint_name, foreign_key_constraint_name, generated_unique_constraint_names,
+	};
+
+	#[test]
+	fn generated_unique_names_are_stable_bounded_and_collision_safe() {
+		let fields = vec!["email_addr".to_owned(), "display_name".to_owned()];
+		let first = generated_unique_constraint_names("accounts", &fields, &[]);
+		let reserved = vec![first[0].0.to_ascii_uppercase()];
+		let collided = generated_unique_constraint_names("accounts", &fields, &reserved);
+
+		assert_eq!(
+			first,
+			generated_unique_constraint_names("accounts", &fields, &[])
+		);
+		assert!(first.iter().all(|(name, _)| name.len() <= 63));
+		assert_ne!(
+			first[0].0.to_ascii_lowercase(),
+			collided[0].0.to_ascii_lowercase()
+		);
+		assert_eq!(collided[0].1, "display_name");
+	}
+
+	#[test]
+	fn generated_fk_and_domain_names_use_physical_columns() {
+		assert_eq!(
+			foreign_key_constraint_name("posts", "author_key"),
+			"fk_posts_author_key"
+		);
+		assert_eq!(
+			enum_domain_constraint_name("jobs", "status"),
+			"jobs_status_model_enum_check"
+		);
+	}
+}

--- a/crates/reinhardt-db/src/orm.rs
+++ b/crates/reinhardt-db/src/orm.rs
@@ -133,6 +133,9 @@
 //! built-in MySQL profile requires 8.0.1 or newer. Older/custom servers report
 //! their exact feature set through [`TransactionExecutor::row_lock_capabilities`].
 
+#[doc(hidden)]
+pub use crate::naming;
+
 // Core modules - always available
 pub mod aggregation;
 /// Annotation module.

--- a/crates/reinhardt-db/src/orm/model.rs
+++ b/crates/reinhardt-db/src/orm/model.rs
@@ -627,6 +627,15 @@ pub trait Model: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone {
 		Vec::new()
 	}
 
+	/// Returns public model fields owned by an exact physical constraint name.
+	///
+	/// `Some(fields)` proves ownership. `Some(Vec::new())` represents a known
+	/// form-level constraint. Manual implementations opt in by overriding this
+	/// method; unknown names return `None`.
+	fn constraint_fields(_constraint: &str) -> Option<Vec<&'static str>> {
+		None
+	}
+
 	/// Get database-generated column names that must be omitted from ORM writes.
 	fn generated_field_names() -> &'static [&'static str] {
 		&[]

--- a/crates/reinhardt-db/tests/constraint_metadata.rs
+++ b/crates/reinhardt-db/tests/constraint_metadata.rs
@@ -2,8 +2,20 @@
 #![allow(unexpected_cfgs)]
 
 use reinhardt_core::macros::model;
-use reinhardt_db::{migrations::model_registry::global_registry, orm::Model};
+use reinhardt_db::{
+	associations::ForeignKeyField, migrations::model_registry::global_registry, orm::Model,
+};
 use serde::{Deserialize, Serialize};
+
+#[model(
+	app_label = "constraint_metadata_runtime",
+	table_name = "constraint_metadata_owners"
+)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ConstraintMetadataOwner {
+	#[field(primary_key = true)]
+	id: i64,
+}
 
 #[model(
 	app_label = "constraint_metadata_runtime",
@@ -18,10 +30,16 @@ use serde::{Deserialize, Serialize};
 struct ConstraintMetadataRecord {
 	#[field(primary_key = true)]
 	id: i64,
+	#[field(db_column = "email_addr", unique = true, max_length = 255)]
+	email: String,
+	#[field(check = "age >= 18")]
+	age: i32,
 	#[field(db_column = "tenant_key")]
 	tenant_id: i64,
 	#[field(db_column = "slug_key", max_length = 255)]
 	slug: String,
+	#[rel(foreign_key, db_column = "owner_key")]
+	owner: ForeignKeyField<ConstraintMetadataOwner>,
 }
 
 #[test]
@@ -51,4 +69,47 @@ fn derived_unique_constraint_keeps_logical_and_physical_metadata_distinct() {
 
 	assert_eq!(registered_constraint.fields, ["tenant_key", "slug_key"]);
 	assert_eq!(registered_constraint.expression, None);
+}
+
+#[test]
+fn derived_constraint_fields_match_registered_physical_constraints() {
+	let registered_model = global_registry()
+		.get_model("constraint_metadata_runtime", "ConstraintMetadataRecord")
+		.expect("derived model migration registration");
+
+	for constraint in registered_model.constraints().iter().filter(|constraint| {
+		constraint.constraint_type == "unique" || constraint.constraint_type == "foreign_key"
+	}) {
+		let expected = match constraint.fields.as_slice() {
+			["tenant_key", "slug_key"] => vec!["tenant_id", "slug"],
+			["email_addr"] => vec!["email"],
+			["owner_key"] => vec!["owner_id"],
+			fields => panic!("unexpected registered constraint fields: {fields:?}"),
+		};
+		assert_eq!(
+			ConstraintMetadataRecord::constraint_fields(&constraint.name),
+			Some(expected),
+			"constraint {} must resolve through the derived model",
+			constraint.name
+		);
+	}
+
+	assert_eq!(
+		ConstraintMetadataRecord::constraint_fields(
+			"constraint_metadata_active_tenant_slug_unique"
+		),
+		Some(vec!["tenant_id", "slug"]),
+	);
+	assert_eq!(
+		ConstraintMetadataRecord::constraint_fields("age_check"),
+		Some(Vec::new()),
+	);
+	assert_eq!(ConstraintMetadataRecord::constraint_fields("unknown"), None);
+
+	let owner_id = ConstraintMetadataRecord::field_metadata()
+		.into_iter()
+		.find(|field| field.db_column.as_deref() == Some("owner_key"))
+		.expect("derived foreign key field metadata");
+	assert_eq!(owner_id.name, "owner_id");
+	assert_eq!(owner_id.db_column.as_deref(), Some("owner_key"));
 }

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -636,6 +636,11 @@ violations map to the form. Unmapped or unproven errors remain the original
 framework error, so the caller chooses the safe fallback above. This helper is
 native-only; browser code consumes the resulting `ServerFnError` instead.
 
+This conversion preserves the existing serialized `ServerFnError` wire shape:
+it adds no database metadata to the browser response. Generated client forms
+route field errors by logical model field names. Composite `UNIQUE` and `CHECK`
+violations have no single logical field, so they reach the form error instead.
+
 ### Typed multipart server functions
 
 The function-like `#[server_fn]` API infers multipart transport when a

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -609,6 +609,33 @@ Arguments supplied from ambient context use `ambient_arguments`. The old
 transport layer: `#[server_fn]` client stubs attach `X-CSRFToken`, while
 non-WASM forms still render the hidden CSRF input for traditional posts.
 
+### Structured Server-Function Errors
+
+The native `model-server-fnset` feature can turn a proven model constraint
+violation into a safe validation response. Use the optional callback only for
+fixed, client-safe text:
+
+```rust,ignore
+let server_error = ServerFnError::try_from_model_error_with::<User, _>(
+	error,
+	|database_error, _fields| {
+		(database_error.constraint() == Some("users_email_unique"))
+			.then(|| "This email is already registered".to_owned())
+	},
+)
+.unwrap_or_else(|error| {
+	tracing::error!(error = %error, "user write failed");
+	ServerFnError::application("Failed to save user")
+});
+```
+
+Callback code must not return `DatabaseError::message()`, rejected values,
+table names, constraint names, or vendor diagnostics to the browser. A known
+single-field violation maps to that field; composite `UNIQUE` and `CHECK`
+violations map to the form. Unmapped or unproven errors remain the original
+framework error, so the caller chooses the safe fallback above. This helper is
+native-only; browser code consumes the resulting `ServerFnError` instead.
+
 ### Typed multipart server functions
 
 The function-like `#[server_fn]` API infers multipart transport when a

--- a/crates/reinhardt-pages/docs/server_fn_macro.md
+++ b/crates/reinhardt-pages/docs/server_fn_macro.md
@@ -904,6 +904,11 @@ form-level errors. Unmapped or unproven errors remain the original framework
 error. The mapping helper is native-only; client code handles the serialized
 `ServerFnError` response.
 
+Conversion keeps the existing serialized `ServerFnError` wire shape and adds
+no database metadata to that response. Generated client forms route field
+errors by logical model field names. Composite `UNIQUE` and `CHECK` violations
+have no single logical field, so they reach the form error.
+
 ## Troubleshooting
 
 ### Issue: "cannot find type `X` in this scope" in WASM build

--- a/crates/reinhardt-pages/docs/server_fn_macro.md
+++ b/crates/reinhardt-pages/docs/server_fn_macro.md
@@ -877,6 +877,33 @@ pub async fn safe_operation(
 }
 ```
 
+### 5. Map Proven Constraint Violations Safely
+
+With the native `model-server-fnset` feature, map only constraint violations
+that the framework can prove belong to the model. An optional callback may
+replace the default with fixed, client-safe text:
+
+```rust,ignore
+let server_error = ServerFnError::try_from_model_error_with::<User, _>(
+	error,
+	|database_error, _fields| {
+		(database_error.constraint() == Some("users_email_unique"))
+			.then(|| "This email is already registered".to_owned())
+	},
+)
+.unwrap_or_else(|error| {
+	tracing::error!(error = %error, "user write failed");
+	ServerFnError::application("Failed to save user")
+});
+```
+
+Never return `DatabaseError::message()`, rejected values, table names,
+constraint names, or vendor diagnostics to the browser. A known single-field
+violation becomes a field error; composite `UNIQUE` and `CHECK` violations are
+form-level errors. Unmapped or unproven errors remain the original framework
+error. The mapping helper is native-only; client code handles the serialized
+`ServerFnError` response.
+
 ## Troubleshooting
 
 ### Issue: "cannot find type `X` in this scope" in WASM build

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -355,6 +355,11 @@
 //! original framework error. The conversion helper is native-only; browser
 //! code receives the resulting [`ServerFnError`].
 //!
+//! Conversion preserves the serialized [`ServerFnError`] wire shape and adds no
+//! database metadata to the browser response. Generated client forms route
+//! field errors by logical model field names. Composite `UNIQUE` and `CHECK`
+//! violations have no single logical field, so they reach the form error.
+//!
 //! ## Typed server function sets
 //!
 //! [`server_fn::server_fnset`] groups existing server function markers into a

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -336,15 +336,15 @@
 //!
 //! ```rust,ignore
 //! let server_error = ServerFnError::try_from_model_error_with::<User, _>(
-//! 	error,
-//! 	|database_error, _fields| {
-//! 		(database_error.constraint() == Some("users_email_unique"))
-//! 			.then(|| "This email is already registered".to_owned())
-//! 	},
+//!     error,
+//!     |database_error, _fields| {
+//!         (database_error.constraint() == Some("users_email_unique"))
+//!             .then(|| "This email is already registered".to_owned())
+//!     },
 //! )
 //! .unwrap_or_else(|error| {
-//! 	tracing::error!(error = %error, "user write failed");
-//! 	ServerFnError::application("Failed to save user")
+//!     tracing::error!(error = %error, "user write failed");
+//!     ServerFnError::application("Failed to save user")
 //! });
 //! ```
 //!

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -329,6 +329,32 @@
 //! }
 //! ```
 //!
+//! With the native `model-server-fnset` feature,
+//! [`ServerFnError::try_from_model_error_with`] maps only proven model
+//! constraint violations. The optional callback may supply fixed,
+//! client-safe text:
+//!
+//! ```rust,ignore
+//! let server_error = ServerFnError::try_from_model_error_with::<User, _>(
+//! 	error,
+//! 	|database_error, _fields| {
+//! 		(database_error.constraint() == Some("users_email_unique"))
+//! 			.then(|| "This email is already registered".to_owned())
+//! 	},
+//! )
+//! .unwrap_or_else(|error| {
+//! 	tracing::error!(error = %error, "user write failed");
+//! 	ServerFnError::application("Failed to save user")
+//! });
+//! ```
+//!
+//! Callback code must not return `DatabaseError::message()`, rejected values,
+//! table names, constraint names, or vendor diagnostics to the browser.
+//! Single-field violations are field errors, while composite `UNIQUE` and
+//! `CHECK` violations are form errors. Unmapped or unproven errors remain the
+//! original framework error. The conversion helper is native-only; browser
+//! code receives the resulting [`ServerFnError`].
+//!
 //! ## Typed server function sets
 //!
 //! [`server_fn::server_fnset`] groups existing server function markers into a

--- a/crates/reinhardt-pages/src/server_fn.rs
+++ b/crates/reinhardt-pages/src/server_fn.rs
@@ -77,6 +77,8 @@ pub mod injectable;
 pub mod metadata;
 #[cfg(feature = "msw")]
 pub mod mockable;
+#[cfg(all(native, feature = "model-server-fnset"))]
+mod model_error;
 pub mod model_set;
 #[cfg(native)]
 mod multipart;

--- a/crates/reinhardt-pages/src/server_fn/model_error.rs
+++ b/crates/reinhardt-pages/src/server_fn/model_error.rs
@@ -1,0 +1,456 @@
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind};
+use reinhardt_db::{backends::error::database_table_matches_model, orm::Model};
+
+use super::ServerFnError;
+
+enum ValidationTarget {
+	Field,
+	Form,
+}
+
+struct ResolvedViolation {
+	fields: Vec<String>,
+	target: ValidationTarget,
+	default_message: &'static str,
+}
+
+impl ServerFnError {
+	/// Converts a proven database constraint violation into a safe validation error.
+	pub fn try_from_model_error<M>(
+		error: reinhardt_core::exception::Error,
+	) -> Result<Self, reinhardt_core::exception::Error>
+	where
+		M: Model,
+	{
+		Self::try_from_model_error_with::<M, _>(error, |_, _| None)
+	}
+
+	/// Converts a proven database constraint violation using an optional safe message.
+	pub fn try_from_model_error_with<M, F>(
+		error: reinhardt_core::exception::Error,
+		message: F,
+	) -> Result<Self, reinhardt_core::exception::Error>
+	where
+		M: Model,
+		F: FnOnce(&DatabaseError, &[&str]) -> Option<String>,
+	{
+		let resolved = {
+			let Some(database_error) = error.database_error() else {
+				return Err(error);
+			};
+			let Some(resolved) = resolve_model_violation::<M>(database_error) else {
+				return Err(error);
+			};
+			resolved
+		};
+
+		let field_refs = resolved
+			.fields
+			.iter()
+			.map(String::as_str)
+			.collect::<Vec<_>>();
+		let safe_message = message(
+			error
+				.database_error()
+				.expect("resolved model violations always retain their database error"),
+			&field_refs,
+		)
+		.unwrap_or_else(|| resolved.default_message.to_owned());
+
+		match resolved.target {
+			ValidationTarget::Field => Ok(Self::validation_with_message(
+				safe_message.clone(),
+				[(resolved.fields[0].clone(), safe_message)],
+			)),
+			ValidationTarget::Form => Ok(Self::validation_with_message(
+				safe_message,
+				std::iter::empty::<(String, String)>(),
+			)),
+		}
+	}
+}
+
+fn resolve_model_violation<M: Model>(database_error: &DatabaseError) -> Option<ResolvedViolation> {
+	if let Some(table) = database_error.table()
+		&& !database_table_matches_model(M::table_name(), table)
+	{
+		return None;
+	}
+
+	let constraint_fields = match database_error.constraint() {
+		Some(constraint) => Some(normalize_fields(M::constraint_fields(constraint)?)?),
+		None => None,
+	};
+	let column_fields = if database_error.columns().is_empty() {
+		None
+	} else {
+		Some(resolve_columns::<M>(database_error.columns())?)
+	};
+
+	if let (Some(constraint_fields), Some(column_fields)) = (&constraint_fields, &column_fields)
+		&& constraint_fields != column_fields
+	{
+		return None;
+	}
+
+	match database_error.kind() {
+		DatabaseErrorKind::UniqueViolation => {
+			let fields = constraint_fields.as_ref().or(column_fields.as_ref())?;
+			match fields.len() {
+				1 => field(fields.clone(), "A record with this value already exists"),
+				2.. if constraint_fields.is_some() => Some(form(
+					fields.clone(),
+					"A record with these values already exists",
+				)),
+				_ => None,
+			}
+		}
+		DatabaseErrorKind::NotNullViolation => match column_fields.as_ref() {
+			Some(fields) if fields.len() == 1 => field(fields.clone(), "This field is required"),
+			_ => None,
+		},
+		DatabaseErrorKind::ForeignKeyViolation => match constraint_fields.as_ref() {
+			Some(fields) if fields.len() == 1 => field(fields.clone(), "Select a valid value"),
+			_ => None,
+		},
+		DatabaseErrorKind::CheckViolation => constraint_fields.as_ref().map(|fields| {
+			form(
+				fields.clone(),
+				"The submitted values violate a data constraint",
+			)
+		}),
+		_ => None,
+	}
+}
+
+fn resolve_columns<M: Model>(columns: &[String]) -> Option<Vec<String>> {
+	let metadata = M::field_metadata();
+	let fields = columns
+		.iter()
+		.map(|column| {
+			let mut matches = metadata
+				.iter()
+				.filter(|field| field.db_column_name() == column)
+				.map(|field| field.name.clone());
+			let field = matches.next()?;
+			matches.next().is_none().then_some(field)
+		})
+		.collect::<Option<Vec<_>>>()?;
+	normalize_fields(fields)
+}
+
+fn normalize_fields<I, S>(fields: I) -> Option<Vec<String>>
+where
+	I: IntoIterator<Item = S>,
+	S: Into<String>,
+{
+	let mut fields = fields.into_iter().map(Into::into).collect::<Vec<_>>();
+	fields.sort_unstable();
+	fields
+		.windows(2)
+		.all(|pair| pair[0] != pair[1])
+		.then_some(fields)
+}
+
+fn field(fields: Vec<String>, default_message: &'static str) -> Option<ResolvedViolation> {
+	(fields.len() == 1).then_some(ResolvedViolation {
+		fields,
+		target: ValidationTarget::Field,
+		default_message,
+	})
+}
+
+fn form(fields: Vec<String>, default_message: &'static str) -> ResolvedViolation {
+	ResolvedViolation {
+		fields,
+		target: ValidationTarget::Form,
+		default_message,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::HashMap;
+
+	use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
+	use reinhardt_db::orm::{FieldSelector, Manager, Model, inspection::FieldInfo};
+	use serde::{Deserialize, Serialize};
+
+	use crate::server_fn::{ServerFnError, ServerFnErrorKind};
+
+	#[derive(Clone)]
+	struct RecordFields;
+
+	impl FieldSelector for RecordFields {
+		fn with_alias(self, _alias: &str) -> Self {
+			self
+		}
+	}
+
+	#[derive(Clone, Debug, Deserialize, Serialize)]
+	struct Record {
+		id: Option<i64>,
+		email: String,
+		tenant_id: i64,
+		owner_id: i64,
+		status: String,
+	}
+
+	impl Model for Record {
+		type PrimaryKey = i64;
+		type Fields = RecordFields;
+		type Objects = Manager<Self>;
+
+		fn table_name() -> &'static str {
+			"records"
+		}
+
+		fn new_fields() -> Self::Fields {
+			RecordFields
+		}
+
+		fn primary_key(&self) -> Option<Self::PrimaryKey> {
+			self.id
+		}
+
+		fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+			self.id = Some(value);
+		}
+
+		fn field_metadata() -> Vec<FieldInfo> {
+			vec![
+				field("email", "email_addr"),
+				field("tenant_id", "tenant_id"),
+				field("owner_id", "owner_id"),
+				field("status", "status"),
+			]
+		}
+
+		fn constraint_fields(constraint: &str) -> Option<Vec<&'static str>> {
+			match constraint {
+				"records_email_key" => Some(vec!["email"]),
+				"records_email_tenant_key" => Some(vec!["email", "tenant_id"]),
+				"records_owner_fkey" => Some(vec!["owner_id"]),
+				"records_status_check" => Some(vec!["status"]),
+				_ => None,
+			}
+		}
+	}
+
+	fn field(name: &str, db_column: &str) -> FieldInfo {
+		FieldInfo {
+			name: name.to_owned(),
+			field_type: "CharField".to_owned(),
+			storage_kind: None,
+			domain: None,
+			nullable: false,
+			primary_key: false,
+			unique: false,
+			blank: false,
+			editable: true,
+			default: None,
+			db_default: None,
+			db_column: (name != db_column).then(|| db_column.to_owned()),
+			choices: None,
+			attributes: HashMap::new(),
+		}
+	}
+
+	fn database_error(
+		kind: DatabaseErrorKind,
+		constraint: Option<&str>,
+		columns: &[&str],
+	) -> Error {
+		let mut error = DatabaseError::new(
+			kind,
+			"private driver message containing rejected@example.com",
+		)
+		.with_code("PRIVATE")
+		.with_table("records")
+		.with_columns(columns.iter().copied());
+		if let Some(constraint) = constraint {
+			error = error.with_constraint(constraint);
+		}
+		Error::from(error.with_source(std::io::Error::other("private source")))
+	}
+
+	fn assert_field_error(error: ServerFnError, field: &str, message: &str) {
+		assert_eq!(error.kind(), ServerFnErrorKind::Validation);
+		assert_eq!(error.status(), Some(422));
+		assert_eq!(error.user_message(), message);
+		assert_eq!(error.field_errors().len(), 1);
+		assert_eq!(error.field_errors()[0].field(), field);
+		assert_eq!(error.field_errors()[0].message(), message);
+	}
+
+	fn assert_unchanged(error: Error) {
+		let message = error.to_string();
+		let metadata = error.database_error().map(|database_error| {
+			(
+				database_error.kind(),
+				database_error.code().map(str::to_owned),
+				database_error.constraint().map(str::to_owned),
+				database_error.table().map(str::to_owned),
+				database_error.columns().to_vec(),
+			)
+		});
+
+		let returned = ServerFnError::try_from_model_error::<Record>(error)
+			.expect_err("unproven errors must remain unchanged");
+		assert_eq!(returned.to_string(), message);
+		assert_eq!(
+			returned.database_error().map(|database_error| (
+				database_error.kind(),
+				database_error.code().map(str::to_owned),
+				database_error.constraint().map(str::to_owned),
+				database_error.table().map(str::to_owned),
+				database_error.columns().to_vec(),
+			)),
+			metadata
+		);
+	}
+
+	#[test]
+	fn maps_exact_default_messages_and_targets() {
+		assert_field_error(
+			ServerFnError::try_from_model_error::<Record>(database_error(
+				DatabaseErrorKind::UniqueViolation,
+				Some("records_email_key"),
+				&["email_addr"],
+			))
+			.expect("single UNIQUE maps to its field"),
+			"email",
+			"A record with this value already exists",
+		);
+
+		let composite = ServerFnError::try_from_model_error::<Record>(database_error(
+			DatabaseErrorKind::UniqueViolation,
+			Some("records_email_tenant_key"),
+			&["tenant_id", "email_addr"],
+		))
+		.expect("known composite UNIQUE maps to form-level validation");
+		assert_eq!(
+			composite.user_message(),
+			"A record with these values already exists"
+		);
+		assert_eq!(composite.field_errors(), []);
+
+		assert_field_error(
+			ServerFnError::try_from_model_error::<Record>(database_error(
+				DatabaseErrorKind::NotNullViolation,
+				None,
+				&["email_addr"],
+			))
+			.expect("NOT NULL maps to its field"),
+			"email",
+			"This field is required",
+		);
+		assert_field_error(
+			ServerFnError::try_from_model_error::<Record>(database_error(
+				DatabaseErrorKind::ForeignKeyViolation,
+				Some("records_owner_fkey"),
+				&[],
+			))
+			.expect("known FK maps to its field"),
+			"owner_id",
+			"Select a valid value",
+		);
+
+		let check = ServerFnError::try_from_model_error::<Record>(database_error(
+			DatabaseErrorKind::CheckViolation,
+			Some("records_status_check"),
+			&[],
+		))
+		.expect("known CHECK maps to form-level validation");
+		assert_eq!(
+			check.user_message(),
+			"The submitted values violate a data constraint"
+		);
+		assert_eq!(check.field_errors(), []);
+	}
+
+	#[test]
+	fn callback_uses_safe_override_or_default() {
+		let overridden = ServerFnError::try_from_model_error_with::<Record, _>(
+			database_error(
+				DatabaseErrorKind::UniqueViolation,
+				Some("records_email_key"),
+				&["email_addr"],
+			),
+			|_, fields| {
+				assert_eq!(fields, ["email"]);
+				Some("Choose another email address".to_owned())
+			},
+		)
+		.expect("callback runs only after safe field routing is resolved");
+		assert_field_error(overridden, "email", "Choose another email address");
+
+		let defaulted = ServerFnError::try_from_model_error_with::<Record, _>(
+			database_error(
+				DatabaseErrorKind::UniqueViolation,
+				Some("records_email_key"),
+				&["email_addr"],
+			),
+			|_, _| None,
+		)
+		.expect("missing callback message uses the safe default");
+		assert_field_error(
+			defaulted,
+			"email",
+			"A record with this value already exists",
+		);
+	}
+
+	#[test]
+	fn fails_closed_for_unproven_database_metadata() {
+		for error in [
+			database_error(
+				DatabaseErrorKind::UniqueViolation,
+				Some("records_unknown_key"),
+				&["email_addr"],
+			),
+			database_error(
+				DatabaseErrorKind::NotNullViolation,
+				None,
+				&["unknown_column"],
+			),
+			database_error(
+				DatabaseErrorKind::UniqueViolation,
+				Some("records_email_key"),
+				&["tenant_id"],
+			),
+			Error::from(
+				DatabaseError::new(DatabaseErrorKind::ForeignKeyViolation, "private")
+					.with_table("other_records")
+					.with_constraint("records_owner_fkey"),
+			),
+			Error::from(
+				DatabaseError::new(DatabaseErrorKind::UniqueViolation, "private")
+					.with_table("other_records")
+					.with_constraint("records_email_key"),
+			),
+		] {
+			assert_unchanged(error);
+		}
+	}
+
+	#[test]
+	fn preserves_non_database_errors_and_serializes_only_safe_details() {
+		assert_unchanged(Error::Internal("private".to_owned()));
+
+		let error = ServerFnError::try_from_model_error::<Record>(database_error(
+			DatabaseErrorKind::UniqueViolation,
+			Some("records_email_key"),
+			&["email_addr"],
+		))
+		.expect("known violation converts to a safe error");
+		let serialized = serde_json::to_string(&error).expect("server error serializes");
+		assert!(!serialized.contains("private driver message"));
+		assert!(!serialized.contains("rejected@example.com"));
+		assert!(!serialized.contains("PRIVATE"));
+		assert!(!serialized.contains("records"));
+		let round_trip: ServerFnError =
+			serde_json::from_str(&serialized).expect("server error deserializes");
+		assert_eq!(round_trip, error);
+	}
+}

--- a/crates/reinhardt-pages/tests/model_form_native_submit.rs
+++ b/crates/reinhardt-pages/tests/model_form_native_submit.rs
@@ -2,7 +2,84 @@
 
 include!("ui/form/model_json_support.rs");
 
+#[cfg(feature = "model-server-fnset")]
+use std::collections::HashMap;
+
 use reinhardt_pages::{FieldError, form, server_fn::ServerFnErrorKind, use_form};
+
+#[cfg(feature = "model-server-fnset")]
+use reinhardt_core::exception::{DatabaseError, DatabaseErrorKind, Error};
+#[cfg(feature = "model-server-fnset")]
+use reinhardt_db::orm::{FieldSelector, Manager, Model, inspection::FieldInfo};
+#[cfg(feature = "model-server-fnset")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "model-server-fnset")]
+#[derive(Clone)]
+struct ConstraintQuestionFields;
+
+#[cfg(feature = "model-server-fnset")]
+impl FieldSelector for ConstraintQuestionFields {
+	fn with_alias(self, _alias: &str) -> Self {
+		self
+	}
+}
+
+#[cfg(feature = "model-server-fnset")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ConstraintQuestion {
+	id: Option<i64>,
+	title: String,
+}
+
+#[cfg(feature = "model-server-fnset")]
+impl Model for ConstraintQuestion {
+	type PrimaryKey = i64;
+	type Fields = ConstraintQuestionFields;
+	type Objects = Manager<Self>;
+
+	fn table_name() -> &'static str {
+		"questions"
+	}
+
+	fn new_fields() -> Self::Fields {
+		ConstraintQuestionFields
+	}
+
+	fn primary_key(&self) -> Option<Self::PrimaryKey> {
+		self.id
+	}
+
+	fn set_primary_key(&mut self, value: Self::PrimaryKey) {
+		self.id = Some(value);
+	}
+
+	fn field_metadata() -> Vec<FieldInfo> {
+		vec![FieldInfo {
+			name: "title".to_owned(),
+			field_type: "CharField".to_owned(),
+			storage_kind: None,
+			domain: None,
+			nullable: false,
+			primary_key: false,
+			unique: false,
+			blank: false,
+			editable: true,
+			default: None,
+			db_default: None,
+			db_column: None,
+			choices: None,
+			attributes: HashMap::new(),
+		}]
+	}
+
+	fn constraint_fields(constraint: &str) -> Option<Vec<&'static str>> {
+		match constraint {
+			"questions_title_key" | "questions_title_check" => Some(vec!["title"]),
+			_ => None,
+		}
+	}
+}
 
 #[test]
 fn native_submit_maps_payload_errors_to_validation() {
@@ -66,6 +143,66 @@ fn model_form_routes_structured_server_errors_to_selected_fields() {
 		assert_eq!(
 			runtime.form_state().form_error.get(),
 			Some("Please correct the submitted values\nowner_id: Owner is required".to_owned())
+		);
+	});
+}
+
+#[cfg(feature = "model-server-fnset")]
+#[test]
+fn generated_model_form_routes_serialized_database_constraint_errors() {
+	reinhardt_core::reactive::ReactiveScope::run(|| {
+		let unique_form = form! {
+			name: ConstraintQuestionUniqueForm,
+			model: Question,
+			policy: QuestionPolicy,
+			fields: [title],
+			server_fn: save_question,
+		};
+		let unique_runtime = use_form(&unique_form).build();
+		let unique = ServerFnError::try_from_model_error::<ConstraintQuestion>(Error::from(
+			DatabaseError::new(DatabaseErrorKind::UniqueViolation, "private duplicate")
+				.with_table("questions")
+				.with_constraint("questions_title_key")
+				.with_columns(["title"]),
+		))
+		.expect("known unique constraint converts");
+		let serialized = serde_json::to_string(&unique).expect("safe error serializes");
+		let unique: ServerFnError =
+			serde_json::from_str(&serialized).expect("safe error deserializes");
+		unique_runtime.apply_server_error(&unique);
+		assert_eq!(
+			unique_runtime
+				.get_field_state(unique_form.title_field())
+				.error
+				.as_ref()
+				.map(FieldError::message),
+			Some("A record with this value already exists")
+		);
+
+		let check_form = form! {
+			name: ConstraintQuestionCheckForm,
+			model: Question,
+			policy: QuestionPolicy,
+			fields: [title],
+			server_fn: save_question,
+		};
+		let check_runtime = use_form(&check_form).build();
+		let check = ServerFnError::try_from_model_error::<ConstraintQuestion>(Error::from(
+			DatabaseError::new(DatabaseErrorKind::CheckViolation, "private check")
+				.with_table("questions")
+				.with_constraint("questions_title_check"),
+		))
+		.expect("known CHECK constraint converts");
+		check_runtime.apply_server_error(&check);
+		assert_eq!(
+			check_runtime.form_state().form_error.get(),
+			Some("The submitted values violate a data constraint".to_owned())
+		);
+		assert!(
+			check_runtime
+				.get_field_state(check_form.title_field())
+				.error
+				.is_none()
 		);
 	});
 }

--- a/crates/reinhardt-utils/src/storage/local.rs
+++ b/crates/reinhardt-utils/src/storage/local.rs
@@ -8,7 +8,6 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::{Arc, OnceLock};
-use tokio::fs;
 
 /// Local filesystem storage
 pub struct LocalStorage {

--- a/tests/integration/tests/backends/database_error_classification.rs
+++ b/tests/integration/tests/backends/database_error_classification.rs
@@ -90,14 +90,16 @@ fn record_insert_sql(
 	sql_for_backend(&statement, backend)
 }
 
-async fn execute_error_kind(connection: &DatabaseConnection, sql: &str) -> DatabaseErrorKind {
-	let Err(error) = connection.execute(sql, vec![]).await else {
-		panic!("the invalid statement must fail");
-	};
+async fn execute_constraint_error(connection: &DatabaseConnection, sql: &str) -> Error {
+	connection
+		.execute(sql, vec![])
+		.await
+		.expect_err("the invalid statement must fail")
+}
 
-	error
-		.database_kind()
-		.expect("the execution failure must be classified as a database error")
+fn source_chain_contains_sqlx(error: &(dyn std::error::Error + 'static)) -> bool {
+	std::iter::successors(Some(error), |current| current.source())
+		.any(|source| source.downcast_ref::<sqlx::Error>().is_some())
 }
 
 fn assert_database_kind(error: Error, expected: DatabaseErrorKind) {
@@ -171,19 +173,38 @@ async fn create_portable_schema(connection: &DatabaseConnection) {
 		.expect("the baseline row must be inserted");
 }
 
-async fn portable_constraint_kinds(connection: &DatabaseConnection) -> [DatabaseErrorKind; 4] {
+async fn portable_constraint_errors(connection: &DatabaseConnection) -> Vec<Error> {
 	let backend = connection.backend();
 	let unique = record_insert_sql(backend, 2, "duplicate", 1, Some("present"), 1);
 	let foreign_key = record_insert_sql(backend, 3, "foreign-key", 999, Some("present"), 1);
 	let not_null = record_insert_sql(backend, 4, "not-null", 1, None, 1);
 	let check = record_insert_sql(backend, 5, "check", 1, Some("present"), 0);
 
-	[
-		execute_error_kind(connection, &unique).await,
-		execute_error_kind(connection, &foreign_key).await,
-		execute_error_kind(connection, &not_null).await,
-		execute_error_kind(connection, &check).await,
+	vec![
+		execute_constraint_error(connection, &unique).await,
+		execute_constraint_error(connection, &foreign_key).await,
+		execute_constraint_error(connection, &not_null).await,
+		execute_constraint_error(connection, &check).await,
 	]
+}
+
+fn assert_portable_constraint_errors(errors: Vec<Error>) {
+	assert_eq!(
+		errors
+			.iter()
+			.map(|error| error.database_kind())
+			.collect::<Vec<_>>(),
+		PORTABLE_CONSTRAINT_KINDS.map(Some)
+	);
+	for error in errors {
+		let database_error = error
+			.database_error()
+			.expect("the execution failure must be classified as a database error");
+		assert_eq!(database_error.constraint(), None);
+		assert_eq!(database_error.table(), None);
+		assert_eq!(database_error.columns(), []);
+		assert!(source_chain_contains_sqlx(&error));
+	}
 }
 
 #[cfg(feature = "postgres")]
@@ -203,10 +224,10 @@ async fn postgres_constraint_errors_have_portable_kinds(
 	create_portable_schema(&connection).await;
 
 	// Act
-	let kinds = portable_constraint_kinds(&connection).await;
+	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_eq!(kinds, PORTABLE_CONSTRAINT_KINDS);
+	assert_portable_constraint_errors(errors);
 }
 
 #[cfg(feature = "sqlite")]
@@ -228,10 +249,10 @@ async fn sqlite_constraint_errors_have_portable_kinds() {
 	create_portable_schema(&connection).await;
 
 	// Act
-	let kinds = portable_constraint_kinds(&connection).await;
+	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_eq!(kinds, PORTABLE_CONSTRAINT_KINDS);
+	assert_portable_constraint_errors(errors);
 }
 
 #[cfg(feature = "mysql")]
@@ -255,10 +276,93 @@ async fn mysql_constraint_errors_have_portable_kinds() {
 	create_portable_schema(&connection).await;
 
 	// Act
-	let kinds = portable_constraint_kinds(&connection).await;
+	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_eq!(kinds, PORTABLE_CONSTRAINT_KINDS);
+	assert_portable_constraint_errors(errors);
+}
+
+#[cfg(feature = "postgres")]
+#[rstest]
+#[tokio::test]
+async fn postgres_constraint_errors_retain_structured_metadata(
+	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
+) {
+	let (_container, _pool, _port, url) = postgres_container.await;
+	let owner = BackendsConnection::connect(&url)
+		.await
+		.expect("the PostgreSQL fixture must accept framework connections");
+	let lease =
+		DatabaseConnectionLease::register(owner).expect("connection registration must succeed");
+	let connection = lease.handle();
+	for statement in [
+		"CREATE TABLE records_parent (id BIGINT PRIMARY KEY)",
+		"CREATE TABLE records (id BIGINT PRIMARY KEY, unique_value TEXT CONSTRAINT \"records.unique\" UNIQUE, parent_id BIGINT CONSTRAINT records_parent_fk REFERENCES records_parent(id), required_value TEXT NOT NULL, quantity INTEGER CONSTRAINT records_quantity_check CHECK (quantity > 0))",
+		"INSERT INTO records_parent (id) VALUES (1)",
+		"INSERT INTO records (id, unique_value, parent_id, required_value, quantity) VALUES (1, 'duplicate', 1, 'present', 1)",
+	] {
+		connection
+			.execute(statement, vec![])
+			.await
+			.expect("the PostgreSQL metadata fixture must be created");
+	}
+
+	let errors = [
+		execute_constraint_error(
+			&connection,
+			"INSERT INTO records (id, unique_value, parent_id, required_value, quantity) VALUES (2, 'duplicate', 1, 'present', 1)",
+		)
+		.await,
+		execute_constraint_error(
+			&connection,
+			"INSERT INTO records (id, unique_value, parent_id, required_value, quantity) VALUES (3, 'foreign-key', 999, 'present', 1)",
+		)
+		.await,
+		execute_constraint_error(
+			&connection,
+			"INSERT INTO records (id, unique_value, parent_id, required_value, quantity) VALUES (4, 'not-null', 1, NULL, 1)",
+		)
+		.await,
+		execute_constraint_error(
+			&connection,
+			"INSERT INTO records (id, unique_value, parent_id, required_value, quantity) VALUES (5, 'check', 1, 'present', 0)",
+		)
+		.await,
+	];
+	let expected = [
+		(
+			DatabaseErrorKind::UniqueViolation,
+			Some("records.unique"),
+			None,
+		),
+		(
+			DatabaseErrorKind::ForeignKeyViolation,
+			Some("records_parent_fk"),
+			None,
+		),
+		(
+			DatabaseErrorKind::NotNullViolation,
+			None,
+			Some("required_value"),
+		),
+		(
+			DatabaseErrorKind::CheckViolation,
+			Some("records_quantity_check"),
+			None,
+		),
+	];
+
+	for (error, (kind, constraint, column)) in errors.into_iter().zip(expected) {
+		assert_eq!(error.database_kind(), Some(kind));
+		let database_error = error.database_error().expect("database error metadata");
+		assert_eq!(database_error.table(), Some("records"));
+		assert_eq!(database_error.constraint(), constraint);
+		assert_eq!(
+			database_error.columns(),
+			column.into_iter().collect::<Vec<_>>()
+		);
+		assert!(source_chain_contains_sqlx(&error));
+	}
 }
 
 #[cfg(feature = "postgres")]

--- a/tests/integration/tests/backends/database_error_classification.rs
+++ b/tests/integration/tests/backends/database_error_classification.rs
@@ -188,7 +188,7 @@ async fn portable_constraint_errors(connection: &DatabaseConnection) -> Vec<Erro
 	]
 }
 
-fn assert_portable_constraint_errors(errors: Vec<Error>) {
+fn assert_portable_constraint_kinds(errors: &[Error]) {
 	assert_eq!(
 		errors
 			.iter()
@@ -196,6 +196,9 @@ fn assert_portable_constraint_errors(errors: Vec<Error>) {
 			.collect::<Vec<_>>(),
 		PORTABLE_CONSTRAINT_KINDS.map(Some)
 	);
+}
+
+fn assert_empty_constraint_metadata(errors: &[Error]) {
 	for error in errors {
 		let database_error = error
 			.database_error()
@@ -227,7 +230,7 @@ async fn postgres_constraint_errors_have_portable_kinds(
 	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_portable_constraint_errors(errors);
+	assert_portable_constraint_kinds(&errors);
 }
 
 #[cfg(feature = "sqlite")]
@@ -252,7 +255,8 @@ async fn sqlite_constraint_errors_have_portable_kinds() {
 	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_portable_constraint_errors(errors);
+	assert_portable_constraint_kinds(&errors);
+	assert_empty_constraint_metadata(&errors);
 }
 
 #[cfg(feature = "mysql")]
@@ -279,7 +283,8 @@ async fn mysql_constraint_errors_have_portable_kinds() {
 	let errors = portable_constraint_errors(&connection).await;
 
 	// Assert
-	assert_portable_constraint_errors(errors);
+	assert_portable_constraint_kinds(&errors);
+	assert_empty_constraint_metadata(&errors);
 }
 
 #[cfg(feature = "postgres")]

--- a/tests/integration/tests/backends/database_error_classification.rs
+++ b/tests/integration/tests/backends/database_error_classification.rs
@@ -205,8 +205,8 @@ fn assert_empty_constraint_metadata(errors: &[Error]) {
 			.expect("the execution failure must be classified as a database error");
 		assert_eq!(database_error.constraint(), None);
 		assert_eq!(database_error.table(), None);
-		assert_eq!(database_error.columns(), []);
-		assert!(source_chain_contains_sqlx(&error));
+		assert_eq!(database_error.columns(), &[] as &[String]);
+		assert!(source_chain_contains_sqlx(error));
 	}
 }
 

--- a/tests/integration/tests/constraint_metadata.rs
+++ b/tests/integration/tests/constraint_metadata.rs
@@ -80,7 +80,12 @@ fn derived_constraint_fields_match_registered_physical_constraints() {
 	for constraint in registered_model.constraints().iter().filter(|constraint| {
 		constraint.constraint_type == "unique" || constraint.constraint_type == "foreign_key"
 	}) {
-		let expected = match constraint.fields.as_slice() {
+		let physical_fields = constraint
+			.fields
+			.iter()
+			.map(String::as_str)
+			.collect::<Vec<_>>();
+		let expected = match physical_fields.as_slice() {
 			["tenant_key", "slug_key"] => vec!["tenant_id", "slug"],
 			["email_addr"] => vec!["email"],
 			["owner_key"] => vec!["owner_id"],


### PR DESCRIPTION
## Summary

This PR addresses:

- Expose backend-neutral constraint metadata on `DatabaseError` while preserving the original SQLx source chain.
- Reuse shared constraint naming and generated model metadata so physical database columns resolve to logical model fields.
- Map supported violations in native `reinhardt-pages` generated forms with precision-first, fail-closed field/form routing and an optional safe-message callback.
- Add adapter, derive, generated-form, and integration coverage plus documentation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Driver error text is diagnostic output and varies by backend, version, and locale. This change exposes metadata at the adapter boundary instead of requiring applications to parse messages, while keeping existing opaque error handling and source-chain access intact.

Fixes #6222

Related to: #6160; reinhardt-cloud#879

## How Was This Tested?

- `cargo test --offline -p reinhardt-integration-tests --test constraint_metadata -- --nocapture` — 2 passed.
- `cargo test --offline -p reinhardt-macros --test model_form_codegen` — 5 passed.
- `cargo test -p reinhardt-integration-tests --test backends --no-run` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

The full workspace all-features run was not claimed as green because the local environment has shared Cargo contention and unrelated existing failures (an unused import in `reinhardt-utils`, unavailable Docker socket for placeholder checks, and baseline SemVer differences).

## Performance Impact

Not performance-related.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6160 — generated constraint-name stability
- reinhardt-cloud#879 — motivating downstream duplicate-error handling

## Labels to Apply

### Type Label (select one)
- [x] `enhancement` - New feature or improvement
- [ ] `bug` - Bug fix
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change (**MUST** match "Yes" in Breaking Change Assessment above)

### Scope Label (select all that apply)
- [x] `database` - Database layer, schema, migrations
- [x] `orm` - ORM layer, models, query builder
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [x] `api` - REST API, serializers, views
- [ ] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - Websockets, connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)
- [x] `high` - Important fix or feature

---

**Additional Context:**

- Composite UNIQUE violations route to a form-level error; unknown or unmapped constraints return the original database error unchanged.
- NOT NULL and FK violations become field errors only with exact metadata; CHECK violations remain form-level unless an explicit single-field mapping exists.
- The message callback can customize only the safe user-facing message after routing; database metadata is not added to the wire payload.
- The implementation is limited to generated `reinhardt-pages` forms and `ServerFnError`; legacy `reinhardt-forms::ModelForm` is unchanged.