### PR TITLE
fix(utils): qualify native filesystem test helper

### DIFF
--- a/crates/reinhardt-utils/src/storage/local.rs
+++ b/crates/reinhardt-utils/src/storage/local.rs
@@ -790,7 +790,7 @@ mod tests {
 
 		let (storage, temp_dir) = create_test_storage().await;
 		let outside = TempDir::new().expect("outside directory should be created");
-		fs::write(outside.path().join("secret.txt"), b"secret")
+		tokio::fs::write(outside.path().join("secret.txt"), b"secret")
 			.await
 			.expect("outside fixture should be written");
 		symlink(outside.path(), temp_dir.path().join("escape"))


### PR DESCRIPTION
<!-- Thank you for contributing to Reinhardt! Please fill out the information below. -->

## Summary

This PR addresses:

- Fixes the native test compilation failure in `crates/reinhardt-utils/src/storage/local.rs`.
- Qualifies the filesystem write used by the symlink-escape fixture.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (code that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The release PR for `develop/0.4.0` failed native test and bin/example compilation because the test referenced `fs::write` while the `tokio::fs` alias is only available for WASM builds.

Related to: #6228
Related to: #6230

## How Was This Tested?

- `cargo fmt --all -- --check`
- `cargo check -p reinhardt-utils --tests --all-features`
- `cargo test -p reinhardt-utils --all-features storage::local::tests::storage_rejects_symlinks_that_escape_the_base_directory -- --exact`

The Docker-backed integration tests were not run locally because no Docker daemon is available.

## Performance Impact

Not applicable.

## Breaking Changes

Not applicable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with `cargo fmt --all -- --check`
- [ ] I have checked the code with `cargo make clippy-check`

## Related Issues

- #6228
- #6230

## Labels to Apply

### Type Label
- [x] `bug`

### Additional Labels

None.

### Scope Label

None.

### Priority Label

Maintainers will apply priority labels.

---

**Additional Context:**

This is a one-line qualification fix on the release branch base.
