### PR TITLE
style: fix format and clippy failures on typed form bindings

### DIFF
--- a/crates/reinhardt-admin/src/server/fields.rs
+++ b/crates/reinhardt-admin/src/server/fields.rs
@@ -132,9 +132,14 @@ pub async fn get_fields(
 				.iter()
 				.map(|field| field.name.clone())
 				.collect::<Vec<_>>();
-			allowed_fields.extend(form.aliases.iter().filter(|&(logical, physical)| form.fields
+			allowed_fields.extend(
+				form.aliases
 					.iter()
-					.any(|field| field.name == *physical)).map(|(logical, physical)| logical.clone()));
+					.filter(|&(_, physical)| {
+						form.fields.iter().any(|field| field.name == *physical)
+					})
+					.map(|(logical, _)| logical.clone()),
+			);
 			retain_allowed_fields(values, &allowed_fields);
 		}
 		values

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -2698,17 +2698,17 @@ fn generate_model_form(
 	};
 	let model_form_number_validation = match &model_source.selection {
 		TypedModelFieldSelection::Fields(fields) => {
-			let checks = fields.iter().filter_map(|field| {
+			let checks = fields.iter().map(|field| {
 				let variant = field_variant_ident(field);
 				let error = format_ident!("__{}_number_parse_error", field, span = field.span());
-				Some(quote! {
+				quote! {
 					if let ::core::option::Option::Some(parse_error) = self.#error.get() {
 						error.add_field_error(
 							__ReinhardtModelFormField::#variant,
 							parse_error.to_string(),
 						);
 					}
-				})
+				}
 			});
 			quote! { #(#checks)* }
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses:

- Reformat the aliased edit-form field allow-list so Format Check accepts `fields.rs`.
- Replace an always-`Some` `filter_map` in model form codegen so Clippy Lint no longer fails with `clippy::unnecessary_filter_map`.

These are the two primary CI failures on #6240. Auto-Fix Style and CI Success failed as follow-on jobs after Format Check / Clippy Lint.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

PR #6240 failed required CI because Format Check and Clippy Lint denied the new form-binding code:

- `crates/reinhardt-admin/src/server/fields.rs` was not rustfmt-clean.
- `crates/reinhardt-pages/macros/src/form/codegen.rs` used `.filter_map(...)` that always returned `Some(quote! { ... })`.

This branch lands those style-only fixes onto `feature/issue-6221-typed-form-field-bindings` so #6240 can pass Format Check and Clippy Lint.

Related to: #6240, #6221

## How Was This Tested?

- [x] `rustfmt --edition 2024 --check` on the two changed files
- [x] `cargo clippy -p reinhardt-pages-macros --all-features --lib --no-deps -- -D warnings`
- [x] `cargo clippy -p reinhardt-admin --all-features --lib --no-deps -- -D warnings`
- [ ] Full workspace `cargo make fmt-check` / `cargo make clippy-check` (scoped to the failing crates; workspace Auto-Fix Style also hit a pre-existing `cap-std` resolver conflict in `clippy-fix-examples`)

## Performance Impact

Not performance-related. Iterator shape is equivalent; rustfmt-only whitespace plus dropping unused closure bindings.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (style-only; clippy on the failing crates passes)
- [x] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with rustfmt on the changed files
- [x] I have checked the changed crates with `cargo clippy ... -- -D warnings`

- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Related to #6240
- Related to #6221

## Labels to Apply

### Type Label (select one)
- [ ] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [x] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)
- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)
- [ ] `database` - Database layer, schema, migrations
- [ ] `auth` - Authentication, authorization, sessions
- [ ] `orm` - ORM layer, models, query builder
- [ ] `http` - HTTP layer, handlers, middleware
- [ ] `routing` - URL routing, path matching
- [ ] `api` - REST API, serializers, views
- [x] `admin` - Admin interface, admin panels
- [x] `forms` - Form handling, validation, rendering
- [ ] `graphql` - GraphQL schema, resolvers
- [ ] `websockets` - WebSocket connections, handlers
- [ ] `i18n` - Internationalization, localization
- [ ] `ci-cd` - CI/CD workflow changes
- [x] `pages` - Pages/runtime integration

### Priority Label (for maintainers)
- [ ] `critical` - Blocks release or major functionality
- [x] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

Merging this into `feature/issue-6221-typed-form-field-bindings` unblocks Format Check and Clippy Lint on #6240. The Auto-Fix Style `cap-std` 3.4.5 vs 3.4.6 resolver conflict is outside these two files and should not run once Format/Clippy pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05f4b-16e3-7d38-8906-108789062989?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05f4b-16e3-7d38-8906-108789062989&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

