### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.3.15...reinhardt-web@v0.3.16) - 2026-09-02
+
+### Testing
+
+- *(urls)* enforce inactive WASM server routing
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.3.14...reinhardt-web@v0.3.15) - 2026-09-01
 
 ### Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-web"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -493,77 +493,77 @@ module_name_repetitions = "allow"
 
 [workspace.dependencies]
 # Main facade crate (for workspace members that need to reference the root crate)
-reinhardt = { path = ".", package = "reinhardt-web", version = "0.3.15" }
+reinhardt = { path = ".", package = "reinhardt-web", version = "0.3.16" }
 
 # Internal crates
-reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.3.15" }
-reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.3.15" }
-reinhardt-core = { path = "crates/reinhardt-core", version = "0.3.15", default-features = false }
-reinhardt-di = { path = "crates/reinhardt-di", version = "0.3.15" }
-reinhardt-http = { path = "crates/reinhardt-http", version = "0.3.15" }
-reinhardt-server = { path = "crates/reinhardt-server", version = "0.3.15" }
-reinhardt-views = { path = "crates/reinhardt-views", version = "0.3.15", default-features = false }
-reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.3.15", default-features = false }
-reinhardt-router = { path = "crates/reinhardt-router", version = "0.3.15" }
-reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.3.15", default-features = false }
-reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.3.15" }
-reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.3.15" }
-reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.3.15" }
-reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.3.15" }
-reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.3.15" }
-reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.3.15" }
-reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.3.15" }
-reinhardt-test = { path = "crates/reinhardt-test", version = "0.3.15" }
-reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.3.15" }
-reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.3.15" }
-reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.3.15" }
-reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.3.15", default-features = false }
-reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.3.15" }
-reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.3.15", default-features = false }
-reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.3.15" }
-reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.3.15" }
-reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.3.15" }
-reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.3.15" }
-tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.3.15" }
-tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.3.15" }
-tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.3.15" }
+reinhardt-apps = { path = "crates/reinhardt-apps", version = "0.3.16" }
+reinhardt-conf = { path = "crates/reinhardt-conf", version = "0.3.16" }
+reinhardt-core = { path = "crates/reinhardt-core", version = "0.3.16", default-features = false }
+reinhardt-di = { path = "crates/reinhardt-di", version = "0.3.16" }
+reinhardt-http = { path = "crates/reinhardt-http", version = "0.3.16" }
+reinhardt-server = { path = "crates/reinhardt-server", version = "0.3.16" }
+reinhardt-views = { path = "crates/reinhardt-views", version = "0.3.16", default-features = false }
+reinhardt-urls = { path = "crates/reinhardt-urls", version = "0.3.16", default-features = false }
+reinhardt-router = { path = "crates/reinhardt-router", version = "0.3.16" }
+reinhardt-middleware = { path = "crates/reinhardt-middleware", version = "0.3.16", default-features = false }
+reinhardt-pages = { path = "crates/reinhardt-pages", version = "0.3.16" }
+reinhardt-pages-macros = { path = "crates/reinhardt-pages/macros", version = "0.3.16" }
+reinhardt-pages-ast = { path = "crates/reinhardt-pages/ast", version = "0.3.16" }
+reinhardt-manouche = { path = "crates/reinhardt-manouche", version = "0.3.16" }
+reinhardt-forms = { path = "crates/reinhardt-forms", version = "0.3.16" }
+reinhardt-testkit = { path = "crates/reinhardt-testkit", version = "0.3.16" }
+reinhardt-testkit-macros = { path = "crates/reinhardt-testkit-macros", version = "0.3.16" }
+reinhardt-test = { path = "crates/reinhardt-test", version = "0.3.16" }
+reinhardt-tasks = { path = "crates/reinhardt-tasks", version = "0.3.16" }
+reinhardt-streaming = { path = "crates/reinhardt-streaming", version = "0.3.16" }
+reinhardt-utils = { path = "crates/reinhardt-utils", version = "0.3.16" }
+reinhardt-rest = { path = "crates/reinhardt-rest", version = "0.3.16", default-features = false }
+reinhardt-throttling = { path = "crates/reinhardt-throttling", version = "0.3.16" }
+reinhardt-auth = { path = "crates/reinhardt-auth", version = "0.3.16", default-features = false }
+reinhardt-auth-macros = { path = "crates/reinhardt-auth/macros", version = "0.3.16" }
+reinhardt-admin = { path = "crates/reinhardt-admin", version = "0.3.16" }
+reinhardt-admin-cli = { path = "crates/reinhardt-admin-cli", version = "0.3.16" }
+reinhardt-formatter = { path = "crates/reinhardt-formatter", version = "0.3.16" }
+tree-sitter-reinhardt-page = { path = "crates/tree-sitter-reinhardt-page", version = "0.3.16" }
+tree-sitter-reinhardt-form = { path = "crates/tree-sitter-reinhardt-form", version = "0.3.16" }
+tree-sitter-reinhardt-head = { path = "crates/tree-sitter-reinhardt-head", version = "0.3.16" }
 topiary-core = "0.7.3"
 topiary-tree-sitter-facade = "0.7.3"
-reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.3.15" }
-reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.3.15" }
-reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.3.15" }
-reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.3.15", default-features = false }
-reinhardt-db = { path = "crates/reinhardt-db", version = "0.3.15", default-features = false }
-reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.3.15" }
-reinhardt-query = { path = "crates/reinhardt-query", version = "0.3.15" }
-reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.3.15" }
-reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.3.15" }
-reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.3.15" }
-reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.3.15" }
-reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.3.15" }
-reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.3.15" }
-reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.3.15" }
-reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.3.15" }
-reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.3.15" }
+reinhardt-grpc = { path = "crates/reinhardt-grpc", version = "0.3.16" }
+reinhardt-grpc-macros = { path = "crates/reinhardt-grpc/macros", version = "0.3.16" }
+reinhardt-graphql-macros = { path = "crates/reinhardt-graphql/macros", version = "0.3.16" }
+reinhardt-commands = { path = "crates/reinhardt-commands", version = "0.3.16", default-features = false }
+reinhardt-db = { path = "crates/reinhardt-db", version = "0.3.16", default-features = false }
+reinhardt-db-macros = { path = "crates/reinhardt-db-macros", version = "0.3.16" }
+reinhardt-query = { path = "crates/reinhardt-query", version = "0.3.16" }
+reinhardt-shortcuts = { path = "crates/reinhardt-shortcuts", version = "0.3.16" }
+reinhardt-dispatch = { path = "crates/reinhardt-dispatch", version = "0.3.16" }
+reinhardt-i18n = { path = "crates/reinhardt-i18n", version = "0.3.16" }
+reinhardt-mail = { path = "crates/reinhardt-mail", version = "0.3.16" }
+reinhardt-graphql = { path = "crates/reinhardt-graphql", version = "0.3.16" }
+reinhardt-websockets = { path = "crates/reinhardt-websockets", version = "0.3.16" }
+reinhardt-dentdelion = { path = "crates/reinhardt-dentdelion", version = "0.3.16" }
+reinhardt-deeplink = { path = "crates/reinhardt-deeplink", version = "0.3.16" }
+reinhardt-openapi = { path = "crates/reinhardt-openapi", version = "0.3.16" }
 
 # Feature crates (develop/0.2.0)
-reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.3.15" }
-reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.3.15" }
+reinhardt-providers = { path = "crates/reinhardt-providers", version = "0.3.16" }
+reinhardt-storages = { path = "crates/reinhardt-storages", version = "0.3.16" }
 
 # Query subcrates
-reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.3.15" }
+reinhardt-query-macros = { path = "crates/reinhardt-query/macros", version = "0.3.16" }
 
 # Core subcrates
-reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.3.15" }
+reinhardt-macros = { path = "crates/reinhardt-core/macros", version = "0.3.16" }
 
 # DI subcrates
-reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.3.15" }
+reinhardt-di-macros = { path = "crates/reinhardt-di/macros", version = "0.3.16" }
 
 # REST subcrates
-reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.3.15" }
+reinhardt-openapi-macros = { path = "crates/reinhardt-rest/openapi-macros", version = "0.3.16" }
 
 # REST subcrates (continued)
-reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.3.15" }
+reinhardt-routers-macros = { path = "crates/reinhardt-urls/routers-macros", version = "0.3.16" }
 
 # Streaming
 rskafka = { version = "0.6" }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you have written `ModelSerializer` or `Depends()` before, Reinhardt will feel
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 
 reinhardt-admin startproject my-api && cd my-api
 cargo run --bin manage runserver  # Visit http://127.0.0.1:8000
@@ -103,7 +103,7 @@ Reinhardt follows a **three-phase lifecycle** for every crate:
 | **Stable** (`0.x.0`) | Full SemVer 2.0 guarantees. |
 
 <!-- reinhardt-version-sync -->
-**Current release line:** Reinhardt documentation tracks `0.3.15`. From
+**Current release line:** Reinhardt documentation tracks `0.3.16`. From
 `0.1.0` onward, all public APIs follow SemVer 2.0; future breaking changes
 move through the documented alpha and RC lifecycle before stable publication.
 
@@ -131,7 +131,7 @@ Get a well-balanced feature set with zero configuration:
 [dependencies]
 # Import as 'reinhardt', published as 'reinhardt-web'
 # Default enables the "standard" preset (balanced feature set)
-reinhardt = { version = "0.3.15", package = "reinhardt-web" }
+reinhardt = { version = "0.3.16", package = "reinhardt-web" }
 ```
 
 **Includes:** Core, Database (PostgreSQL), REST API (serializers, parsers, pagination, filters, throttling, versioning, metadata, content negotiation), Auth, Middleware (sessions), Pages (WASM Frontend with SSR), Signals
@@ -153,7 +153,7 @@ For compatibility checks, framework development, and projects that intentionally
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = ["full"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = ["full"] }
 ```
 
 **Includes:** Everything in Standard, plus Admin, GraphQL, WebSockets, Cache, i18n, Mail, Static Files, Storage, and more
@@ -167,7 +167,7 @@ Lightweight and fast, perfect for simple APIs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = ["minimal"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = ["minimal"] }
 ```
 
 **Includes:** HTTP, routing, DI, parameter extraction, server
@@ -182,26 +182,26 @@ Install only the components you need:
 ```toml
 [dependencies]
 # Core components
-reinhardt-http = "0.3.15"
-reinhardt-urls = "0.3.15"
+reinhardt-http = "0.3.16"
+reinhardt-urls = "0.3.16"
 
 # Optional: Database
-reinhardt-db = "0.3.15"
+reinhardt-db = "0.3.16"
 
 # Optional: Authentication
-reinhardt-auth = "0.3.15"
+reinhardt-auth = "0.3.16"
 
 # Optional: browser-bound social OAuth state (add `session-redis` for Redis)
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = ["social-auth"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = ["social-auth"] }
 
 # Optional: REST API features
-reinhardt-rest = "0.3.15"
+reinhardt-rest = "0.3.16"
 
 # Optional: Admin panel
-reinhardt-admin = "0.3.15"
+reinhardt-admin = "0.3.16"
 
 # Optional: Advanced features
-reinhardt-graphql = "0.3.15"
+reinhardt-graphql = "0.3.16"
 reinhardt-websockets = "0.3.13"
 ```
 
@@ -220,7 +220,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 ### 2. Create a New Project
@@ -237,7 +237,7 @@ during project creation. Scripts can pass them explicitly:
 <!-- reinhardt-version-sync -->
 ```bash
 reinhardt-admin startproject my-api \
-  --reinhardt-version "0.3.15" \
+  --reinhardt-version "0.3.16" \
   --features standard,admin \
   --no-interactive
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -105,7 +105,7 @@ separate dependency-advisory review; it is not a comprehensive product audit.
 Reinhardt follows the lifecycle in
 [`instructions/STABILITY_POLICY.md`](instructions/STABILITY_POLICY.md).
 <!-- reinhardt-version-sync -->
-Security fixes target the current supported release, `0.3.15`, and the current
+Security fixes target the current supported release, `0.3.16`, and the current
 development line as appropriate.
 
 ## Reporting a Vulnerability

--- a/crates/reinhardt-admin-cli/CHANGELOG.md
+++ b/crates/reinhardt-admin-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.3.15...reinhardt-admin-cli@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.3.14...reinhardt-admin-cli@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-admin-cli/Cargo.toml
+++ b/crates/reinhardt-admin-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin-cli"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin-cli/README.md
+++ b/crates/reinhardt-admin-cli/README.md
@@ -14,7 +14,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 This installs the `reinhardt-admin` command.
@@ -40,7 +40,7 @@ reinhardt-admin startproject myproject --with-rest /path/to/directory
 
 # Pin the generated Reinhardt dependency
 reinhardt-admin startproject myproject --with-rest \
-  --reinhardt-version 0.3.15 \
+  --reinhardt-version 0.3.16 \
   --features standard,admin \
   --no-interactive
 ```
@@ -58,7 +58,7 @@ reinhardt-admin configure
 
 # Update a project without prompts
 reinhardt-admin configure /path/to/project \
-  --reinhardt-version 0.3.15 \
+  --reinhardt-version 0.3.16 \
   --features minimal,db-sqlite \
   --no-interactive
 ```
@@ -108,7 +108,7 @@ reinhardt-admin plugin info auth-delion --remote
 
 # Install a plugin
 reinhardt-admin plugin install auth-delion
-reinhardt-admin plugin install auth-delion --version 0.3.15
+reinhardt-admin plugin install auth-delion --version 0.3.16
 
 # Remove a plugin
 reinhardt-admin plugin remove auth-delion

--- a/crates/reinhardt-admin-cli/src/main.rs
+++ b/crates/reinhardt-admin-cli/src/main.rs
@@ -14,7 +14,7 @@
 //!
 //! <!-- reinhardt-version-sync -->
 //! ```bash
-//! cargo install reinhardt-admin-cli --version "0.3.15"
+//! cargo install reinhardt-admin-cli --version "0.3.16"
 //! ```
 //!
 //! ## Usage

--- a/crates/reinhardt-admin/CHANGELOG.md
+++ b/crates/reinhardt-admin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.3.15...reinhardt-admin@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.3.14...reinhardt-admin@v0.3.15) - 2026-09-01
 
 ### Fixed

--- a/crates/reinhardt-admin/Cargo.toml
+++ b/crates/reinhardt-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-admin"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-admin/README.md
+++ b/crates/reinhardt-admin/README.md
@@ -34,10 +34,10 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:2 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["admin"] }
+reinhardt = { version = "0.3.16", features = ["admin"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["full"] }  # All features
+# reinhardt = { version = "0.3.16", features = ["full"] }  # All features
 ```
 
 Then import admin features:

--- a/crates/reinhardt-apps/CHANGELOG.md
+++ b/crates/reinhardt-apps/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.3.15...reinhardt-apps@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.3.14...reinhardt-apps@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-apps/Cargo.toml
+++ b/crates/reinhardt-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-apps"
-version = "0.3.15"
+version = "0.3.16"
 description = "Application registry and management for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-apps/README.md
+++ b/crates/reinhardt-apps/README.md
@@ -19,11 +19,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["apps"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["apps"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["full"] }      # All features
 ```
 
 Then import app features:
@@ -53,7 +53,7 @@ installed_apps! {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.15",
+	version = "0.3.16",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin"]
 }
@@ -148,7 +148,7 @@ pub fn get_installed_apps() -> Vec<String> {
 ```toml
 [dependencies]
 reinhardt = {
-	version = "0.3.15",
+	version = "0.3.16",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "admin", "static-files"]
 }
@@ -240,7 +240,7 @@ pub fn get_installed_apps() -> Vec<String> {
 # Cargo.toml
 [dependencies]
 reinhardt = {
-	version = "0.3.15",
+	version = "0.3.16",
 	package = "reinhardt-web",
 	features = ["auth", "sessions", "database"]
 }
@@ -300,7 +300,7 @@ INSTALLED_APPS = [
 ```toml
 # Cargo.toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["auth", "admin"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["auth", "admin"] }
 ```
 
 ```rust

--- a/crates/reinhardt-auth/Cargo.toml
+++ b/crates/reinhardt-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth"
-version = "0.3.15"
+version = "0.3.16"
 description = "Authentication and authorization system"
 keywords = ["auth", "jwt", "authentication", "django", "web"]
 categories = ["authentication", "web-programming"]

--- a/crates/reinhardt-auth/README.md
+++ b/crates/reinhardt-auth/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["auth"] }
+reinhardt = { version = "0.3.16", features = ["auth"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import authentication features:

--- a/crates/reinhardt-auth/macros/Cargo.toml
+++ b/crates/reinhardt-auth/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-auth-macros"
-version = "0.3.15"
+version = "0.3.16"
 description = "Procedural macros for reinhardt-auth (guard!)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-commands/CHANGELOG.md
+++ b/crates/reinhardt-commands/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.3.15...reinhardt-commands@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.3.14...reinhardt-commands@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-commands"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["commands"] }
+reinhardt = { version = "0.3.16", features = ["commands"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import command features:
@@ -39,7 +39,7 @@ package:
 ```bash
 # Pin the documented Reinhardt release for reproducibility.
 # Omit --version to let Cargo choose the latest stable release.
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 This installs the `reinhardt-admin` command:
@@ -129,7 +129,7 @@ use reinhardt::commands::TemplateContext;
 
 let mut context = TemplateContext::new();
 context.insert("project_name", "my_project");
-context.insert("version", "0.3.15");
+context.insert("version", "0.3.16");
 context.insert("features", vec!["auth", "admin"]);  // Any Serialize type
 ```
 
@@ -341,7 +341,7 @@ Projects using `collect_migrations!` must add `linkme` as a dependency:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["standard"] }
+reinhardt = { version = "0.3.16", features = ["standard"] }
 linkme = "0.3"
 ```
 

--- a/crates/reinhardt-conf/CHANGELOG.md
+++ b/crates/reinhardt-conf/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.3.15...reinhardt-conf@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.3.14...reinhardt-conf@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-conf"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -29,11 +29,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["conf"] }
+reinhardt = { version = "0.3.16", features = ["conf"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import configuration features:
@@ -52,13 +52,13 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 # With async support
-reinhardt = { version = "0.3.15", features = ["conf", "async"] }
+reinhardt = { version = "0.3.16", features = ["conf", "async"] }
 
 # With encryption
-reinhardt = { version = "0.3.15", features = ["conf", "encryption"] }
+reinhardt = { version = "0.3.16", features = ["conf", "encryption"] }
 
 # With Vault integration
-reinhardt = { version = "0.3.15", features = ["conf", "vault"] }
+reinhardt = { version = "0.3.16", features = ["conf", "vault"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/CHANGELOG.md
+++ b/crates/reinhardt-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.3.15...reinhardt-core@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.3.14...reinhardt-core@v0.3.15) - 2026-09-01
 
 ### Fixed

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-core"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -94,7 +94,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = "0.3.15"
+reinhardt-core = "0.3.16"
 ```
 
 ### Optional Features
@@ -104,7 +104,7 @@ Enable specific modules based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-core = { version = "0.3.15", features = ["signals", "macros", "security"] }
+reinhardt-core = { version = "0.3.16", features = ["signals", "macros", "security"] }
 ```
 
 Available features:

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db-macros/Cargo.toml
+++ b/crates/reinhardt-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/CHANGELOG.md
+++ b/crates/reinhardt-db/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.3.15...reinhardt-db@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.3.14...reinhardt-db@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-db/Cargo.toml
+++ b/crates/reinhardt-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-db"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-db/README.md
+++ b/crates/reinhardt-db/README.md
@@ -158,7 +158,7 @@ Add this to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = "0.3.15"
+reinhardt-db = "0.3.16"
 ```
 
 ### Optional Features
@@ -168,7 +168,7 @@ Enable specific features based on your needs:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-db = { version = "0.3.15", features = ["postgres", "orm", "migrations"] }
+reinhardt-db = { version = "0.3.16", features = ["postgres", "orm", "migrations"] }
 ```
 
 Available features:

--- a/crates/reinhardt-deeplink/Cargo.toml
+++ b/crates/reinhardt-deeplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-deeplink"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/CHANGELOG.md
+++ b/crates/reinhardt-dentdelion/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.3.15...reinhardt-dentdelion@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.3.14...reinhardt-dentdelion@v0.3.15) - 2026-09-01
 
 ### Fixed

--- a/crates/reinhardt-dentdelion/Cargo.toml
+++ b/crates/reinhardt-dentdelion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dentdelion"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dentdelion/README.md
+++ b/crates/reinhardt-dentdelion/README.md
@@ -22,11 +22,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["dentdelion"] }
+reinhardt = { version = "0.3.16", features = ["dentdelion"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import dentdelion features:
@@ -62,7 +62,7 @@ pub struct MyPlugin {
 impl MyPlugin {
     pub fn new() -> Self {
         Self {
-            metadata: PluginMetadata::builder("my-plugin", "0.3.15")
+            metadata: PluginMetadata::builder("my-plugin", "0.3.16")
                 .description("My custom plugin")
                 .author("Your Name")
                 .build()
@@ -225,7 +225,7 @@ Dentdelion uses the WebAssembly Interface Types (WIT) standard for plugin interf
 
 <!-- reinhardt-version-sync -->
 ```wit
-package reinhardt:dentdelion@0.3.15;
+package reinhardt:dentdelion@0.3.16;
 
 // Host functions available to plugins
 interface host {

--- a/crates/reinhardt-di/Cargo.toml
+++ b/crates/reinhardt-di/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "reinhardt-di"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-di/README.md
+++ b/crates/reinhardt-di/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["di"] }
+reinhardt = { version = "0.3.16", features = ["di"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import DI features:

--- a/crates/reinhardt-di/macros/Cargo.toml
+++ b/crates/reinhardt-di/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-di-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-dispatch/Cargo.toml
+++ b/crates/reinhardt-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-dispatch"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-dispatch/README.md
+++ b/crates/reinhardt-dispatch/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["dispatch"] }
+reinhardt = { version = "0.3.16", features = ["dispatch"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import dispatch features:

--- a/crates/reinhardt-formatter/Cargo.toml
+++ b/crates/reinhardt-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-formatter"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-forms/CHANGELOG.md
+++ b/crates/reinhardt-forms/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-forms@v0.3.15...reinhardt-forms@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-forms@v0.3.14...reinhardt-forms@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-forms/Cargo.toml
+++ b/crates/reinhardt-forms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-forms"
-version = "0.3.15"
+version = "0.3.16"
 description = "Form handling and validation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-forms/README.md
+++ b/crates/reinhardt-forms/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["forms"] }
+reinhardt = { version = "0.3.16", features = ["forms"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 
 # Forms is included in the standard preset
 ```

--- a/crates/reinhardt-graphql/Cargo.toml
+++ b/crates/reinhardt-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql"
-version = "0.3.15"
+version = "0.3.16"
 description = "GraphQL API support for Reinhardt (facade crate)"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -107,11 +107,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["graphql"] }
+reinhardt = { version = "0.3.16", features = ["graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import GraphQL features:
@@ -128,10 +128,10 @@ use reinhardt::graphql::types::{UserStorage, UserEvent};
 <!-- reinhardt-version-sync:2 -->
 ```toml
 # With dependency injection
-reinhardt = { version = "0.3.15", features = ["graphql", "di"] }
+reinhardt = { version = "0.3.16", features = ["graphql", "di"] }
 
 # With gRPC transport
-reinhardt = { version = "0.3.15", features = ["graphql", "grpc"] }
+reinhardt = { version = "0.3.16", features = ["graphql", "grpc"] }
 ```
 
 ## Examples

--- a/crates/reinhardt-graphql/macros/Cargo.toml
+++ b/crates/reinhardt-graphql/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-graphql-macros"
-version = "0.3.15"
+version = "0.3.16"
 description = "Procedural macros for GraphQL schema generation"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/CHANGELOG.md
+++ b/crates/reinhardt-grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.3.15...reinhardt-grpc@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.3.14...reinhardt-grpc@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-grpc/Cargo.toml
+++ b/crates/reinhardt-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc"
-version = "0.3.15"
+version = "0.3.16"
 description = "gRPC support for building RPC services"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-grpc/README.md
+++ b/crates/reinhardt-grpc/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["grpc"] }
+reinhardt = { version = "0.3.16", features = ["grpc"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import gRPC features:
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-grpc = "0.3.15"
+reinhardt-grpc = "0.3.16"
 tonic = "0.12"
 prost = "0.13"
 
@@ -193,7 +193,7 @@ Facade consumers can enable `grpc` alongside a preset that includes DI:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = ["minimal", "grpc"] }
 ```
 
 Direct `reinhardt-grpc` consumers can instead enable this crate's `di`

--- a/crates/reinhardt-grpc/macros/Cargo.toml
+++ b/crates/reinhardt-grpc/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-grpc-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/Cargo.toml
+++ b/crates/reinhardt-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-http"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -87,11 +87,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = "0.3.15"
+reinhardt = "0.3.16"
 
 # Or use a preset with parsers support:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 **Note:** HTTP types are available through the main `reinhardt` crate, which provides a unified interface to all framework components.

--- a/crates/reinhardt-i18n/Cargo.toml
+++ b/crates/reinhardt-i18n/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-i18n"
-version = "0.3.15"
+version = "0.3.16"
 description = "Internationalization and localization support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-i18n/README.md
+++ b/crates/reinhardt-i18n/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["i18n"] }
+reinhardt = { version = "0.3.16", features = ["i18n"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import i18n features:

--- a/crates/reinhardt-mail/Cargo.toml
+++ b/crates/reinhardt-mail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-mail"
-version = "0.3.15"
+version = "0.3.16"
 description = "Email sending functionality with multiple backends"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-mail/README.md
+++ b/crates/reinhardt-mail/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["mail"] }
+reinhardt = { version = "0.3.16", features = ["mail"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import mail features:

--- a/crates/reinhardt-manouche/CHANGELOG.md
+++ b/crates/reinhardt-manouche/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-manouche@v0.3.15...reinhardt-manouche@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-manouche@v0.3.14...reinhardt-manouche@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-manouche/Cargo.toml
+++ b/crates/reinhardt-manouche/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-manouche"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-middleware/Cargo.toml
+++ b/crates/reinhardt-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-middleware"
-version = "0.3.15"
+version = "0.3.16"
 description = "Middleware system for request/response processing pipeline"
 keywords = ["middleware", "web", "cors", "security", "http"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-middleware/README.md
+++ b/crates/reinhardt-middleware/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["middleware"] }
+reinhardt = { version = "0.3.16", features = ["middleware"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import middleware features:

--- a/crates/reinhardt-openapi/Cargo.toml
+++ b/crates/reinhardt-openapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-pages/CHANGELOG.md
+++ b/crates/reinhardt-pages/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.3.15...reinhardt-pages@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.3.14...reinhardt-pages@v0.3.15) - 2026-09-01
 
 ### Fixed

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/ast/Cargo.toml
+++ b/crates/reinhardt-pages/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-ast"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-pages/macros/Cargo.toml
+++ b/crates/reinhardt-pages/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-pages-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-providers/Cargo.toml
+++ b/crates/reinhardt-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-providers"
-version = "0.3.15"
+version = "0.3.16"
 description = "Cloud provider integrations for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-query/Cargo.toml
+++ b/crates/reinhardt-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-query/README.md
+++ b/crates/reinhardt-query/README.md
@@ -44,7 +44,7 @@ Add to your `Cargo.toml`:
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt-query = { version = "0.3.15" }
+reinhardt-query = { version = "0.3.16" }
 ```
 
 ## Quick Start

--- a/crates/reinhardt-query/macros/Cargo.toml
+++ b/crates/reinhardt-query/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-query-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-rest/CHANGELOG.md
+++ b/crates/reinhardt-rest/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.3.15...reinhardt-rest@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.3.14...reinhardt-rest@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-rest/Cargo.toml
+++ b/crates/reinhardt-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-rest"
-version = "0.3.15"
+version = "0.3.16"
 description = "REST API framework aggregator for Reinhardt"
 keywords = ["rest", "api", "web", "framework", "django"]
 categories = ["web-programming", "web-programming::http-server"]

--- a/crates/reinhardt-rest/README.md
+++ b/crates/reinhardt-rest/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["rest"] }
+reinhardt = { version = "0.3.16", features = ["rest"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import REST features:

--- a/crates/reinhardt-rest/openapi-macros/Cargo.toml
+++ b/crates/reinhardt-rest/openapi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-openapi-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-router/Cargo.toml
+++ b/crates/reinhardt-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-router"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-server/CHANGELOG.md
+++ b/crates/reinhardt-server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-server@v0.3.15...reinhardt-server@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-server@v0.3.14...reinhardt-server@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-server/Cargo.toml
+++ b/crates/reinhardt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-server"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -44,17 +44,17 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:5 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["server"] }
+reinhardt = { version = "0.3.16", features = ["server"] }
 
 # For WebSocket support:
-# reinhardt = { version = "0.3.15", features = ["server", "websocket"] }
+# reinhardt = { version = "0.3.16", features = ["server", "websocket"] }
 
 # For GraphQL support:
-# reinhardt = { version = "0.3.15", features = ["server", "graphql"] }
+# reinhardt = { version = "0.3.16", features = ["server", "graphql"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import server features:

--- a/crates/reinhardt-shortcuts/Cargo.toml
+++ b/crates/reinhardt-shortcuts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-shortcuts"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-shortcuts/README.md
+++ b/crates/reinhardt-shortcuts/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["shortcuts"] }
+reinhardt = { version = "0.3.16", features = ["shortcuts"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import shortcuts features:

--- a/crates/reinhardt-storages/CHANGELOG.md
+++ b/crates/reinhardt-storages/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-storages@v0.3.15...reinhardt-storages@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-storages@v0.3.14...reinhardt-storages@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-storages/Cargo.toml
+++ b/crates/reinhardt-storages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-storages"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 authors = ["Reinhardt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/reinhardt-streaming/Cargo.toml
+++ b/crates/reinhardt-streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-streaming"
-version = "0.3.15"
+version = "0.3.16"
 description = "Backend-agnostic streaming abstraction with Kafka support"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/Cargo.toml
+++ b/crates/reinhardt-tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-tasks"
-version = "0.3.15"
+version = "0.3.16"
 description = "Background task execution and scheduling"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-tasks/README.md
+++ b/crates/reinhardt-tasks/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["tasks"] }
+reinhardt = { version = "0.3.16", features = ["tasks"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import task features:

--- a/crates/reinhardt-test/Cargo.toml
+++ b/crates/reinhardt-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-test"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-test/README.md
+++ b/crates/reinhardt-test/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["test"] }
+reinhardt = { version = "0.3.16", features = ["test"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import testing features:

--- a/crates/reinhardt-testkit-macros/Cargo.toml
+++ b/crates/reinhardt-testkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-testkit/Cargo.toml
+++ b/crates/reinhardt-testkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-testkit"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/reinhardt-throttling/Cargo.toml
+++ b/crates/reinhardt-throttling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-throttling"
-version = "0.3.15"
+version = "0.3.16"
 description = "Throttling and rate limiting for Reinhardt framework"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-urls/CHANGELOG.md
+++ b/crates/reinhardt-urls/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.3.15...reinhardt-urls@v0.3.16) - 2026-09-02
+
+### Testing
+
+- *(urls)* enforce inactive WASM server routing
+
 ## [0.3.10](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.3.9...reinhardt-urls@v0.3.10) - 2026-08-22
 
 ### Security

--- a/crates/reinhardt-urls/Cargo.toml
+++ b/crates/reinhardt-urls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-urls"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -54,14 +54,14 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:4 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["urls"] }
+reinhardt = { version = "0.3.16", features = ["urls"] }
 
 # For specific sub-features:
-# reinhardt = { version = "0.3.15", features = ["urls-routers", "urls-proxy"] }
+# reinhardt = { version = "0.3.16", features = ["urls-routers", "urls-proxy"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import URLs features:

--- a/crates/reinhardt-urls/routers-macros/Cargo.toml
+++ b/crates/reinhardt-urls/routers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-routers-macros"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reinhardt-utils/CHANGELOG.md
+++ b/crates/reinhardt-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-utils@v0.3.15...reinhardt-utils@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-utils@v0.3.14...reinhardt-utils@v0.3.15) - 2026-09-01
 
 ### Fixed

--- a/crates/reinhardt-utils/Cargo.toml
+++ b/crates/reinhardt-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-utils"
-version = "0.3.15"
+version = "0.3.16"
 description = "Utility functions aggregator for Reinhardt"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-utils/README.md
+++ b/crates/reinhardt-utils/README.md
@@ -15,11 +15,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["utils"] }
+reinhardt = { version = "0.3.16", features = ["utils"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import utility features:

--- a/crates/reinhardt-views/CHANGELOG.md
+++ b/crates/reinhardt-views/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.3.15...reinhardt-views@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.3.14...reinhardt-views@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-views/Cargo.toml
+++ b/crates/reinhardt-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-views"
-version = "0.3.15"
+version = "0.3.16"
 description = "View layer aggregator for viewsets and views-core"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -17,11 +17,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["views"] }
+reinhardt = { version = "0.3.16", features = ["views"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import view features:
@@ -263,7 +263,7 @@ use reinhardt::views::{OpenAPISpec, Info, PathItem, Operation};
 
 let spec = OpenAPISpec::new(Info::new(
     "My API".into(),
-    "0.3.15".into()
+    "0.3.16".into()
 ));
 ```
 

--- a/crates/reinhardt-websockets/CHANGELOG.md
+++ b/crates/reinhardt-websockets/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.3.15...reinhardt-websockets@v0.3.16) - 2026-09-02
+
+### Maintenance
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.3.14...reinhardt-websockets@v0.3.15) - 2026-09-01
 
 ### Maintenance

--- a/crates/reinhardt-websockets/Cargo.toml
+++ b/crates/reinhardt-websockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinhardt-websockets"
-version = "0.3.15"
+version = "0.3.16"
 description = "WebSocket support for real-time bidirectional communication"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/reinhardt-websockets/README.md
+++ b/crates/reinhardt-websockets/README.md
@@ -13,11 +13,11 @@ Add `reinhardt` to your `Cargo.toml`:
 <!-- reinhardt-version-sync:3 -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", features = ["websockets"] }
+reinhardt = { version = "0.3.16", features = ["websockets"] }
 
 # Or use a preset:
-# reinhardt = { version = "0.3.15", features = ["standard"] }  # Recommended
-# reinhardt = { version = "0.3.15", features = ["full"] }      # All features
+# reinhardt = { version = "0.3.16", features = ["standard"] }  # Recommended
+# reinhardt = { version = "0.3.16", features = ["full"] }      # All features
 ```
 
 Then import WebSocket features:

--- a/crates/tree-sitter-reinhardt-form/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-form"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-head/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-head/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-head"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/tree-sitter-reinhardt-page/Cargo.toml
+++ b/crates/tree-sitter-reinhardt-page/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-reinhardt-page"
-version = "0.3.15"
+version = "0.3.16"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.15", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.16", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -35,7 +35,7 @@ By default, examples use the parent Reinhardt checkout through the examples work
 <!-- reinhardt-version-sync -->
 ```toml
 [workspace.dependencies]
-reinhardt = { path = "..", version = "0.3.15", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.16", package = "reinhardt-web" }
 ```
 
 ### Explicit Patch Mode
@@ -69,7 +69,7 @@ rm -f .cargo/config.toml
 ```toml
 [dependencies]
 # ✅ Main reinhardt crate only
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["core", "database"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["core", "database"] }
 
 # ✅ External crates are fine
 tokio = { workspace = true }
@@ -85,7 +85,7 @@ rstest = "0.26.1"
 <!-- reinhardt-version-sync -->
 ```toml
 [dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", features = ["core"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", features = ["core"] }
 reinhardt-http = { path = "../../../crates/reinhardt-http" }      # ❌ NEVER
 reinhardt-routers = { path = "../../../crates/reinhardt-urls/crates/routers" }  # ❌ NEVER
 reinhardt-di = { path = "../../../crates/reinhardt-di" }          # ❌ NEVER

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.dependencies]
 # Reinhardt framework from this repository.
 # reinhardt-version-sync
-reinhardt = { path = "..", version = "0.3.15", package = "reinhardt-web" }
+reinhardt = { path = "..", version = "0.3.16", package = "reinhardt-web" }
 
 # The examples workspace is resolved independently in standalone CI, so it must
 # carry the same resolver workaround as the root workspace.

--- a/website/config.toml
+++ b/website/config.toml
@@ -24,11 +24,11 @@ og_image    = "https://reinhardt-web.dev/og-image.png"
 github_repo = "https://github.com/kent8192/reinhardt-web"
 crates_io   = "https://crates.io/crates/reinhardt-web"
 # reinhardt-version-sync
-docs_rs     = "https://docs.rs/reinhardt-web/0.3.15/reinhardt/"
+docs_rs     = "https://docs.rs/reinhardt-web/0.3.16/reinhardt/"
 changelog   = "https://github.com/kent8192/reinhardt-web/blob/main/CHANGELOG.md"
 deepwiki    = "https://deepwiki.com/kent8192/reinhardt-web"
 # reinhardt-version-sync
-reinhardt_version = "0.3.15"
+reinhardt_version = "0.3.16"
 
 # Populated at build time by deploy-website.yml.
 # Local dev: no version selector is shown (empty versions list).

--- a/website/content/docs/api/_index.md
+++ b/website/content/docs/api/_index.md
@@ -14,7 +14,7 @@ sidebar_weight = 10
 Welcome to the Reinhardt API reference documentation. This guide provides comprehensive information about Reinhardt's APIs, modules, and components.
 
 <!-- reinhardt-version-sync -->
-> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.15/reinhardt/).
+> **Note**: Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.16/reinhardt/).
 > Comprehensive documentation is also available in each crate's `lib.rs` file.
 
 ## Reinhardt Crate Structure
@@ -930,7 +930,7 @@ Main package that re-exports all components based on feature flags.
 **Documentation:**
 
 <!-- reinhardt-version-sync -->
-- [Main documentation](https://docs.rs/reinhardt-web/0.3.15/reinhardt/)
+- [Main documentation](https://docs.rs/reinhardt-web/0.3.16/reinhardt/)
 - [Feature Flags Guide](/docs/feature-flags/)
 
 ## Common Patterns
@@ -996,4 +996,4 @@ Found an error in the documentation? Want to improve it?
 ---
 
 <!-- reinhardt-version-sync -->
-**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.15/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.
+**Note**: This is a high-level overview. Full API documentation for this release is available at [docs.rs/reinhardt-web](https://docs.rs/reinhardt-web/0.3.16/reinhardt/). Comprehensive documentation is also available in each crate's `lib.rs` file.

--- a/website/content/docs/cookbook/_index.md
+++ b/website/content/docs/cookbook/_index.md
@@ -38,6 +38,6 @@ The Cookbook provides practical guides for solving common tasks.
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.15/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.3.16/reinhardt/)
 - [Migration Guides](/quickstart/migration-guides/)
 - [Troubleshooting](../troubleshooting/)

--- a/website/content/docs/troubleshooting/_index.md
+++ b/website/content/docs/troubleshooting/_index.md
@@ -30,6 +30,6 @@ Troubleshooting guides provide solutions to common problems encountered during d
 ## See Also
 
 <!-- reinhardt-version-sync -->
-- [API Reference](https://docs.rs/reinhardt-web/0.3.15/reinhardt/)
+- [API Reference](https://docs.rs/reinhardt-web/0.3.16/reinhardt/)
 - [Cookbook](../cookbook/)
 - [Migration Guides](/quickstart/migration-guides/)

--- a/website/content/quickstart/_index.md
+++ b/website/content/quickstart/_index.md
@@ -17,7 +17,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 ## 2. Create your project

--- a/website/content/quickstart/getting-started.md
+++ b/website/content/quickstart/getting-started.md
@@ -31,7 +31,7 @@ the latest stable release. The literal below is release-managed.
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 **Note:** After installation, the command is `reinhardt-admin`, not
@@ -381,7 +381,7 @@ Check out the [ORM documentation](/docs/api/) for more details.
 ## Getting Help
 
 <!-- reinhardt-version-sync -->
-- 📖 [API Reference](https://docs.rs/reinhardt-web/0.3.15/reinhardt/)
+- 📖 [API Reference](https://docs.rs/reinhardt-web/0.3.16/reinhardt/)
 - 🗺️ [DeepWiki](https://deepwiki.com/kent8192/reinhardt-web) - AI-generated codebase documentation
 - 💬 [GitHub Discussions](https://github.com/kent8192/reinhardt-web/discussions)
 - 🐛 [Report Issues](https://github.com/kent8192/reinhardt-web/issues)

--- a/website/content/quickstart/tutorials/basis/1-project-setup.md
+++ b/website/content/quickstart/tutorials/basis/1-project-setup.md
@@ -19,13 +19,13 @@ Use Rust 1.96.0 or newer. The generated Rust 2024 project requires that
 toolchain level.
 
 <!-- reinhardt-version-sync -->
-This tutorial uses the `0.3.15` Reinhardt generator.
+This tutorial uses the `0.3.16` Reinhardt generator.
 
 Install the Reinhardt project generator:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 The installed binary is `reinhardt-admin`.
@@ -121,14 +121,14 @@ features used by later parts of this tutorial:
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = ["pages", "client-router"] }
 wasm-bindgen = "=0.2.122"
 ```
 
 <!-- reinhardt-version-sync -->
 ```toml
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reinhardt = { version = "0.3.15", package = "reinhardt-web", default-features = false, features = [
+reinhardt = { version = "0.3.16", package = "reinhardt-web", default-features = false, features = [
     "minimal",
     "pages",
     "client-router",

--- a/website/content/quickstart/tutorials/rest/1-project-setup.md
+++ b/website/content/quickstart/tutorials/rest/1-project-setup.md
@@ -19,7 +19,7 @@ Install `reinhardt-admin-cli` once:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 The installed command is named `reinhardt-admin`.

--- a/website/content/quickstart/tutorials/rest/_index.md
+++ b/website/content/quickstart/tutorials/rest/_index.md
@@ -51,7 +51,7 @@ Install the Reinhardt project generator before starting Part 1:
 
 <!-- reinhardt-version-sync -->
 ```bash
-cargo install reinhardt-admin-cli --version "0.3.15"
+cargo install reinhardt-admin-cli --version "0.3.16"
 ```
 
 After installation, the command is `reinhardt-admin`.


### PR DESCRIPTION



## 🤖 New release

* `reinhardt-query-macros`: 0.3.15 -> 0.3.16
* `reinhardt-query`: 0.3.15 -> 0.3.16
* `reinhardt-macros`: 0.3.15 -> 0.3.16
* `reinhardt-core`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-http`: 0.3.15 -> 0.3.16
* `reinhardt-utils`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-conf`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-di-macros`: 0.3.15 -> 0.3.16
* `reinhardt-di`: 0.3.15 -> 0.3.16
* `reinhardt-server`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-apps`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-auth-macros`: 0.3.15 -> 0.3.16
* `reinhardt-db`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-throttling`: 0.3.15 -> 0.3.16
* `reinhardt-auth`: 0.3.15 -> 0.3.16
* `reinhardt-manouche`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-pages-ast`: 0.3.15 -> 0.3.16
* `reinhardt-pages-macros`: 0.3.15 -> 0.3.16
* `reinhardt-routers-macros`: 0.3.15 -> 0.3.16
* `reinhardt-mail`: 0.3.15 -> 0.3.16
* `reinhardt-middleware`: 0.3.15 -> 0.3.16
* `reinhardt-router`: 0.3.15 -> 0.3.16
* `reinhardt-streaming`: 0.3.15 -> 0.3.16
* `reinhardt-openapi-macros`: 0.3.15 -> 0.3.16
* `reinhardt-rest`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-views`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-urls`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-forms`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-pages`: 0.3.15 -> 0.3.16
* `reinhardt-admin`: 0.3.15 -> 0.3.16
* `reinhardt-tasks`: 0.3.15 -> 0.3.16
* `reinhardt-testkit-macros`: 0.3.15 -> 0.3.16
* `reinhardt-websockets`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-testkit`: 0.3.15 -> 0.3.16
* `reinhardt-test`: 0.3.15 -> 0.3.16
* `tree-sitter-reinhardt-page`: 0.3.15 -> 0.3.16
* `tree-sitter-reinhardt-form`: 0.3.15 -> 0.3.16
* `tree-sitter-reinhardt-head`: 0.3.15 -> 0.3.16
* `reinhardt-dentdelion`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-openapi`: 0.3.15 -> 0.3.16
* `reinhardt-commands`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-admin-cli`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-formatter`: 0.3.15 -> 0.3.16
* `reinhardt-grpc-macros`: 0.3.15 -> 0.3.16
* `reinhardt-grpc`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-db-macros`: 0.3.15 -> 0.3.16
* `reinhardt-dispatch`: 0.3.15 -> 0.3.16
* `reinhardt-shortcuts`: 0.3.15 -> 0.3.16
* `reinhardt-i18n`: 0.3.15 -> 0.3.16
* `reinhardt-graphql-macros`: 0.3.15 -> 0.3.16
* `reinhardt-graphql`: 0.3.15 -> 0.3.16
* `reinhardt-deeplink`: 0.3.15 -> 0.3.16
* `reinhardt-providers`: 0.3.15 -> 0.3.16
* `reinhardt-storages`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `reinhardt-web`: 0.3.15 -> 0.3.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `reinhardt-query-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query-macros@v0.2.0...reinhardt-query-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-query-macros` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-query`

<blockquote>

## [0.3.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-query@v0.3.8...reinhardt-query@v0.3.9) - 2026-08-21

### Fixed

- *(orm)* bind scoped mutations atomically
- *(orm)* preserve declared array element types
- *(orm)* preserve model session query state
</blockquote>

## `reinhardt-macros`

<blockquote>

## [0.3.14](https://github.com/kent8192/reinhardt-web/compare/reinhardt-macros@v0.3.13...reinhardt-macros@v0.3.14) - 2026-08-29

### Added

- *(macros)* add opt-in DTO schema generation

### Fixed

- *(macros)* address dto schema review feedback
- *(macros)* complete dto schema facade wiring
- *(macros)* match qualified validate derives
- *(macros)* recognize direct rest schema derives
</blockquote>

## `reinhardt-core`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-core@v0.3.15...reinhardt-core@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-http`

<blockquote>

## [0.3.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-http@v0.3.8...reinhardt-http@v0.3.9) - 2026-08-21

### Documentation

- *(security)* define request surface boundaries
- *(security)* qualify caller-enforced boundaries
- *(security)* document remaining trust boundaries

### Fixed

- *(security)* qualify boundary control ownership
</blockquote>

## `reinhardt-utils`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-utils@v0.3.15...reinhardt-utils@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-conf`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-conf@v0.3.15...reinhardt-conf@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-di-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di-macros@v0.2.0...reinhardt-di-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-di-macros` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- feat!(di): introduce keyed injectable provider outputs
- *(di)* add wasm parity stubs for injectable macros

### Fixed

- *(di)* support trait-based inject wrapper resolution
- *(di)* preserve Depends inject fallback
</blockquote>

## `reinhardt-di`

<blockquote>

## [0.3.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-di@v0.3.8...reinhardt-di@v0.3.9) - 2026-08-21

### Documentation

- *(security)* define data and identity boundaries
- *(security)* document secret and csrf boundaries

### Fixed

- *(security)* qualify boundary control ownership
</blockquote>

## `reinhardt-server`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-server@v0.3.15...reinhardt-server@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-apps`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-apps@v0.3.15...reinhardt-apps@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-auth-macros`

<blockquote>

## [0.3.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth-macros@v0.3.7...reinhardt-auth-macros@v0.3.8) - 2026-08-16

### Maintenance

- auto-fix fmt and clippy

### Styling

- *(auth)* format macro helper

### Testing

- *(auth)* cover guard proc macro
</blockquote>

## `reinhardt-db`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db@v0.3.15...reinhardt-db@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-throttling`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-throttling@v0.2.0...reinhardt-throttling@v0.3.0) - 2026-06-28

Stable release of `reinhardt-throttling` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-auth`

<blockquote>

## [0.3.14](https://github.com/kent8192/reinhardt-web/compare/reinhardt-auth@v0.3.13...reinhardt-auth@v0.3.14) - 2026-08-29

### Added

- *(auth)* add contextual OAuth state records
- *(auth)* add browser-bound OAuth context flow

### Documentation

- document contextual OAuth state features
</blockquote>

## `reinhardt-manouche`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-manouche@v0.3.15...reinhardt-manouche@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-pages-ast`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-ast@v0.2.0...reinhardt-pages-ast@v0.3.0) - 2026-06-28

Stable release of `reinhardt-pages-ast` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-pages-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages-macros@v0.2.0...reinhardt-pages-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-pages-macros` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- *(params)* generalize cookie extractors
- *(pages)* add route-backed component macros
- *(forms)* add dynamic FieldArray runtime support
- Added `#[derive(FromRequest)]`, `#[page_props]`, and
  `#[component("/path", "name")]` macro codegen for route-backed page
  components.

### Fixed

- *(todo-check)* clear public api audit markers
- *(di)* support trait-based inject wrapper resolution
- *(di)* preserve Depends inject fallback
- *(pages)* resolve generated builder dependency path
- *(pages)* address CodeRabbit component macro review
- *(forms)* propagate boxed field arrays to page macros
- *(forms)* box page macro collection validation
- *(forms)* address field array review feedback
- *(forms)* harden field array review paths
- Fixed generated builder derives to resolve through `reinhardt-pages` so
  downstream crates do not need a direct `bon` dependency.

### Performance

- *(pages)* reduce native endpoint dispatch allocations

### Maintenance

- merge main into develop/0.3.0
- merge develop 0.3.0 into build-time perf branch
- merge develop/0.3.0 into component route macros
</blockquote>

## `reinhardt-routers-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-routers-macros@v0.2.0...reinhardt-routers-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-routers-macros` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-mail`

<blockquote>

## [0.3.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-mail@v0.3.6...reinhardt-mail@v0.3.7) - 2026-08-12

### Testing

- *(mail)* cover message values and delivery
- *(mail)* cover backend selection and file delivery
- *(mail)* cover role helper failure policies
- *(mail)* strengthen coverage assertions
- *(mail)* move cross-crate coverage
- *(mail)* strengthen backend and failure coverage
- *(mail)* align backend coverage with public APIs
- *(mail)* close review coverage gaps
</blockquote>

## `reinhardt-middleware`

<blockquote>

## [0.3.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-middleware@v0.3.14...reinhardt-middleware@v0.3.15) - 2026-09-01

### Security

- *(middleware)* prevent private cache replay

### Testing

- *(middleware)* cover authenticated cache bypass order
</blockquote>

## `reinhardt-router`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-router@v0.2.0...reinhardt-router@v0.3.0) - 2026-06-28

Stable release of `reinhardt-router` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-streaming`

<blockquote>

## [0.3.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-streaming@v0.3.6...reinhardt-streaming@v0.3.7) - 2026-08-12

### Fixed

- *(streaming)* retry kafka receive in coverage test

### Testing

- *(streaming)* raise coverage to 90%
</blockquote>

## `reinhardt-openapi-macros`

<blockquote>

## [0.3.14](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi-macros@v0.3.13...reinhardt-openapi-macros@v0.3.14) - 2026-08-29

### Fixed

- *(macros)* address dto schema review feedback
- *(macros)* complete dto schema facade wiring
</blockquote>

## `reinhardt-rest`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-rest@v0.3.15...reinhardt-rest@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-views`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-views@v0.3.15...reinhardt-views@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-urls`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-urls@v0.3.15...reinhardt-urls@v0.3.16) - 2026-09-02

### Testing

- *(urls)* enforce inactive WASM server routing
</blockquote>

## `reinhardt-forms`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-forms@v0.3.15...reinhardt-forms@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-pages`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-pages@v0.3.15...reinhardt-pages@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-admin`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin@v0.3.15...reinhardt-admin@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-tasks`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-tasks@v0.2.2...reinhardt-tasks@v0.3.0) - 2026-06-28

Stable release of `reinhardt-tasks` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- merge main into develop/0.3.0
</blockquote>

## `reinhardt-testkit-macros`

<blockquote>

## [0.3.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit-macros@v0.3.6...reinhardt-testkit-macros@v0.3.7) - 2026-08-12

### Testing

- *(testkit)* cover DI override macro contracts
</blockquote>

## `reinhardt-websockets`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-websockets@v0.3.15...reinhardt-websockets@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-testkit`

<blockquote>

## [0.3.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-testkit@v0.3.6...reinhardt-testkit@v0.3.7) - 2026-08-12

### Fixed

- *(testkit)* assert public method and cookie headers
- *(testkit)* avoid hard-coded credential fixtures

### Testing

- *(testkit)* raise coverage to 75%
- *(testkit)* decode credential assertions
- *(testkit)* move integration coverage and assert request state
- *(testkit)* move client coverage and reject invalid states
- *(testkit)* move cross-crate scenarios to integration tests
- *(testkit)* preserve request assertion details
- *(testkit)* close review coverage gaps
- *(testkit)* cover authentication and rejection boundaries
- *(testkit)* reject mismatched assertion inputs
- *(testkit)* strengthen assertion boundary coverage
</blockquote>

## `reinhardt-test`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-test@v0.2.0...reinhardt-test@v0.3.0) - 2026-06-28

Stable release of `reinhardt-test` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- *(test)* add native msw mock server
- Native `reinhardt_test::msw::MockServiceWorker` support backed by a loopback
  HTTP mock server for explicit endpoint injection.

### Changed

- *(test)* share msw state across runtimes
- *(test)* adapt wasm msw to shared state

### Fixed

- *(scaffolding)* generate target-neutral Pages apps
- *(test)* consume native msw network error handlers
- *(test)* reject concurrent native msw startup
- *(test)* serialize native msw lifecycle state
- *(test)* stop native MSW keep-alive tasks

### Documentation

- *(test)* document native msw endpoint injection

### Testing

- *(test)* add native msw behavior coverage
- *(test)* tighten native msw coverage

### Styling

- *(test)* format native msw changes
</blockquote>

## `tree-sitter-reinhardt-page`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/tree-sitter-reinhardt-page@v0.1.2...tree-sitter-reinhardt-page@v0.3.0) - 2026-06-28

Stable release of `tree-sitter-reinhardt-page` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- *(formatter)* add semantic page grammar nodes
- *(formatter)* rustfmt page expression islands

### Fixed

- *(formatter)* handle reviewed page rustfmt islands
</blockquote>

## `tree-sitter-reinhardt-form`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/tree-sitter-reinhardt-form@v0.1.2...tree-sitter-reinhardt-form@v0.3.0) - 2026-06-28

Stable release of `tree-sitter-reinhardt-form` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `tree-sitter-reinhardt-head`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/tree-sitter-reinhardt-head@v0.1.2...tree-sitter-reinhardt-head@v0.3.0) - 2026-06-28

Stable release of `tree-sitter-reinhardt-head` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-dentdelion`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dentdelion@v0.3.15...reinhardt-dentdelion@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-openapi`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-openapi@v0.2.0...reinhardt-openapi@v0.3.0) - 2026-06-28

Stable release of `reinhardt-openapi` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-commands`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-commands@v0.3.15...reinhardt-commands@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-admin-cli`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-admin-cli@v0.3.15...reinhardt-admin-cli@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-formatter`

<blockquote>

## [0.3.13](https://github.com/kent8192/reinhardt-web/compare/reinhardt-formatter@v0.3.12...reinhardt-formatter@v0.3.13) - 2026-08-27

### Fixed

- *(formatter)* stabilize direct page capture indentation
</blockquote>

## `reinhardt-grpc-macros`

<blockquote>

## [0.3.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc-macros@v0.3.7...reinhardt-grpc-macros@v0.3.8) - 2026-08-16

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-grpc`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-grpc@v0.3.15...reinhardt-grpc@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-db-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-db-macros@v0.2.0...reinhardt-db-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-db-macros` for the Reinhardt 0.3.0 line. This
crate moves with the coordinated Reinhardt 0.3.0 release train.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- align crate release metadata with the Reinhardt 0.3.0 stable release train.
</blockquote>

## `reinhardt-dispatch`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-dispatch@v0.2.2...reinhardt-dispatch@v0.3.0) - 2026-06-28

Stable release of `reinhardt-dispatch` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Maintenance

- merge main into develop/0.3.0
</blockquote>

## `reinhardt-shortcuts`

<blockquote>

## [0.3.7](https://github.com/kent8192/reinhardt-web/compare/reinhardt-shortcuts@v0.3.6...reinhardt-shortcuts@v0.3.7) - 2026-08-12

### Fixed

- *(shortcuts)* serialize template context payload

### Testing

- *(shortcuts)* raise coverage to 80%
</blockquote>

## `reinhardt-i18n`

<blockquote>

## [0.3.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-i18n@v0.3.7...reinhardt-i18n@v0.3.8) - 2026-08-16

### Maintenance

- auto-fix fmt and clippy
- auto-fix fmt and clippy

### Testing

- *(i18n)* cover lazy loader and po parser
- *(i18n)* cover empty fallback locale
</blockquote>

## `reinhardt-graphql-macros`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql-macros@v0.2.0...reinhardt-graphql-macros@v0.3.0) - 2026-06-28

Stable release of `reinhardt-graphql-macros` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- feat!(di): introduce keyed injectable provider outputs
</blockquote>

## `reinhardt-graphql`

<blockquote>

## [0.3.9](https://github.com/kent8192/reinhardt-web/compare/reinhardt-graphql@v0.3.8...reinhardt-graphql@v0.3.9) - 2026-08-21

### Documentation

- *(security)* define UI and transport boundaries
- *(security)* qualify remaining raw boundaries

### Fixed

- *(security)* qualify boundary control ownership
- *(security)* qualify boundary control ownership
- *(security)* qualify boundary control ownership
</blockquote>

## `reinhardt-deeplink`

<blockquote>

## [0.3.0](https://github.com/kent8192/reinhardt-web/compare/reinhardt-deeplink@v0.2.0...reinhardt-deeplink@v0.3.0) - 2026-06-28

Stable release of `reinhardt-deeplink` for the Reinhardt 0.3.0 line. This
entry consolidates the 0.3.0 release-candidate series into one
stable release section.

### Migration Notes

- Review the root CHANGELOG and `instructions/MIGRATION_0.3.md` before upgrading from 0.2.x.

### Added

- *(urls)* [**breaking**] remove raw server route registration APIs
</blockquote>

## `reinhardt-providers`

<blockquote>

## [0.3.8](https://github.com/kent8192/reinhardt-web/compare/reinhardt-providers@v0.3.7...reinhardt-providers@v0.3.8) - 2026-08-16

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-storages`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-storages@v0.3.15...reinhardt-storages@v0.3.16) - 2026-09-02

### Maintenance

- update Cargo.toml dependencies
</blockquote>

## `reinhardt-web`

<blockquote>

## [0.3.16](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.3.15...reinhardt-web@v0.3.16) - 2026-09-02

### Testing

- *(urls)* enforce inactive WASM server routing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).