### PR TITLE
fix(macros): restore upload metadata in model form test fixtures

### DIFF
--- a/crates/reinhardt-core/macros/tests/ui/model/support.rs
+++ b/crates/reinhardt-core/macros/tests/ui/model/support.rs
@@ -309,6 +309,15 @@ pub mod model_form {
 		ForbiddenField { field: String },
 		InvalidValue { field: String, message: String },
 	}
+
+	/// Mirrors the upload metadata stored and cloned by generated cleaned payloads.
+	#[derive(Clone)]
+	pub struct ModelFormUpload {
+		pub name: &'static str,
+		pub filename: Option<String>,
+		pub content_type: Option<String>,
+		pub size: u64,
+	}
 }
 
 pub mod db {


### PR DESCRIPTION
## Summary

Restore `ModelFormUpload` in the standalone ModelForm macro fixture so generated cleaned payloads compile and clone their upload metadata.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

The shared fixture at `crates/reinhardt-core/macros/tests/ui/model/support.rs` aliases the test crate as `reinhardt_core`, but omitted the upload metadata type now referenced by generated cleaned payloads. This caused nine `E0425` errors in `model_form_codegen.rs` during [Cargo Check (tests) for #6263](https://github.com/kent8192/reinhardt-web/actions/runs/34037129418/job/101497195513).

Add the four metadata fields and `Clone` required by the generated contract. The fixture documentation explains this dependency. The repair targets `develop/0.4.0`, the release PR's source branch, so release-plz can include it when regenerating #6263.

## How Was This Tested?

The focused compilation reproduced all nine errors before the fix and passed afterward:

- `cargo check -p reinhardt-macros --all-features --test model_form_codegen --quiet`
- `CARGO_BUILD_JOBS=2 cargo test -p reinhardt-macros --all-features --test model_form_codegen --quiet` — 10 tests passed.
- `CARGO_BUILD_JOBS=2 cargo test -p reinhardt-macros --all-features --test ui test_model_macro_parity -- --test-threads=1` — 37 compile-fail cases and 18 pass cases succeeded.
- `CARGO_BUILD_JOBS=2 cargo check --workspace --all-features --tests --quiet` — passed.
- `CARGO_BUILD_JOBS=2 cargo make clippy-check` — passed with warnings denied.
- `CARGO_BUILD_JOBS=2 cargo make fmt-check` — passed.
- `git diff --check` — passed.

Workspace test compilation, Clippy, and formatting were verified again after updating the base to `555561fe8dba62dfb1921e5ef920d04cf3a44dc3`. The macro implementation and relevant tests did not change during that base update. Existing codegen and UI cases provide regression coverage; no new test functions were needed.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/kent8192/reinhardt-web/blob/develop/0.4.0/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](https://github.com/kent8192/reinhardt-web/blob/develop/0.4.0/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (fixture contract comment)
- [x] My changes generate no new warnings
- [x] Existing regression tests prove the fix is effective
- [x] Affected codegen and UI tests pass locally with my changes
- [x] Database backend testing is not applicable to this standalone fixture
- [x] I have verified formatting with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

Refs #6263.

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

### Scope Label

- [x] `forms` - Form handling, validation, rendering

---

🤖 Generated with [Codex](https://openai.com/codex/)
