### PR TITLE
fix(pages): render form field attributes and help text

### DIFF
--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -249,7 +249,8 @@ jobs:
             cargo test --target wasm32-unknown-unknown \
               --features testing \
               --test csrf_wasm_test --test server_fn_wasm_test \
-              --test client_launcher_navigation_test
+              --test client_launcher_navigation_test \
+              --test form_field_attributes
 
       - name: Run WASM observer-system tests (reinhardt-urls)
         working-directory: crates/reinhardt-urls

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -194,6 +194,22 @@ Typed native attributes are accepted for the controls that support them:
 | `multiple` | file-like inputs and multi-select |
 | `list` | datalist-compatible text-like inputs |
 
+Built-in fields render validation and display properties identically in SSR and
+WASM, including fields in groups and collections. `min_length` / `max_length`
+produce `minlength` / `maxlength` on text-like inputs and textareas; `pattern`
+applies to text-like inputs. `min_value` / `max_value` supply number/range bounds;
+an explicit native `min` or `max` takes precedence for that bound independently.
+`readonly` is emitted only for editable text, number, temporal, and textarea
+controls. False boolean flags are omitted. Field-level `disabled` also disables
+all generated radio choices; radio autofocus is assigned only to the first choice.
+
+`help_text` becomes escaped text in a `p.reinhardt-help` below the control (a
+`span.reinhardt-help` inside custom wrappers), linked through `aria-describedby`
+to `<control-id>--help`. Existing description references in `attrs` are retained.
+Collection descriptions use each indexed control ID;
+radio choices share a description ID based on the field name. Hidden inputs omit
+help text. Experimental custom widgets own their markup.
+
 `FieldGroup` renders as semantic `<fieldset>` output. When `label` is
 present, the label is rendered as a `<legend>` inside the fieldset.
 

--- a/crates/reinhardt-pages/macros/src/form/codegen.rs
+++ b/crates/reinhardt-pages/macros/src/form/codegen.rs
@@ -3951,14 +3951,15 @@ fn generate_collection_field_view(
 	let input_type = widget_to_input_type(&field.widget);
 	let label_text = field.display.label.as_deref().unwrap_or(&field_name_str);
 	let placeholder = field.display.placeholder.as_deref().unwrap_or("");
-	let required = field.validation.required;
 	let autocomplete_attr = field.display.autocomplete.as_deref().map(|val| {
 		quote! { .attr("autocomplete", #val) }
 	});
 	let wrapper_class = field.styling.wrapper_class();
 	let label_class = field.styling.label_class();
 	let input_class = field.styling.input_class();
-	let custom_attrs = generate_custom_attrs(&field.custom_attrs);
+	let field_id = quote! { __field_id };
+	let field_attrs = generate_field_attrs(field, &field_id, false);
+	let help_text = generate_field_help_text(field, &field_id);
 	let listener = generate_collection_bind_listener(field, pages_crate, collection_name);
 	let field_value = collection_field_value_expr(field);
 	let value_attr = if matches!(
@@ -3984,9 +3985,8 @@ fn generate_collection_field_view(
 					.attr("id", __field_id.clone())
 					.attr("class", #input_class)
 					.attr("placeholder", #placeholder)
-					.bool_attr("required", #required)
 					#autocomplete_attr
-					#custom_attrs
+					#field_attrs
 					#listener
 					.child(#field_value)
 			}
@@ -3998,10 +3998,9 @@ fn generate_collection_field_view(
 					.attr("name", __field_name.clone())
 					.attr("id", __field_id.clone())
 					.attr("class", #input_class)
-					.bool_attr("required", #required)
 					.bool_attr("multiple", #multiple)
 					#autocomplete_attr
-					#custom_attrs
+					#field_attrs
 					#listener
 			}
 		}
@@ -4013,9 +4012,8 @@ fn generate_collection_field_view(
 					.attr("id", __field_id.clone())
 					.attr("class", #input_class)
 					.attr("value", "true")
-					.bool_attr("required", #required)
 					#checked_attr
-					#custom_attrs
+					#field_attrs
 					#listener
 			}
 		}
@@ -4027,10 +4025,9 @@ fn generate_collection_field_view(
 					.attr("id", __field_id.clone())
 					.attr("class", #input_class)
 					.attr("placeholder", #placeholder)
-					.bool_attr("required", #required)
 					#value_attr
 					#autocomplete_attr
-					#custom_attrs
+					#field_attrs
 					#listener
 			}
 		}
@@ -4092,6 +4089,7 @@ fn generate_collection_field_view(
 					#wrapper_attrs
 					#label_element
 					.child(#input_element)
+					#help_text
 			}
 		}
 	}
@@ -4403,9 +4401,9 @@ fn generate_field_view(
 	let label_class = field.styling.label_class();
 	let input_class = field.styling.input_class();
 
-	// Generate custom attributes (aria-*, data-*)
-	let custom_attrs = generate_custom_attrs(&field.custom_attrs);
-	let native_attrs = generate_native_attrs(&field.native_attrs);
+	let field_id = quote! { #field_name_str };
+	let field_attrs = generate_field_attrs(field, &field_id, false);
+	let help_text = generate_field_help_text(field, &field_id);
 
 	// Generate event listener for two-way binding
 	let event_listener =
@@ -4480,10 +4478,8 @@ fn generate_field_view(
 					.attr("id", #field_name_str)
 					.attr("class", #input_class)
 					.attr("placeholder", #placeholder)
-						.bool_attr("required", #required)
 						#autocomplete_attr
-						#native_attrs
-						#custom_attrs
+						#field_attrs
 						#event_listener
 			}
 		}
@@ -4630,11 +4626,9 @@ fn generate_field_view(
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
 					.attr("class", #input_class)
-					.bool_attr("required", #required)
 					.bool_attr("multiple", #multiple)
 					#autocomplete_attr
-					#native_attrs
-					#custom_attrs
+					#field_attrs
 					#event_listener
 					#choice_children
 			}
@@ -4646,13 +4640,12 @@ fn generate_field_view(
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
 						.attr("class", #input_class)
-						.bool_attr("required", #required)
-						#native_attrs
-						#custom_attrs
+						#field_attrs
 						#event_listener
 			}
 		}
 		TypedWidget::RadioSelect if field.choices_config.is_some() => {
+			let field_attrs = generate_field_attrs(field, &field_id, true);
 			let choices_name =
 				syn::Ident::new(&format!("{}_choices", field.name), field.name.span());
 			let choice_items_name =
@@ -4715,11 +4708,8 @@ fn generate_field_view(
 											.attr("id", __choice_id)
 											.attr("value", choice_value.to_string())
 											.attr("class", #input_class)
-											.bool_attr("required", #required)
-											.bool_attr("disabled", choice.disabled)
 											#checked_attr
-											#native_attrs
-											#custom_attrs
+											#field_attrs
 											#event_listener
 									)
 									.child(choice.label)
@@ -4738,9 +4728,7 @@ fn generate_field_view(
 					.attr("name", #field_name_str)
 					.attr("id", #field_name_str)
 						.attr("class", #input_class)
-						.bool_attr("required", #required)
-						#native_attrs
-						#custom_attrs
+						#field_attrs
 						#event_listener
 			}
 		}
@@ -4753,10 +4741,8 @@ fn generate_field_view(
 					.attr("id", #field_name_str)
 					.attr("class", #input_class)
 						.attr("placeholder", #placeholder)
-						.bool_attr("required", #required)
 						#autocomplete_attr
-						#native_attrs
-						#custom_attrs
+						#field_attrs
 						#event_listener
 			}
 		}
@@ -4816,6 +4802,7 @@ fn generate_field_view(
 				#icon_left
 				.child(#input_element)
 				#icon_right
+				#help_text
 		}
 	}
 }
@@ -4919,18 +4906,152 @@ fn generate_icon_child_attrs(attrs: &[reinhardt_manouche::core::TypedIconAttr]) 
 	result
 }
 
-/// Generates custom attribute code (aria-*, data-*) for form field input elements.
+/// Lowers field metadata once for ordinary controls, radio choices, and collection items.
+fn generate_field_attrs(
+	field: &TypedFormFieldDef,
+	field_id: &TokenStream,
+	radio_choice: bool,
+) -> TokenStream {
+	let text_input = matches!(
+		field.widget,
+		TypedWidget::TextInput
+			| TypedWidget::SearchInput
+			| TypedWidget::TelInput
+			| TypedWidget::UrlInput
+			| TypedWidget::EmailInput
+			| TypedWidget::PasswordInput
+	);
+	let textarea = matches!(field.widget, TypedWidget::Textarea);
+	let numeric = matches!(
+		field.widget,
+		TypedWidget::NumberInput | TypedWidget::RangeInput
+	);
+	let readonly = field.display.readonly
+		&& (text_input
+			|| textarea
+			|| matches!(
+				field.widget,
+				TypedWidget::NumberInput
+					| TypedWidget::DateInput
+					| TypedWidget::MonthInput
+					| TypedWidget::WeekInput
+					| TypedWidget::TimeInput
+					| TypedWidget::DateTimeInput
+			));
+	let required = field.validation.required
+		&& !matches!(
+			field.widget,
+			TypedWidget::HiddenInput | TypedWidget::RangeInput | TypedWidget::ColorInput
+		);
+	let disabled = field.display.disabled;
+	let autofocus = field.display.autofocus && !matches!(field.widget, TypedWidget::HiddenInput);
+	let (disabled, autofocus) = if radio_choice {
+		// A radio field disables every choice but assigns autofocus only once.
+		(
+			quote! { #disabled || choice.disabled },
+			quote! { #autofocus && i == 0 },
+		)
+	} else {
+		(quote! { #disabled }, quote! { #autofocus })
+	};
+	let mut result = quote! {
+		.bool_attr("required", #required)
+		.bool_attr("disabled", #disabled)
+		.bool_attr("readonly", #readonly)
+		.bool_attr("autofocus", #autofocus)
+	};
+
+	if text_input || textarea {
+		for (name, value) in [
+			("minlength", field.validation.min_length),
+			("maxlength", field.validation.max_length),
+		] {
+			if let Some(value) = value {
+				let value = value.to_string();
+				result.extend(quote! { .attr(#name, #value) });
+			}
+		}
+	}
+	if text_input && let Some(pattern) = &field.validation.pattern {
+		result.extend(quote! { .attr("pattern", #pattern) });
+	}
+	if numeric {
+		// Explicit native bounds take precedence independently, without duplicate attributes.
+		for (name, legacy, native) in [
+			("min", field.validation.min_value, &field.native_attrs.min),
+			("max", field.validation.max_value, &field.native_attrs.max),
+		] {
+			if native.is_none()
+				&& let Some(value) = legacy
+			{
+				let value = value.to_string();
+				result.extend(quote! { .attr(#name, #value) });
+			}
+		}
+	}
+	result.extend(generate_native_attrs(&field.native_attrs));
+	let help_id = field
+		.display
+		.help_text
+		.as_ref()
+		.filter(|_| !matches!(field.widget, TypedWidget::HiddenInput))
+		.map(|_| quote! { ::std::format!("{}--help", #field_id) });
+	result.extend(generate_custom_attrs(&field.custom_attrs, help_id.as_ref()));
+	result
+}
+
+/// Renders help as escaped text with an ID derived from the corresponding control.
+fn generate_field_help_text(field: &TypedFormFieldDef, field_id: &TokenStream) -> TokenStream {
+	if matches!(
+		field.widget,
+		TypedWidget::HiddenInput | TypedWidget::CustomExperimental(_)
+	) {
+		return TokenStream::new();
+	}
+	// Custom wrappers may accept only phrasing content, such as a paragraph.
+	let help_tag = if field.wrapper.is_some() { "span" } else { "p" };
+	field
+		.display
+		.help_text
+		.as_ref()
+		.map(|text| {
+			quote! {
+				.child(
+					PageElement::new(#help_tag)
+						.attr("id", ::std::format!("{}--help", #field_id))
+						.attr("class", "reinhardt-help")
+						.child(#text)
+				)
+			}
+		})
+		.unwrap_or_default()
+}
+
+/// Generates custom attributes, retaining existing descriptions when adding help text.
 ///
 /// Converts underscores in attribute names to hyphens for HTML output.
 /// For example, `aria_label` becomes `aria-label`.
-fn generate_custom_attrs(attrs: &[TypedCustomAttr]) -> TokenStream {
+fn generate_custom_attrs(attrs: &[TypedCustomAttr], help_id: Option<&TokenStream>) -> TokenStream {
 	let mut result = TokenStream::new();
+	let mut has_description = false;
 	for attr in attrs {
 		let html_name = attr.html_name(); // Convert underscores to hyphens
 		let value = &attr.value;
+		if html_name == "aria-describedby"
+			&& let Some(help_id) = help_id
+		{
+			result.extend(quote! {
+				.attr(#html_name, ::std::format!("{} {}", #value, #help_id))
+			});
+			has_description = true;
+			continue;
+		}
 		result.extend(quote! {
 			.attr(#html_name, #value)
 		});
+	}
+	if !has_description && let Some(help_id) = help_id {
+		result.extend(quote! { .attr("aria-describedby", #help_id) });
 	}
 	result
 }
@@ -7579,7 +7700,7 @@ mod tests {
 		assert!(output_str.contains("let choice_value = choice . value"));
 		assert!(output_str.contains(". attr (\"type\" , \"radio\")"));
 		assert!(output_str.contains(". attr (\"value\" , choice_value . to_string ())"));
-		assert!(output_str.contains(". bool_attr (\"disabled\" , choice . disabled)"));
+		assert!(output_str.contains(". bool_attr (\"disabled\" , false || choice . disabled)"));
 		assert!(output_str.contains(". child (choice . label)"));
 		assert!(output_str.contains(". listener (\"change\""));
 	}

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -1082,6 +1082,24 @@ pub fn head(input: TokenStream) -> TokenStream {
 /// | `readonly` | flag/bool | `readonly` or `readonly: true` | Read-only input |
 /// | `autofocus` | flag/bool | `autofocus` or `autofocus: true` | Auto-focus on load |
 ///
+/// Built-in controls render these properties in both SSR and WASM, including
+/// fields inside groups and collections. False boolean flags are omitted.
+/// `min_length` and `max_length` become `minlength` and `maxlength` on text-like
+/// inputs and textareas; `pattern` applies only to text-like inputs. `readonly`
+/// applies to text-like, numeric, and temporal inputs and textareas, following
+/// native HTML semantics (not select, checkbox, radio, range, color, or file inputs).
+/// `min_value` and `max_value` become numeric input/range bounds. An explicit
+/// native `min` or `max` overrides the corresponding legacy bound independently.
+///
+/// `help_text` renders as escaped text in a `p.reinhardt-help` after the control,
+/// or a `span.reinhardt-help` inside a custom wrapper to preserve phrasing content.
+/// Its ID is the control ID followed by `--help`; `aria-describedby` combines this
+/// ID with any existing `attrs: { aria_describedby: "..." }` references. Hidden
+/// controls omit help text. Radio choices share a description ID based on the
+/// field name, respect both field-level and choice-level disabled flags, and apply
+/// autofocus only to the first choice. Custom widget adapters continue to own
+/// their rendered markup.
+///
 /// ### Data Properties
 ///
 /// | Property | Type | Syntax | Description |

--- a/crates/reinhardt-pages/tests/form_field_attributes.rs
+++ b/crates/reinhardt-pages/tests/form_field_attributes.rs
@@ -1,0 +1,681 @@
+//! Regression coverage for native form attributes and accessible help text.
+
+use reinhardt_pages::{Page, form, use_form};
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[cfg(target_arch = "wasm32")]
+const HELP: &str = "<strong>Use \"full\" name & details.</strong>";
+const ESCAPED_HELP: &str = "&lt;strong&gt;Use &quot;full&quot; name &amp; details.&lt;/strong&gt;";
+
+type AttributeExpectation<'a> = (&'a str, Option<&'a str>);
+type HelpExpectation<'a> = (&'a str, &'a str, Option<&'a str>);
+
+fn element_html<'a>(html: &'a str, id: &str) -> &'a str {
+	let position = html
+		.find(&format!(" id=\"{id}\""))
+		.unwrap_or_else(|| panic!("missing rendered element #{id}: {html}"));
+	&html[html[..position].rfind('<').expect("element opening tag")..]
+}
+
+fn attribute_values<'a>(tag: &'a str, name: &str) -> Vec<&'a str> {
+	tag.split(&format!(" {name}=\""))
+		.skip(1)
+		.map(|value| value.split_once('"').expect("attribute closing quote").0)
+		.collect()
+}
+
+fn assert_rendered_fields(
+	page: Page,
+	expected: &[(&str, &[AttributeExpectation<'_>])],
+	help_elements: &[HelpExpectation<'_>],
+) {
+	// Arrange: inspect the actual SSR serialization, including duplicate attributes.
+	let html = page.render_to_string();
+	for (id, attributes) in expected {
+		assert_eq!(html.matches(&format!(" id=\"{id}\"")).count(), 1);
+		let tag = element_html(&html, id).split_once('>').unwrap().0;
+		for (name, value) in *attributes {
+			assert_eq!(
+				attribute_values(tag, name),
+				value.iter().copied().collect::<Vec<_>>(),
+				"SSR #{id} {name}"
+			);
+		}
+	}
+	for (id, expected_tag, parent_id) in help_elements {
+		let (tag, contents) = element_html(&html, id).split_once('>').unwrap();
+		assert_eq!(tag[1..].split_whitespace().next(), Some(*expected_tag));
+		assert_eq!(attribute_values(tag, "class"), ["reinhardt-help"]);
+		assert_eq!(contents.split_once('<').unwrap().0, ESCAPED_HELP);
+		assert_eq!(html.matches(&format!(" id=\"{id}\"")).count(), 1);
+		if let Some(parent_id) = parent_id {
+			let parent = element_html(&html, parent_id);
+			let parent_tag = parent[1..].split_whitespace().next().unwrap();
+			let closing_tag = format!("</{parent_tag}>");
+			let parent_contents = parent.split_once(closing_tag.as_str()).unwrap().0;
+			assert_eq!(parent_contents.matches(&format!(" id=\"{id}\"")).count(), 1);
+		}
+	}
+
+	#[cfg(target_arch = "wasm32")]
+	{
+		use reinhardt_pages::portal::{PortalTarget, mount_portal};
+		use wasm_bindgen::JsValue;
+
+		// Act: the portal owns the mounted DOM and reactive subscriptions.
+		let _portal = mount_portal(PortalTarget::body(), page).expect("mount form");
+		let document = web_sys::window().unwrap().document().unwrap();
+		for (id, attributes) in expected {
+			let element = document.get_element_by_id(id).expect("mounted control");
+			for (name, value) in *attributes {
+				assert_eq!(
+					element.get_attribute(name).as_deref(),
+					*value,
+					"WASM #{id} {name}"
+				);
+				if matches!(*name, "disabled" | "readonly" | "required" | "autofocus") {
+					let property = if *name == "readonly" {
+						"readOnly"
+					} else {
+						name
+					};
+					let actual = js_sys::Reflect::get(&element, &JsValue::from_str(property))
+						.expect("native control property");
+					if let Some(actual) = actual.as_bool() {
+						assert_eq!(actual, value.is_some(), "WASM #{id} {property}");
+					}
+				}
+			}
+		}
+		for (id, expected_tag, parent_id) in help_elements {
+			let help = document.get_element_by_id(id).expect("mounted help text");
+			assert_eq!(help.tag_name(), expected_tag.to_ascii_uppercase());
+			assert_eq!(help.text_content().as_deref(), Some(HELP));
+			assert_eq!(help.child_element_count(), 0, "help must remain plain text");
+			assert_eq!(
+				help.get_attribute("class").as_deref(),
+				Some("reinhardt-help")
+			);
+			assert_eq!(
+				document
+					.query_selector_all(&format!("[id=\"{id}\"]"))
+					.unwrap()
+					.length(),
+				1
+			);
+			if let Some(parent_id) = parent_id {
+				assert_eq!(
+					help.parent_element(),
+					document.get_element_by_id(parent_id),
+					"help must stay inside its custom wrapper"
+				);
+			}
+		}
+	}
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn built_in_and_grouped_fields_preserve_applicable_metadata() {
+	// Arrange
+	let form = form! {
+		name: AttributeForm,
+		action: "/attributes",
+		fields: {
+			name: CharField {
+				label: "Name",
+				required,
+				min_length: 2,
+				max_length: 40,
+				pattern: "[A-Za-z ]+",
+				autofocus,
+				disabled: false,
+				readonly: false,
+				placeholder: "Full name",
+				autocomplete: "name",
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+				attrs: {
+					aria_describedby: "external-description",
+					data_testid: "name-control"
+				},
+			}
+			name_help: CharField {}
+			paragraph: CharField {
+				wrapper: p {
+					id: "paragraph-wrapper"
+				},
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+			}
+			bio: TextField {
+				required: true,
+				disabled: true,
+				readonly: true,
+				autofocus: false,
+				min_length: 3,
+				max_length: 120,
+				pattern: "[A-Z]+",
+				placeholder: "Biography",
+				autocomplete: "off",
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+			}
+			locked: CharField { disabled }
+			reference: CharField { readonly }
+			enabled: CharField {
+				required: false,
+				disabled: false,
+				readonly: false,
+				autofocus: false,
+				attrs: {
+					aria_describedby: "existing-description"
+				},
+			}
+			count: IntegerField {
+				min_value: 1,
+				max_value: 100,
+				readonly: true,
+				min_length: 2,
+				max_length: 3,
+				pattern: "[0-9]+",
+			}
+			min_override: IntegerField {
+				min_value: 1,
+				max_value: 10,
+				min: 3,
+				step: 2
+			}
+			max_override: FloatField {
+				min_value: 1,
+				max_value: 10,
+				max: 8,
+				step: "0.5"
+			}
+			range: IntegerField {
+				widget: RangeInput,
+				min_value: 1,
+				max_value: 10,
+				readonly
+			}
+			check: BooleanField {
+				required,
+				disabled,
+				readonly,
+				min_length: 2,
+				pattern: "true",
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+			}
+			radio: ChoiceField<i64> {
+				widget: RadioSelect,
+				required: true,
+				disabled: true,
+				readonly: true,
+				choices_from: "choices",
+				choice_value: "value",
+				choice_label: "label",
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+				attrs: {
+					aria_describedby: "radio-instructions"
+				},
+			}
+			select: ChoiceField<String> {
+				widget: Select,
+				required,
+				disabled,
+				readonly,
+				choices: [("a", "First"), ("b", "Second")],
+				autocomplete: "off",
+				help_text: "<strong>Use \"full\" name & details.</strong>",
+			}
+			multi: MultipleChoiceField<String> {
+				widget: SelectMultiple,
+				bind: false,
+				disabled: false,
+				readonly: true,
+				choices: [("a", "First"), ("b", "Second")],
+			}
+			avatar: FileField {
+				accept: "image/png",
+				capture: "environment",
+				disabled: true,
+				readonly: true
+			}
+			address: FieldGroup {
+				label: "Address",
+				fields: {
+					street: CharField {
+						min_length: 4,
+						max_length: 80,
+						readonly,
+						disabled: true,
+						help_text: "<strong>Use \"full\" name & details.</strong>",
+					}
+				}
+			}
+		}
+	};
+	form.radio_choices()
+		.set(vec![(1, "First".into()), (2, "Second".into())]);
+
+	// Act / Assert
+	assert_rendered_fields(
+		form.into_page(),
+		&[
+			(
+				"name",
+				&[
+					("minlength", Some("2")),
+					("maxlength", Some("40")),
+					("pattern", Some("[A-Za-z ]+")),
+					("autofocus", Some("autofocus")),
+					("required", Some("required")),
+					("disabled", None),
+					("readonly", None),
+					("placeholder", Some("Full name")),
+					("autocomplete", Some("name")),
+					("data-testid", Some("name-control")),
+					("aria-describedby", Some("external-description name--help")),
+				],
+			),
+			(
+				"name_help",
+				&[
+					("name", Some("name_help")),
+					("type", Some("text")),
+					("aria-describedby", None),
+				],
+			),
+			(
+				"paragraph",
+				&[("aria-describedby", Some("paragraph--help"))],
+			),
+			(
+				"bio",
+				&[
+					("minlength", Some("3")),
+					("maxlength", Some("120")),
+					("pattern", None),
+					("required", Some("required")),
+					("disabled", Some("disabled")),
+					("readonly", Some("readonly")),
+					("autofocus", None),
+					("placeholder", Some("Biography")),
+					("autocomplete", Some("off")),
+					("aria-describedby", Some("bio--help")),
+				],
+			),
+			(
+				"locked",
+				&[("disabled", Some("disabled")), ("aria-describedby", None)],
+			),
+			("reference", &[("readonly", Some("readonly"))]),
+			(
+				"enabled",
+				&[
+					("required", None),
+					("disabled", None),
+					("readonly", None),
+					("autofocus", None),
+					("aria-describedby", Some("existing-description")),
+				],
+			),
+			(
+				"count",
+				&[
+					("min", Some("1")),
+					("max", Some("100")),
+					("readonly", Some("readonly")),
+					("minlength", None),
+					("maxlength", None),
+					("pattern", None),
+				],
+			),
+			(
+				"min_override",
+				&[("min", Some("3")), ("max", Some("10")), ("step", Some("2"))],
+			),
+			(
+				"max_override",
+				&[
+					("min", Some("1")),
+					("max", Some("8")),
+					("step", Some("0.5")),
+				],
+			),
+			(
+				"range",
+				&[("min", Some("1")), ("max", Some("10")), ("readonly", None)],
+			),
+			(
+				"check",
+				&[
+					("required", Some("required")),
+					("disabled", Some("disabled")),
+					("readonly", None),
+					("minlength", None),
+					("pattern", None),
+					("aria-describedby", Some("check--help")),
+				],
+			),
+			(
+				"radio_0",
+				&[
+					("disabled", Some("disabled")),
+					("readonly", None),
+					("required", Some("required")),
+					("aria-describedby", Some("radio-instructions radio--help")),
+				],
+			),
+			(
+				"radio_1",
+				&[
+					("disabled", Some("disabled")),
+					("readonly", None),
+					("aria-describedby", Some("radio-instructions radio--help")),
+				],
+			),
+			(
+				"select",
+				&[
+					("required", Some("required")),
+					("disabled", Some("disabled")),
+					("readonly", None),
+					("autocomplete", Some("off")),
+					("aria-describedby", Some("select--help")),
+				],
+			),
+			(
+				"multi",
+				&[
+					("multiple", Some("multiple")),
+					("disabled", None),
+					("readonly", None),
+				],
+			),
+			(
+				"avatar",
+				&[
+					("accept", Some("image/png")),
+					("capture", Some("environment")),
+					("disabled", Some("disabled")),
+					("readonly", None),
+				],
+			),
+			(
+				"street",
+				&[
+					("minlength", Some("4")),
+					("maxlength", Some("80")),
+					("readonly", Some("readonly")),
+					("disabled", Some("disabled")),
+					("aria-describedby", Some("street--help")),
+				],
+			),
+		],
+		&[
+			("name--help", "p", None),
+			("paragraph--help", "span", Some("paragraph-wrapper")),
+			("bio--help", "p", None),
+			("check--help", "p", None),
+			("radio--help", "p", None),
+			("select--help", "p", None),
+			("street--help", "p", None),
+		],
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn dynamic_radio_autofocus_is_single_and_choice_disabled_is_preserved() {
+	#[cfg(target_arch = "wasm32")]
+	struct Choices {
+		items: Vec<Choice>,
+	}
+	#[cfg(target_arch = "wasm32")]
+	struct Choice {
+		value: i64,
+		label: String,
+		disabled: bool,
+	}
+	#[cfg(target_arch = "wasm32")]
+	async fn load_choices() -> Result<Choices, reinhardt_pages::ServerFnError> {
+		Ok(Choices {
+			items: vec![
+				Choice {
+					value: 1,
+					label: "First".into(),
+					disabled: false,
+				},
+				Choice {
+					value: 2,
+					label: "Second".into(),
+					disabled: true,
+				},
+			],
+		})
+	}
+
+	// Arrange
+	let form = form! {
+		name: RadioAutofocusForm,
+		action: "/radio-autofocus",
+		choices_loader: load_choices,
+		fields: {
+			focused: ChoiceField<i64> {
+				widget: RadioSelect,
+				autofocus: true,
+				disabled: false,
+				choices_from: "items",
+				choice_value: "value",
+				choice_label: "label",
+				choice_disabled: "disabled",
+			}
+		}
+	};
+	form.focused_choices()
+		.set(vec![(1, "First".into()), (2, "Second".into())]);
+
+	// Act: native SSR uses its supplied choices; the WASM loader adds choice metadata.
+	#[cfg(target_arch = "wasm32")]
+	form.load_choices().await.expect("load choice metadata");
+
+	// Assert
+	assert_rendered_fields(
+		form.into_page(),
+		&[
+			(
+				"focused_0",
+				&[("autofocus", Some("autofocus")), ("disabled", None)],
+			),
+			(
+				"focused_1",
+				&[
+					("autofocus", None),
+					(
+						"disabled",
+						cfg!(target_arch = "wasm32").then_some("disabled"),
+					),
+				],
+			),
+		],
+		&[],
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn collection_fields_preserve_metadata_and_indexed_help_links_after_reordering() {
+	// Arrange
+	let form = form! {
+		name: CollectionAttributeForm,
+		action: "/collection-attributes",
+		fields: {
+			items: FieldArray {
+				fields: {
+					name: CharField {
+						required: true,
+						min_length: 2,
+						max_length: 40,
+						pattern: "[A-Za-z ]+",
+						disabled: true,
+						readonly: true,
+						autofocus: false,
+						placeholder: "Item name",
+						autocomplete: "off",
+						help_text: "<strong>Use \"full\" name & details.</strong>",
+						attrs: {
+							aria_describedby: "collection-instructions",
+							data_testid: "item-name"
+						},
+					}
+					notes: TextField {
+						min_length: 3,
+						max_length: 120,
+						pattern: "[A-Z]+",
+						readonly,
+						disabled: false,
+						required: false,
+						help_text: "<strong>Use \"full\" name & details.</strong>",
+					}
+					quantity: IntegerField {
+						min_value: 1,
+						max_value: 10,
+						min: 3,
+						step: 2,
+						readonly
+					}
+					ratio: FloatField {
+						min_value: 1,
+						max_value: 10,
+						max: 8,
+						step: "0.5"
+					}
+					check: BooleanField {
+						disabled,
+						readonly
+					}
+					radio: ChoiceField<String> {
+						widget: RadioSelect,
+						disabled,
+						readonly
+					}
+					select: ChoiceField<String> {
+						widget: Select,
+						disabled,
+						readonly
+					}
+				}
+			}
+		}
+	};
+	let runtime = use_form(&form).build();
+	let collection = form.items_collection();
+	let mut first = form.new_items_item();
+	first.name = "First".into();
+	let mut second = form.new_items_item();
+	second.name = "Second".into();
+	runtime.push_item(collection, first);
+	let second_key = runtime.push_item(collection, second);
+
+	// Act: reordering must keep each description associated with the rendered index.
+	assert_eq!(runtime.move_item(collection, second_key, 0), Some((1, 0)));
+
+	// Assert
+	assert_rendered_fields(
+		form.into_page(),
+		&[
+			(
+				"items_0_name",
+				&[
+					("name", Some("items[0][name]")),
+					("value", Some("Second")),
+					("minlength", Some("2")),
+					("maxlength", Some("40")),
+					("pattern", Some("[A-Za-z ]+")),
+					("required", Some("required")),
+					("disabled", Some("disabled")),
+					("readonly", Some("readonly")),
+					("autofocus", None),
+					("placeholder", Some("Item name")),
+					("autocomplete", Some("off")),
+					("data-testid", Some("item-name")),
+					(
+						"aria-describedby",
+						Some("collection-instructions items_0_name--help"),
+					),
+				],
+			),
+			(
+				"items_1_name",
+				&[
+					("name", Some("items[1][name]")),
+					("value", Some("First")),
+					("minlength", Some("2")),
+					("disabled", Some("disabled")),
+					(
+						"aria-describedby",
+						Some("collection-instructions items_1_name--help"),
+					),
+				],
+			),
+			(
+				"items_0_notes",
+				&[
+					("minlength", Some("3")),
+					("maxlength", Some("120")),
+					("pattern", None),
+					("readonly", Some("readonly")),
+					("disabled", None),
+					("required", None),
+					("aria-describedby", Some("items_0_notes--help")),
+				],
+			),
+			(
+				"items_0_quantity",
+				&[
+					("min", Some("3")),
+					("max", Some("10")),
+					("step", Some("2")),
+					("readonly", Some("readonly")),
+				],
+			),
+			(
+				"items_0_ratio",
+				&[
+					("min", Some("1")),
+					("max", Some("8")),
+					("step", Some("0.5")),
+				],
+			),
+			(
+				"items_0_check",
+				&[
+					("type", Some("checkbox")),
+					("disabled", Some("disabled")),
+					("readonly", None),
+				],
+			),
+			(
+				"items_0_radio",
+				&[
+					("type", Some("radio")),
+					("disabled", Some("disabled")),
+					("readonly", None),
+				],
+			),
+			(
+				"items_0_select",
+				&[("disabled", Some("disabled")), ("readonly", None)],
+			),
+		],
+		&[
+			("items_0_name--help", "p", None),
+			("items_1_name--help", "p", None),
+			("items_0_notes--help", "p", None),
+			("items_1_notes--help", "p", None),
+		],
+	);
+}


### PR DESCRIPTION
## Summary

Accepted `form!` validation and display properties were missing from generated HTML, leaving disabled/read-only fields editable and native validation and help text absent. The shared rendering path now emits the applicable attributes and escaped, accessible helper content for ordinary, grouped, radio-choice, and collection controls.

- Preserve explicit native numeric bounds independently for each side, existing custom descriptions, and unrelated native attributes.
- Respect field-level and choice-level radio disabled flags; assign radio autofocus only to the first choice.
- Use `--help` IDs to avoid sibling field-name collisions and span helpers inside custom wrappers to keep paragraph markup valid.
- Add native/WASM regressions, include the target in the existing WASM CI job, and document the rendering contract.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Typed field metadata already contained the accepted properties, but ordinary and collection renderers did not consume them. Sharing the lowering code fixes both paths while preserving native widget applicability and avoiding duplicate attributes in SSR and WASM.

Fixes #6269

The main-branch base does not contain a model-backed `form!` renderer. The develop model override path uses separate metadata; this PR does not claim model-form coverage.

## How Was This Tested?

- `cargo test -p reinhardt-pages-macros`: 338 unit tests passed; 1 doctest passed and 78 existing examples ignored.
- `cargo test -p reinhardt-pages --test form_field_attributes`: 3 native tests passed.
- `cargo test -p reinhardt-pages --target wasm32-unknown-unknown --features testing --test form_field_attributes`: 3 browser WASM tests passed using wasm-bindgen-test-runner 0.2.128 and ChromeDriver 152.
- `cargo clippy -p reinhardt-pages-macros --all-targets -- -D warnings` and `cargo clippy -p reinhardt-pages --test form_field_attributes -- -D warnings`: passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p reinhardt-pages-macros`: passed.
- Repository formatter `fmt-all --check`: 3,006 unchanged, 2 DSL files temporarily preformatted, 0 errors.
- `actionlint .github/workflows/wasm-check.yml` and `git diff --check`: passed.
- Fresh Chrome 152 WASM fixture: 23 checks at 1280×1024 and 23 at 390×844, all passed. Real keyboard edits exercised pattern/length/range validity, maximum-length truncation, disabled/read-only interaction, and initial autofocus. Mounted DOM and parsing serialized HTML verified helper escaping, description links, unique IDs, and custom paragraph containment. No runtime/network errors or clipping/overlapping field wrappers were recorded.

The browser-fetched WASM matched the freshly built bundle. Validation covers the changed macro/rendering paths; full-workspace build/test/Clippy and remote CI completion are not claimed.

## Screenshots

### Before

The reproduction in #6269 shows the missing validation/display attributes and helper content.

### After

Desktop and narrow captures were inspected for helper visibility, native disabled appearance, and layout. They are retained with the local verification record and are not attached to this PR.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings in the focused checks above
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests in the affected macro and regression targets pass locally
- [x] I have tested with all affected database backends (not applicable)
- [x] I have formatted the code with the repository formatter and passed `fmt-all --check`
- [ ] I have checked the code with `cargo make clippy-check` (focused Clippy commands passed instead)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6269
- #6268, #6270, and #6271 cover separate value/reset binding, RadioInput parsing, and radio-group naming repairs.

## Labels to Apply

### Type Label

- [x] `bug` - Bug fix

### Scope Labels

- [x] `forms` - Form handling, validation, rendering
- [x] `pages` - Pages rendering
- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

No dependencies or public Rust APIs were changed. Experimental custom widgets retain ownership of their markup.

🤖 Generated with [Codex](https://openai.com/codex)
