### PR TITLE
fix: restore reactive controls and regression checks on develop

### DIFF
--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -102,6 +102,7 @@ nix = { version = "0.29", features = ["signal"] }
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects"] }
 
 [dev-dependencies]
+reinhardt-test = { path = "../reinhardt-test", default-features = false }
 insta = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 regex = { workspace = true }

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -1141,6 +1141,19 @@ reinhardt-admin startproject myproject
 
 **Precedence:** `--template` > `--template-dir` CLI flag > `REINHARDT_TEMPLATE_DIR` env > embedded defaults.
 
+## Testing
+
+Run the admin script regression suites with the default parallel test runner:
+
+```bash
+cargo test -p reinhardt-commands --test admin_scripts_tests --test admin_scripts_additional_tests
+```
+
+Tests that change the process working directory share the `current_dir` serial
+group. Their fixture restores the original directory before removing temporary
+files, including during unwinding. Environment-variable tests share the
+`reinhardt_settings` group and restore the previous values on scope exit.
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -1149,10 +1149,12 @@ Run the admin script regression suites with the default parallel test runner:
 cargo test -p reinhardt-commands --test admin_scripts_tests --test admin_scripts_additional_tests
 ```
 
-Tests that change the process working directory share the `current_dir` serial
-group. Their fixture restores the original directory before removing temporary
-files, including during unwinding. Environment-variable tests share the
-`reinhardt_settings` group and restore the previous values on scope exit.
+Admin script tests receive `rstest` fixtures composed from `reinhardt-test`'s
+`temp_dir`, `TestResource`, and `TeardownGuard` helpers. Tests that change the
+process working directory share the `current_dir` serial group; their fixture
+restores the original directory before removing temporary files, including during
+unwinding. Environment-variable fixtures share the `reinhardt_settings` group and
+restore previous values on scope exit, preserving non-Unicode values as well.
 
 ## License
 

--- a/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
@@ -3,9 +3,14 @@
 //! Continuation of comprehensive test suite for reinhardt-admin
 //! This file contains the remaining test cases from Django's admin_scripts tests
 
+#[path = "support/environment.rs"]
+mod environment;
+
+use environment::EnvVarGuard;
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartProjectCommand,
 };
+use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -46,7 +51,6 @@ impl TestEnvironment {
 #[tokio::test]
 async fn test_manage_multiple_builtin_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "pub const DEBUG: bool = true;\n");
 	env.create_file("settings2.rs", "pub const DEBUG: bool = false;\n");
@@ -58,7 +62,6 @@ async fn test_manage_multiple_builtin_command() {
 #[tokio::test]
 async fn test_manage_multiple_builtin_with_settings() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "// Settings 1\n");
 	env.create_file("settings2.rs", "// Settings 2\n");
@@ -68,21 +71,37 @@ async fn test_manage_multiple_builtin_with_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "settings1");
+	// Arrange
+	let original = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+	{
+		let mut env_guard = EnvVarGuard::new();
+		env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
+
+		// Act
+		let result = std::panic::catch_unwind(|| {
+			let mut nested_guard = EnvVarGuard::new();
+			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
+			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
+			panic!("exercise environment restoration during unwinding");
+		});
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
+			"settings1"
+		);
 	}
-	assert_eq!(
-		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
-		"settings1"
-	);
+	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), original);
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_bad_settings() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "bad_settings");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad_settings");
 	assert_eq!(
 		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
 		"bad_settings"
@@ -90,32 +109,30 @@ async fn test_manage_multiple_builtin_with_bad_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_bad_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 	assert_eq!(std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(), "");
 }
 
 #[tokio::test]
 async fn test_manage_multiple_custom_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 	assert!(env.path().exists());
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_custom_command_with_settings() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "pub const DB: &str = \"db1\";\n");
 	env.create_file("settings2.rs", "pub const DB: &str = \"db2\";\n");
 
 	// Test with explicit settings parameter
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "settings1");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
 
 	assert!(env.file_exists("settings1.rs"));
 	assert!(env.file_exists("settings2.rs"));
@@ -126,11 +143,11 @@ async fn test_manage_multiple_custom_command_with_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_custom_command_with_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "custom.settings");
-		std::env::set_var("CUSTOM_ENV_VAR", "test_value");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "custom.settings");
+	env_guard.set("CUSTOM_ENV_VAR", "test_value");
 
 	// Test that environment variables are respected
 	assert_eq!(
@@ -147,7 +164,6 @@ async fn test_manage_multiple_custom_command_with_environment() {
 #[tokio::test]
 async fn test_manage_check_broken_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create broken app structure
 	env.create_file("apps/broken/mod.rs", "// Broken syntax");
@@ -157,7 +173,6 @@ async fn test_manage_check_broken_app() {
 #[tokio::test]
 async fn test_manage_check_complex_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -177,7 +192,6 @@ async fn test_manage_check_complex_app() {
 #[tokio::test]
 async fn test_manage_check_app_with_import() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -194,7 +208,6 @@ async fn test_manage_check_app_with_import() {
 #[tokio::test]
 async fn test_manage_check_warning_does_not_halt() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -229,7 +242,6 @@ async fn test_manage_runserver_zero_ip_addr() {
 #[tokio::test]
 async fn test_manage_runserver_on_bind() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -294,7 +306,6 @@ async fn test_manage_runserver_runner_ambiguous() {
 #[tokio::test]
 async fn test_manage_runserver_no_database() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -308,7 +319,6 @@ async fn test_manage_runserver_no_database() {
 #[tokio::test]
 async fn test_manage_runserver_readonly_database() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -340,7 +350,6 @@ async fn test_manage_runserver_custom_system_checks() {
 #[tokio::test]
 async fn test_manage_runserver_migration_warning_one_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -355,7 +364,6 @@ async fn test_manage_runserver_migration_warning_one_app() {
 #[tokio::test]
 async fn test_manage_runserver_migration_warning_multiple_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -370,10 +378,10 @@ async fn test_manage_runserver_migration_warning_multiple_apps() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_runserver_empty_allowed_hosts_error() {
-	unsafe {
-		std::env::set_var("ALLOWED_HOSTS", "");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("ALLOWED_HOSTS", "");
 
 	// Empty ALLOWED_HOSTS in production should error
 	assert_eq!(std::env::var("ALLOWED_HOSTS").unwrap(), "");
@@ -604,7 +612,6 @@ async fn test_commandtypes_base_command_no_label() {
 #[tokio::test]
 async fn test_commandtypes_app_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create app structure
 	env.create_file("apps/testapp/mod.rs", "// Test app\n");
@@ -614,7 +621,6 @@ async fn test_commandtypes_app_command() {
 #[tokio::test]
 async fn test_commandtypes_app_command_no_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test app command with no apps
 	assert!(env.path().exists());
@@ -623,7 +629,6 @@ async fn test_commandtypes_app_command_no_apps() {
 #[tokio::test]
 async fn test_commandtypes_app_command_multiple_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("apps/app1/mod.rs", "// App 1\n");
 	env.create_file("apps/app2/mod.rs", "// App 2\n");
@@ -639,7 +644,6 @@ async fn test_commandtypes_app_command_multiple_apps() {
 #[tokio::test]
 async fn test_discovery_precedence() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test command discovery precedence
 	env.create_file("commands/custom.rs", "// Custom command\n");
@@ -684,7 +688,6 @@ async fn test_argumentorder_setting_then_option() {
 #[tokio::test]
 async fn test_diffsettings_basic() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings.rs", "pub const DEBUG: bool = true;\n");
 	// Test basic diff settings
@@ -694,7 +697,6 @@ async fn test_diffsettings_basic() {
 #[tokio::test]
 async fn test_diffsettings_settings_configured() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"settings.rs",
@@ -711,7 +713,6 @@ async fn test_diffsettings_settings_configured() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_non_python_files_not_formatted() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test that non-Rust files are not template-formatted
 	assert!(env.path().exists());
@@ -720,9 +721,14 @@ async fn test_startproject_custom_project_template_non_python_files_not_formatte
 #[tokio::test]
 async fn test_startproject_template_dir_with_trailing_slash() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
-	let mut ctx = CommandContext::new(vec!["testproject".to_string()]);
+	let mut ctx = CommandContext::new(vec![
+		"testproject".to_owned(),
+		env.path()
+			.join("testproject")
+			.to_string_lossy()
+			.into_owned(),
+	]);
 	ctx.set_option("template".to_string(), "/path/to/template/".to_string());
 
 	let cmd = StartProjectCommand;
@@ -750,7 +756,6 @@ async fn test_startproject_template_dir_with_trailing_slash() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_with_non_ascii_templates() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test with non-ASCII template content
 	assert!(env.path().exists());
@@ -759,7 +764,6 @@ async fn test_startproject_custom_project_template_with_non_ascii_templates() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_hidden_directory_default_excluded() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test that hidden directories are excluded by default
 	assert!(env.path().exists());
@@ -768,7 +772,6 @@ async fn test_startproject_custom_project_template_hidden_directory_default_excl
 #[tokio::test]
 async fn test_startproject_custom_project_template_hidden_directory_included() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test including hidden directories
 	assert!(env.path().exists());
@@ -777,7 +780,6 @@ async fn test_startproject_custom_project_template_hidden_directory_included() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_exclude_directory() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test excluding specific directories
 	assert!(env.path().exists());
@@ -786,7 +788,6 @@ async fn test_startproject_custom_project_template_exclude_directory() {
 #[tokio::test]
 async fn test_startproject_failure_to_format_code() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test handling of code formatting failures
 	assert!(env.path().exists());

--- a/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
@@ -6,10 +6,13 @@
 #[path = "support/environment.rs"]
 mod environment;
 
-use environment::EnvVarGuard;
+use environment::{EnvVars, env_vars};
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartProjectCommand,
 };
+use reinhardt_test::TeardownGuard;
+use reinhardt_test::fixtures::temp_dir;
+use rstest::{fixture, rstest};
 use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
@@ -20,13 +23,12 @@ struct TestEnvironment {
 	temp_dir: TempDir,
 }
 
-impl TestEnvironment {
-	fn new() -> Self {
-		Self {
-			temp_dir: TempDir::new().expect("Failed to create temp directory"),
-		}
-	}
+#[fixture]
+fn test_env(temp_dir: TempDir) -> TestEnvironment {
+	TestEnvironment { temp_dir }
+}
 
+impl TestEnvironment {
 	fn path(&self) -> PathBuf {
 		self.temp_dir.path().to_path_buf()
 	}
@@ -48,10 +50,9 @@ impl TestEnvironment {
 // ManageMultipleSettings Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_builtin_command() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_builtin_command(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings1.rs", "pub const DEBUG: bool = true;\n");
 	env.create_file("settings2.rs", "pub const DEBUG: bool = false;\n");
 
@@ -59,10 +60,9 @@ async fn test_manage_multiple_builtin_command() {
 	assert!(env.file_exists("settings2.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_builtin_with_settings() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_builtin_with_settings(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings1.rs", "// Settings 1\n");
 	env.create_file("settings2.rs", "// Settings 2\n");
 
@@ -70,37 +70,51 @@ async fn test_manage_multiple_builtin_with_settings() {
 	assert!(env.file_exists("settings2.rs"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_environment() {
+async fn test_manage_multiple_builtin_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+	#[from(env_vars)] mut nested_guard: TeardownGuard<EnvVars>,
+) {
 	// Arrange
 	let original = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
+	assert_eq!(
+		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
+		"settings1"
+	);
+
+	#[cfg(unix)]
 	{
-		let mut env_guard = EnvVarGuard::new();
-		env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
-
-		// Act
-		let result = std::panic::catch_unwind(|| {
-			let mut nested_guard = EnvVarGuard::new();
-			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
-			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
-			panic!("exercise environment restoration during unwinding");
-		});
-
-		// Assert
-		assert!(result.is_err());
-		assert_eq!(
-			std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
-			"settings1"
+		use std::os::unix::ffi::OsStringExt;
+		env_guard.set(
+			"REINHARDT_SETTINGS_MODULE",
+			std::ffi::OsString::from_vec(vec![b's', 0xff]),
 		);
 	}
+	let before_unwind = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+
+	// Act
+	let result = std::panic::catch_unwind(move || {
+		nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
+		nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
+		panic!("exercise environment restoration during unwinding");
+	});
+
+	// Assert
+	assert!(result.is_err());
+	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), before_unwind);
+	drop(env_guard);
 	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), original);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_bad_settings() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_builtin_with_bad_settings(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad_settings");
 	assert_eq!(
 		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
@@ -108,30 +122,33 @@ async fn test_manage_multiple_builtin_with_bad_settings() {
 	);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_bad_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 	assert_eq!(std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(), "");
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_custom_command() {
-	let env = TestEnvironment::new();
+async fn test_manage_multiple_custom_command(#[from(test_env)] env: TestEnvironment) {
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_custom_command_with_settings() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_custom_command_with_settings(
+	#[from(test_env)] env: TestEnvironment,
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env.create_file("settings1.rs", "pub const DB: &str = \"db1\";\n");
 	env.create_file("settings2.rs", "pub const DB: &str = \"db2\";\n");
 
 	// Test with explicit settings parameter
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
 
 	assert!(env.file_exists("settings1.rs"));
@@ -142,10 +159,12 @@ async fn test_manage_multiple_custom_command_with_settings() {
 	);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_custom_command_with_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_custom_command_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "custom.settings");
 	env_guard.set("CUSTOM_ENV_VAR", "test_value");
 
@@ -161,19 +180,17 @@ async fn test_manage_multiple_custom_command_with_environment() {
 // ManageCheck Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_broken_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_broken_app(#[from(test_env)] env: TestEnvironment) {
 	// Create broken app structure
 	env.create_file("apps/broken/mod.rs", "// Broken syntax");
 	assert!(env.file_exists("apps/broken/mod.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_complex_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_complex_app(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -189,10 +206,9 @@ async fn test_manage_check_complex_app() {
 	// Complex app structure for testing check command
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_app_with_import() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_app_with_import(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -205,10 +221,9 @@ async fn test_manage_check_app_with_import() {
 	// App with import issues for testing check command
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_warning_does_not_halt() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_warning_does_not_halt(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -239,10 +254,9 @@ async fn test_manage_runserver_zero_ip_addr() {
 	assert_eq!(ctx.arg(0), Some(&"0.0.0.0:8000".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_on_bind() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_on_bind(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -303,10 +317,9 @@ async fn test_manage_runserver_runner_ambiguous() {
 	assert_eq!(ctx.arg(0), Some(&"8000".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_no_database() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_no_database(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -316,10 +329,9 @@ async fn test_manage_runserver_no_database() {
 	assert!(env.file_exists("Cargo.toml"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_readonly_database() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_readonly_database(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -347,10 +359,9 @@ async fn test_manage_runserver_custom_system_checks() {
 	assert_eq!(ctx.option("check"), Some(&"custom.checks".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_migration_warning_one_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_migration_warning_one_app(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -361,10 +372,11 @@ async fn test_manage_runserver_migration_warning_one_app() {
 	assert!(env.file_exists("apps/myapp/migrations/001_initial.sql"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_migration_warning_multiple_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_migration_warning_multiple_apps(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -377,10 +389,12 @@ async fn test_manage_runserver_migration_warning_multiple_apps() {
 	assert!(env.file_exists("apps/app2/migrations/001.sql"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_runserver_empty_allowed_hosts_error() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_runserver_empty_allowed_hosts_error(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("ALLOWED_HOSTS", "");
 
 	// Empty ALLOWED_HOSTS in production should error
@@ -609,27 +623,24 @@ async fn test_commandtypes_base_command_no_label() {
 // CommandTypes Tests - App Commands
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command(#[from(test_env)] env: TestEnvironment) {
 	// Create app structure
 	env.create_file("apps/testapp/mod.rs", "// Test app\n");
 	assert!(env.file_exists("apps/testapp/mod.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command_no_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command_no_apps(#[from(test_env)] env: TestEnvironment) {
 	// Test app command with no apps
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command_multiple_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command_multiple_apps(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("apps/app1/mod.rs", "// App 1\n");
 	env.create_file("apps/app2/mod.rs", "// App 2\n");
 
@@ -641,10 +652,9 @@ async fn test_commandtypes_app_command_multiple_apps() {
 // Discovery Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_discovery_precedence() {
-	let env = TestEnvironment::new();
-
+async fn test_discovery_precedence(#[from(test_env)] env: TestEnvironment) {
 	// Test command discovery precedence
 	env.create_file("commands/custom.rs", "// Custom command\n");
 	assert!(env.file_exists("commands/custom.rs"));
@@ -685,19 +695,17 @@ async fn test_argumentorder_setting_then_option() {
 // DiffSettings Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_diffsettings_basic() {
-	let env = TestEnvironment::new();
-
+async fn test_diffsettings_basic(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings.rs", "pub const DEBUG: bool = true;\n");
 	// Test basic diff settings
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_diffsettings_settings_configured() {
-	let env = TestEnvironment::new();
-
+async fn test_diffsettings_settings_configured(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"settings.rs",
 		"pub const DEBUG: bool = true;\npub const SECRET_KEY: &str = \"test\";\n",
@@ -710,18 +718,20 @@ async fn test_diffsettings_settings_configured() {
 // Additional StartProject Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_non_python_files_not_formatted() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_non_python_files_not_formatted(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test that non-Rust files are not template-formatted
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_template_dir_with_trailing_slash() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_template_dir_with_trailing_slash(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	let mut ctx = CommandContext::new(vec![
 		"testproject".to_owned(),
 		env.path()
@@ -753,42 +763,45 @@ async fn test_startproject_template_dir_with_trailing_slash() {
 // Removed empty test: test_startproject_project_template_tarball_url
 // This test was empty and will be implemented when needed
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_with_non_ascii_templates() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_with_non_ascii_templates(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test with non-ASCII template content
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_hidden_directory_default_excluded() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_hidden_directory_default_excluded(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test that hidden directories are excluded by default
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_hidden_directory_included() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_hidden_directory_included(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test including hidden directories
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_exclude_directory() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_exclude_directory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test excluding specific directories
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_failure_to_format_code() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_failure_to_format_code(#[from(test_env)] env: TestEnvironment) {
 	// Test handling of code formatting failures
 	assert!(env.path().exists());
 }

--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -5,6 +5,10 @@
 //!
 //! Reference: <https://github.com/django/django/blob/main/tests/admin_scripts/tests.py>
 
+#[path = "support/environment.rs"]
+mod environment;
+
+use environment::EnvVarGuard;
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartAppCommand, StartProjectCommand,
 };
@@ -15,12 +19,9 @@ use tempfile::TempDir;
 
 /// Helper struct for setting up test environments
 struct TestEnvironment {
+	// Restore the working directory before the temporary directory is removed.
+	_cwd: CurrentDirGuard,
 	temp_dir: TempDir,
-}
-
-/// RAII guard for environment variables - automatically cleans up on drop
-struct EnvVarGuard {
-	vars: Vec<String>,
 }
 
 struct CurrentDirGuard {
@@ -41,32 +42,12 @@ impl Drop for CurrentDirGuard {
 	}
 }
 
-impl EnvVarGuard {
-	fn new() -> Self {
-		Self { vars: Vec::new() }
-	}
-
-	fn set(&mut self, key: &str, value: &str) {
-		unsafe {
-			std::env::set_var(key, value);
-		}
-		self.vars.push(key.to_string());
-	}
-}
-
-impl Drop for EnvVarGuard {
-	fn drop(&mut self) {
-		for key in &self.vars {
-			unsafe {
-				std::env::remove_var(key);
-			}
-		}
-	}
-}
-
 impl TestEnvironment {
 	fn new() -> Self {
 		Self {
+			_cwd: CurrentDirGuard {
+				original: std::env::current_dir().expect("read current directory"),
+			},
 			temp_dir: TempDir::new().expect("Failed to create temp directory"),
 		}
 	}
@@ -96,7 +77,7 @@ impl TestEnvironment {
 // StartProject Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_creates_project_structure() {
 	let env = TestEnvironment::new();
@@ -117,7 +98,7 @@ async fn test_startproject_creates_project_structure() {
 	assert!(env.file_exists(&format!("{}/src/bin/manage.rs", project_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_with_custom_directory() {
 	let env = TestEnvironment::new();
@@ -136,7 +117,7 @@ async fn test_startproject_with_custom_directory() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", custom_dir)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_missing_name() {
 	let ctx = CommandContext::new(vec![]);
@@ -152,7 +133,7 @@ async fn test_startproject_missing_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_mtv_style() {
 	let env = TestEnvironment::new();
@@ -171,7 +152,7 @@ async fn test_startproject_mtv_style() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", project_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_restful_style() {
 	let env = TestEnvironment::new();
@@ -190,7 +171,7 @@ async fn test_startproject_restful_style() {
 }
 
 // Translation of Django's StartProject tests
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_wrong_args() {
 	// Test wrong number of arguments
@@ -200,19 +181,31 @@ async fn test_startproject_wrong_args() {
 	assert!(result.is_err());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_simple_project() {
-	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
+	// Arrange
+	let original_dir = std::env::current_dir().expect("read current directory");
 
-	let ctx = CommandContext::new(vec!["testproject".to_string()]);
-	let cmd = StartProjectCommand;
-	let result = cmd.execute(&ctx).await;
-	assert!(result.is_ok());
+	// Act
+	{
+		let env = TestEnvironment::new();
+		std::env::set_current_dir(env.path()).expect("Failed to change directory");
+
+		let ctx = CommandContext::new(vec!["testproject".to_string()]);
+		let cmd = StartProjectCommand;
+		let result = cmd.execute(&ctx).await;
+		assert!(result.is_ok());
+	}
+
+	// Assert
+	assert_eq!(
+		std::env::current_dir().expect("read restored current directory"),
+		original_dir
+	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_importable_project_name() {
 	// Test that reserved keywords fail
@@ -228,7 +221,7 @@ async fn test_startproject_importable_project_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_command_does_not_import() {
 	// Verify command doesn't import project code
@@ -241,7 +234,7 @@ async fn test_startproject_command_does_not_import() {
 	assert!(result.is_ok());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_simple_project_different_directory() {
 	let env = TestEnvironment::new();
@@ -253,7 +246,7 @@ async fn test_startproject_simple_project_different_directory() {
 	assert!(result.is_ok());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_template() {
 	// Test with custom template path
@@ -267,7 +260,7 @@ async fn test_startproject_custom_project_template() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_file_without_extension() {
 	let env = TestEnvironment::new();
@@ -300,7 +293,7 @@ async fn test_startproject_file_without_extension() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_template_context_variables() {
 	let env = TestEnvironment::new();
@@ -331,7 +324,7 @@ async fn test_startproject_custom_project_template_context_variables() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_no_escaping_of_project_variables() {
 	let env = TestEnvironment::new();
@@ -362,7 +355,7 @@ async fn test_startproject_no_escaping_of_project_variables() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_destination_missing() {
 	let env = TestEnvironment::new();
@@ -399,7 +392,7 @@ async fn test_startproject_custom_project_destination_missing() {
 	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_honor_umask() {
 	#[cfg(unix)]
@@ -432,7 +425,7 @@ async fn test_startproject_honor_umask() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_overlay_preserves_unrelated_existing_files() {
 	// Arrange
@@ -461,7 +454,7 @@ async fn startproject_overlay_preserves_unrelated_existing_files() {
 	assert!(destination.join("Cargo.toml").is_file());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_rejects_file_destinations_without_mutating_them() {
 	// Arrange
@@ -483,7 +476,7 @@ async fn startproject_rejects_file_destinations_without_mutating_them() {
 	assert!(!env.file_exists("destination/Cargo.toml"));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it() {
 	// Arrange
@@ -512,7 +505,7 @@ async fn startproject_rejects_destinations_below_a_regular_file_without_mutating
 // StartApp Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_creates_app_structure() {
 	let env = TestEnvironment::new();
@@ -538,7 +531,7 @@ async fn test_startapp_creates_app_structure() {
 	assert!(env.file_exists(&format!("src/apps/{}/services.rs", app_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_with_custom_directory() {
 	let env = TestEnvironment::new();
@@ -562,7 +555,7 @@ async fn test_startapp_with_custom_directory() {
 	assert!(env.file_exists(&format!("{}/lib.rs", custom_dir)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_missing_name() {
 	let ctx = CommandContext::new(vec![]);
@@ -578,7 +571,7 @@ async fn test_startapp_missing_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_mtv_style() {
 	let env = TestEnvironment::new();
@@ -600,7 +593,7 @@ async fn test_startapp_mtv_style() {
 	assert!(result.is_ok(), "MTV app creation failed");
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_restful_style() {
 	let env = TestEnvironment::new();
@@ -657,7 +650,7 @@ async fn test_startapp_restful_style() {
 	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_workspace_mode() {
 	let env = TestEnvironment::new();
@@ -688,7 +681,7 @@ async fn test_startapp_workspace_mode() {
 }
 
 // Translation of Django's StartApp tests
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_invalid_name() {
 	let env = TestEnvironment::new();
@@ -699,7 +692,7 @@ async fn test_startapp_invalid_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_importable_name() {
 	let env = TestEnvironment::new();
@@ -710,7 +703,7 @@ async fn test_startapp_importable_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_invalid_target_name() {
 	let env = TestEnvironment::new();
@@ -721,7 +714,7 @@ async fn test_startapp_invalid_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_importable_target_name() {
 	let env = TestEnvironment::new();
@@ -732,7 +725,7 @@ async fn test_startapp_importable_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let env = TestEnvironment::new();
@@ -743,7 +736,7 @@ async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_overlaying_app() {
 	let env = TestEnvironment::new();
@@ -770,7 +763,7 @@ async fn test_startapp_overlaying_app() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_template() {
 	let env = TestEnvironment::new();
@@ -806,7 +799,7 @@ async fn test_startapp_template() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	let env = TestEnvironment::new();
@@ -829,7 +822,7 @@ async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory() {
 	let env = TestEnvironment::new();
@@ -855,7 +848,7 @@ async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory()
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_name_with_app_within_other_app() {
 	let env = TestEnvironment::new();
@@ -884,7 +877,7 @@ async fn test_startapp_custom_name_with_app_within_other_app() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_app_directory_creation_error_handling() {
 	let env = TestEnvironment::new();
@@ -938,7 +931,7 @@ fn test_admin_scripts_context_options() {
 // Base Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_base_command_lifecycle() {
 	struct TestCommand {
@@ -1035,7 +1028,7 @@ fn test_command_option_value() {
 // Template Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_template_rendering() {
 	use reinhardt_commands::{TemplateCommand, TemplateContext};
@@ -1090,7 +1083,7 @@ fn test_command_error_variants() {
 // Integration Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_full_project_and_app_workflow() {
 	let env = TestEnvironment::new();
@@ -1169,7 +1162,7 @@ fn test_admin_scripts_to_camel_case() {
 // Translation of DjangoAdminNoSettings test class
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_builtin_command() {
 	// Test builtin command execution without settings
@@ -1179,7 +1172,7 @@ async fn test_djangoadmin_nosettings_builtin_command() {
 }
 
 #[tokio::test]
-#[serial(reinhardt_settings)]
+#[serial(current_dir, reinhardt_settings)]
 async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// Test builtin command with bad settings
 	let env = TestEnvironment::new();
@@ -1197,19 +1190,18 @@ async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
-#[serial]
+#[serial(reinhardt_settings)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_builtin_with_bad_environment() {
 	// Test builtin command with bad environment
-	unsafe {
-		std::env::set_var("PYTHONPATH", "/invalid/path");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("PYTHONPATH", "/invalid/path");
 
 	// Should still work for commands that don't need settings
 	assert_eq!(std::env::var("PYTHONPATH").unwrap(), "/invalid/path");
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 	// Test commands with invalid settings
@@ -1224,7 +1216,7 @@ async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 // Translation of DjangoAdminDefaultSettings test class
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_builtin_command() {
 	let env = TestEnvironment::new();
@@ -1235,7 +1227,7 @@ async fn test_djangoadmin_defaultsettings_builtin_command() {
 	assert!(env.file_exists("settings.rs"));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_builtin_with_settings() {
 	let env = TestEnvironment::new();
@@ -1284,7 +1276,7 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
 	// env_guard automatically cleans up on drop
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_custom_command() {
 	let env = TestEnvironment::new();
@@ -1294,7 +1286,7 @@ async fn test_djangoadmin_defaultsettings_custom_command() {
 	assert!(env.path().exists());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_custom_command_with_settings() {
 	// Test custom command with explicit settings
@@ -1324,7 +1316,7 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
 
 // ===== Reserved namespace validation (#3502) =====
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_rejects_reinhardt_prefix() {
 	let env = TestEnvironment::new();
@@ -1341,7 +1333,7 @@ async fn test_startproject_rejects_reinhardt_prefix() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_rejects_reinhardt_prefix() {
 	let env = TestEnvironment::new();

--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -8,10 +8,13 @@
 #[path = "support/environment.rs"]
 mod environment;
 
-use environment::EnvVarGuard;
+use environment::{EnvVars, env_vars};
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartAppCommand, StartProjectCommand,
 };
+use reinhardt_test::fixtures::temp_dir;
+use reinhardt_test::{TeardownGuard, TestResource};
+use rstest::{fixture, rstest};
 use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
@@ -20,38 +23,40 @@ use tempfile::TempDir;
 /// Helper struct for setting up test environments
 struct TestEnvironment {
 	// Restore the working directory before the temporary directory is removed.
-	_cwd: CurrentDirGuard,
+	_cwd: TeardownGuard<CurrentDir>,
 	temp_dir: TempDir,
 }
 
-struct CurrentDirGuard {
+struct CurrentDir {
 	original: PathBuf,
 }
 
-impl CurrentDirGuard {
-	fn change_to(path: &std::path::Path) -> Self {
-		let original = std::env::current_dir().expect("read current directory");
-		std::env::set_current_dir(path).expect("change current directory");
-		Self { original }
+impl TestResource for CurrentDir {
+	fn setup() -> Self {
+		Self {
+			original: std::env::current_dir().expect("read current directory"),
+		}
 	}
-}
 
-impl Drop for CurrentDirGuard {
-	fn drop(&mut self) {
+	fn teardown(&mut self) {
 		std::env::set_current_dir(&self.original).expect("restore current directory");
 	}
 }
 
-impl TestEnvironment {
-	fn new() -> Self {
-		Self {
-			_cwd: CurrentDirGuard {
-				original: std::env::current_dir().expect("read current directory"),
-			},
-			temp_dir: TempDir::new().expect("Failed to create temp directory"),
-		}
-	}
+#[fixture]
+fn current_dir() -> TeardownGuard<CurrentDir> {
+	TeardownGuard::new()
+}
 
+#[fixture]
+fn test_env(temp_dir: TempDir, current_dir: TeardownGuard<CurrentDir>) -> TestEnvironment {
+	TestEnvironment {
+		_cwd: current_dir,
+		temp_dir,
+	}
+}
+
+impl TestEnvironment {
 	fn path(&self) -> PathBuf {
 		self.temp_dir.path().to_path_buf()
 	}
@@ -77,10 +82,10 @@ impl TestEnvironment {
 // StartProject Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_creates_project_structure() {
-	let env = TestEnvironment::new();
+async fn test_startproject_creates_project_structure(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "myproject";
 
 	// Change to temp directory
@@ -98,10 +103,10 @@ async fn test_startproject_creates_project_structure() {
 	assert!(env.file_exists(&format!("{}/src/bin/manage.rs", project_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_with_custom_directory() {
-	let env = TestEnvironment::new();
+async fn test_startproject_with_custom_directory(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "myproject";
 	let custom_dir = "custom_location";
 
@@ -133,10 +138,10 @@ async fn test_startproject_missing_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_mtv_style() {
-	let env = TestEnvironment::new();
+async fn test_startproject_mtv_style(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "mtv_project";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -152,10 +157,10 @@ async fn test_startproject_mtv_style() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", project_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_restful_style() {
-	let env = TestEnvironment::new();
+async fn test_startproject_restful_style(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "api_project";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -181,16 +186,17 @@ async fn test_startproject_wrong_args() {
 	assert!(result.is_err());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_simple_project() {
+async fn test_startproject_simple_project(#[from(test_env)] env: TestEnvironment) {
 	// Arrange
 	let original_dir = std::env::current_dir().expect("read current directory");
 
 	// Act
 	{
-		let env = TestEnvironment::new();
-		std::env::set_current_dir(env.path()).expect("Failed to change directory");
+		let scoped_env = env;
+		std::env::set_current_dir(scoped_env.path()).expect("Failed to change directory");
 
 		let ctx = CommandContext::new(vec!["testproject".to_string()]);
 		let cmd = StartProjectCommand;
@@ -205,11 +211,11 @@ async fn test_startproject_simple_project() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_importable_project_name() {
+async fn test_startproject_importable_project_name(#[from(test_env)] env: TestEnvironment) {
 	// Test that reserved keywords fail
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let reserved_names = vec!["test", "mod", "use", "fn", "struct"];
@@ -221,11 +227,11 @@ async fn test_startproject_importable_project_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_command_does_not_import() {
+async fn test_startproject_command_does_not_import(#[from(test_env)] env: TestEnvironment) {
 	// Verify command doesn't import project code
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -234,10 +240,12 @@ async fn test_startproject_command_does_not_import() {
 	assert!(result.is_ok());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_simple_project_different_directory() {
-	let env = TestEnvironment::new();
+async fn test_startproject_simple_project_different_directory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["testproject".to_string(), "other_dir".to_string()]);
@@ -246,11 +254,11 @@ async fn test_startproject_simple_project_different_directory() {
 	assert!(result.is_ok());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_template() {
+async fn test_startproject_custom_project_template(#[from(test_env)] env: TestEnvironment) {
 	// Test with custom template path
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let mut ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -260,10 +268,10 @@ async fn test_startproject_custom_project_template() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_file_without_extension() {
-	let env = TestEnvironment::new();
+async fn test_startproject_file_without_extension(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a template directory with files without extensions
@@ -293,10 +301,12 @@ async fn test_startproject_file_without_extension() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_template_context_variables() {
-	let env = TestEnvironment::new();
+async fn test_startproject_custom_project_template_context_variables(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a template with context variables
@@ -324,10 +334,12 @@ async fn test_startproject_custom_project_template_context_variables() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_no_escaping_of_project_variables() {
-	let env = TestEnvironment::new();
+async fn test_startproject_no_escaping_of_project_variables(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create template with special characters
@@ -355,10 +367,12 @@ async fn test_startproject_no_escaping_of_project_variables() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_destination_missing() {
-	let env = TestEnvironment::new();
+async fn test_startproject_custom_project_destination_missing(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Specify a custom destination that doesn't exist
@@ -392,14 +406,14 @@ async fn test_startproject_custom_project_destination_missing() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_honor_umask() {
+async fn test_startproject_honor_umask(#[from(test_env)] env: TestEnvironment) {
 	#[cfg(unix)]
 	{
 		use std::os::unix::fs::PermissionsExt;
 
-		let env = TestEnvironment::new();
 		std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 		let ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -421,19 +435,22 @@ async fn test_startproject_honor_umask() {
 
 	#[cfg(not(unix))]
 	{
-		// Test is Unix-specific
+		// Retain the fixture until this platform-specific test ends.
+		let _env = env;
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_overlay_preserves_unrelated_existing_files() {
+async fn startproject_overlay_preserves_unrelated_existing_files(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	let destination = env.path().join("existing-project");
 	fs::create_dir_all(&destination).expect("create existing destination");
 	fs::write(destination.join("custom.txt"), "keep this file\n").expect("write existing file");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec![
 		"demo_project".to_string(),
 		"existing-project".to_string(),
@@ -454,14 +471,16 @@ async fn startproject_overlay_preserves_unrelated_existing_files() {
 	assert!(destination.join("Cargo.toml").is_file());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_rejects_file_destinations_without_mutating_them() {
+async fn startproject_rejects_file_destinations_without_mutating_them(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	env.create_file("destination", "existing destination file\n");
 	let before = env.read_file("destination");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec!["demo_project".to_string(), "destination".to_string()]);
 
 	// Act
@@ -476,14 +495,16 @@ async fn startproject_rejects_file_destinations_without_mutating_them() {
 	assert!(!env.file_exists("destination/Cargo.toml"));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it() {
+async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	env.create_file("blocked", "regular parent\n");
 	let before = env.read_file("blocked");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec![
 		"demo_project".to_string(),
 		"blocked/project".to_string(),
@@ -505,10 +526,10 @@ async fn startproject_rejects_destinations_below_a_regular_file_without_mutating
 // StartApp Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_creates_app_structure() {
-	let env = TestEnvironment::new();
+async fn test_startapp_creates_app_structure(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "myapp";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -531,10 +552,10 @@ async fn test_startapp_creates_app_structure() {
 	assert!(env.file_exists(&format!("src/apps/{}/services.rs", app_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_with_custom_directory() {
-	let env = TestEnvironment::new();
+async fn test_startapp_with_custom_directory(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "myapp";
 	let custom_dir = "my_apps";
 
@@ -571,10 +592,10 @@ async fn test_startapp_missing_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_mtv_style() {
-	let env = TestEnvironment::new();
+async fn test_startapp_mtv_style(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "mtv_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -593,10 +614,10 @@ async fn test_startapp_mtv_style() {
 	assert!(result.is_ok(), "MTV app creation failed");
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_restful_style() {
-	let env = TestEnvironment::new();
+async fn test_startapp_restful_style(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "api_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -650,10 +671,10 @@ async fn test_startapp_restful_style() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_workspace_mode() {
-	let env = TestEnvironment::new();
+async fn test_startapp_workspace_mode(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "workspace_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -681,10 +702,10 @@ async fn test_startapp_workspace_mode() {
 }
 
 // Translation of Django's StartApp tests
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_invalid_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_invalid_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["1invalid".to_string()]);
@@ -692,10 +713,10 @@ async fn test_startapp_invalid_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_importable_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_importable_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["test".to_string()]);
@@ -703,10 +724,10 @@ async fn test_startapp_importable_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_invalid_target_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_invalid_target_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "1invalid".to_string()]);
@@ -714,10 +735,10 @@ async fn test_startapp_invalid_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_importable_target_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_importable_target_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "test".to_string()]);
@@ -725,10 +746,12 @@ async fn test_startapp_importable_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_trailing_slash_in_target_app_directory_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_trailing_slash_in_target_app_directory_name(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "testapp/".to_string()]);
@@ -736,10 +759,10 @@ async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_overlaying_app() {
-	let env = TestEnvironment::new();
+async fn test_startapp_overlaying_app(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -763,10 +786,10 @@ async fn test_startapp_overlaying_app() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_template() {
-	let env = TestEnvironment::new();
+async fn test_startapp_template(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -799,10 +822,12 @@ async fn test_startapp_template() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
-	let env = TestEnvironment::new();
+async fn test_startapp_creates_directory_when_custom_app_destination_missing(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -822,10 +847,12 @@ async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -848,10 +875,12 @@ async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory()
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_name_with_app_within_other_app() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_name_with_app_within_other_app(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -877,10 +906,12 @@ async fn test_startapp_custom_name_with_app_within_other_app() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_app_directory_creation_error_handling() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_app_directory_creation_error_handling(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -1028,12 +1059,12 @@ fn test_command_option_value() {
 // Template Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_template_rendering() {
+async fn test_template_rendering(#[from(test_env)] env: TestEnvironment) {
 	use reinhardt_commands::{TemplateCommand, TemplateContext};
 
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a simple template directory
@@ -1083,10 +1114,10 @@ fn test_command_error_variants() {
 // Integration Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_full_project_and_app_workflow() {
-	let env = TestEnvironment::new();
+async fn test_full_project_and_app_workflow(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Step 1: Create project
@@ -1171,15 +1202,17 @@ async fn test_djangoadmin_nosettings_builtin_command() {
 	assert_eq!(ctx.arg(0), Some(&"--version".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(current_dir, reinhardt_settings)]
-async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
+async fn test_djangoadmin_nosettings_builtin_with_bad_settings(
+	#[from(test_env)] env: TestEnvironment,
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test builtin command with bad settings
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Set invalid settings environment variable
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad.settings");
 
 	// Command should handle bad settings gracefully
@@ -1190,11 +1223,13 @@ async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[serial(reinhardt_settings)]
 #[tokio::test]
-async fn test_djangoadmin_nosettings_builtin_with_bad_environment() {
+async fn test_djangoadmin_nosettings_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test builtin command with bad environment
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("PYTHONPATH", "/invalid/path");
 
 	// Should still work for commands that don't need settings
@@ -1216,10 +1251,10 @@ async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 // Translation of DjangoAdminDefaultSettings test class
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_builtin_command() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_builtin_command(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create default settings file
@@ -1227,20 +1262,24 @@ async fn test_djangoadmin_defaultsettings_builtin_command() {
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_builtin_with_settings() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_settings(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	env.create_file("settings.rs", "// Settings content\n");
 
 	// Test with explicit settings parameter
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "test.settings");
 
 	// Test command execution with environment variable
@@ -1251,10 +1290,12 @@ async fn test_djangoadmin_defaultsettings_builtin_with_environment() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "nonexistent.settings");
 
 	// Should fail with appropriate error
@@ -1265,10 +1306,12 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 
 	// Should handle empty settings gracefully
@@ -1276,10 +1319,10 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_custom_command() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_custom_command(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test custom command execution
@@ -1298,11 +1341,13 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_settings() {
 	assert_eq!(ctx.arg(1), Some(&"custom.settings".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
+async fn test_djangoadmin_defaultsettings_custom_command_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test custom command with environment settings
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "env.settings");
 	env_guard.set("CUSTOM_VAR", "value");
 
@@ -1316,10 +1361,10 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
 
 // ===== Reserved namespace validation (#3502) =====
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_rejects_reinhardt_prefix() {
-	let env = TestEnvironment::new();
+async fn test_startproject_rejects_reinhardt_prefix(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	for name in ["reinhardt_myapp", "reinhardt-myapp"] {
@@ -1333,10 +1378,10 @@ async fn test_startproject_rejects_reinhardt_prefix() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_rejects_reinhardt_prefix() {
-	let env = TestEnvironment::new();
+async fn test_startapp_rejects_reinhardt_prefix(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	for name in ["reinhardt_myapp", "reinhardt-myapp"] {

--- a/crates/reinhardt-commands/tests/support/environment.rs
+++ b/crates/reinhardt-commands/tests/support/environment.rs
@@ -1,17 +1,15 @@
-//! Environment restoration for serial-protected command tests.
+//! Environment fixtures for serial-protected command tests.
 
-use std::ffi::OsString;
+use reinhardt_test::{TeardownGuard, TestResource};
+use rstest::fixture;
+use std::ffi::{OsStr, OsString};
 
-pub(super) struct EnvVarGuard {
+pub(super) struct EnvVars {
 	vars: Vec<(String, Option<OsString>)>,
 }
 
-impl EnvVarGuard {
-	pub(super) fn new() -> Self {
-		Self { vars: Vec::new() }
-	}
-
-	pub(super) fn set(&mut self, key: &str, value: &str) {
+impl EnvVars {
+	pub(super) fn set(&mut self, key: &str, value: impl AsRef<OsStr>) {
 		self.vars.push((key.to_owned(), std::env::var_os(key)));
 		// SAFETY: environment-changing callers share a serial test group.
 		unsafe {
@@ -20,8 +18,12 @@ impl EnvVarGuard {
 	}
 }
 
-impl Drop for EnvVarGuard {
-	fn drop(&mut self) {
+impl TestResource for EnvVars {
+	fn setup() -> Self {
+		Self { vars: Vec::new() }
+	}
+
+	fn teardown(&mut self) {
 		for (key, original) in self.vars.iter().rev() {
 			// SAFETY: the caller retains its serial test guard during cleanup.
 			unsafe {
@@ -32,4 +34,9 @@ impl Drop for EnvVarGuard {
 			}
 		}
 	}
+}
+
+#[fixture]
+pub(super) fn env_vars() -> TeardownGuard<EnvVars> {
+	TeardownGuard::new()
 }

--- a/crates/reinhardt-commands/tests/support/environment.rs
+++ b/crates/reinhardt-commands/tests/support/environment.rs
@@ -1,0 +1,35 @@
+//! Environment restoration for serial-protected command tests.
+
+use std::ffi::OsString;
+
+pub(super) struct EnvVarGuard {
+	vars: Vec<(String, Option<OsString>)>,
+}
+
+impl EnvVarGuard {
+	pub(super) fn new() -> Self {
+		Self { vars: Vec::new() }
+	}
+
+	pub(super) fn set(&mut self, key: &str, value: &str) {
+		self.vars.push((key.to_owned(), std::env::var_os(key)));
+		// SAFETY: environment-changing callers share a serial test group.
+		unsafe {
+			std::env::set_var(key, value);
+		}
+	}
+}
+
+impl Drop for EnvVarGuard {
+	fn drop(&mut self) {
+		for (key, original) in self.vars.iter().rev() {
+			// SAFETY: the caller retains its serial test guard during cleanup.
+			unsafe {
+				match original {
+					Some(value) => std::env::set_var(key, value),
+					None => std::env::remove_var(key),
+				}
+			}
+		}
+	}
+}

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -76,6 +76,8 @@ hot-reload = ["notify", "tokio", "async"]
 caching = ["moka", "async"]
 
 [dev-dependencies]
+# Path-only test dependencies avoid cyclic publish ordering through the fixture facade.
+reinhardt-test = { path = "../reinhardt-test", default-features = false }
 insta = { workspace = true }
 futures = { workspace = true }
 tempfile = "3.8"

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -390,6 +390,16 @@ These fields exist for Django settings compatibility but are **not yet consumed*
 use reinhardt::conf::settings::{SettingsBuilder, SettingsConfig};
 ```
 
+## Testing
+
+Database audit tests use a uniquely named in-memory SQLite database for each
+backend. Connections within one pool share that database, while concurrent
+backends remain isolated.
+
+```bash
+cargo test -p reinhardt-conf --all-features --lib settings::audit::backends::database::tests -- --test-threads=8
+```
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -392,9 +392,10 @@ use reinhardt::conf::settings::{SettingsBuilder, SettingsConfig};
 
 ## Testing
 
-Database audit tests use a uniquely named in-memory SQLite database for each
-backend. Connections within one pool share that database, while concurrent
-backends remain isolated.
+Database audit tests inject an async `rstest` backend fixture, composed with
+`reinhardt_test::fixtures::random_test_key` for each in-memory SQLite database.
+Connections within one pool share that database, while independently injected
+backends remain isolated. Pool cleanup follows the fixture's lifetime.
 
 ```bash
 cargo test -p reinhardt-conf --all-features --lib settings::audit::backends::database::tests -- --test-threads=8

--- a/crates/reinhardt-conf/src/settings/audit/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/audit/backends/database.rs
@@ -322,6 +322,8 @@ impl AuditBackend for DatabaseAuditBackend {
 mod tests {
 	use super::*;
 	use reinhardt_query::Func;
+	use reinhardt_test::fixtures::random_test_key;
+	use rstest::{fixture, rstest};
 	use serde_json::json;
 	use std::sync::Once;
 
@@ -333,26 +335,28 @@ mod tests {
 		});
 	}
 
-	async fn create_test_backend() -> DatabaseAuditBackend {
-		init_drivers();
+	#[fixture]
+	fn database_url() -> String {
 		// Give each backend its own database while sharing it across pooled connections.
-		let db_url = format!(
-			"sqlite:file:audit-{}?mode=memory&cache=shared",
-			uuid::Uuid::new_v4()
-		);
+		format!("sqlite:file:{}?mode=memory&cache=shared", random_test_key())
+	}
+
+	#[fixture]
+	async fn backend(database_url: String) -> DatabaseAuditBackend {
+		init_drivers();
 
 		// Create backend with AnyPool
 		use sqlx::any::AnyPoolOptions;
 
 		let pool = AnyPoolOptions::new()
 			.max_connections(5)
-			.connect(&db_url)
+			.connect(&database_url)
 			.await
 			.expect("Failed to connect to test database");
 
 		let backend = DatabaseAuditBackend {
 			pool: std::sync::Arc::new(pool),
-			database_url: db_url,
+			database_url,
 		};
 		backend
 			.init_tables()
@@ -361,10 +365,9 @@ mod tests {
 		backend
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_init() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_init(#[future(awt)] backend: DatabaseAuditBackend) {
 		// Verify tables were created
 		let stmt = Query::select()
 			.expr_as(
@@ -375,6 +378,16 @@ mod tests {
 			.to_owned();
 		let sql = stmt.to_string(SqliteQueryBuilder);
 
+		// Keep one connection checked out so the pool must use a second one.
+		let mut connection = backend.pool.acquire().await.unwrap();
+		let first_count: i64 = sqlx::query(&sql)
+			.fetch_one(&mut *connection)
+			.await
+			.unwrap()
+			.try_get("count")
+			.unwrap();
+		assert_eq!(first_count, 0);
+
 		let rows = sqlx::query(&sql)
 			.fetch_all(backend.pool.as_ref())
 			.await
@@ -384,11 +397,14 @@ mod tests {
 		assert_eq!(count, 0);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_log_event() {
-		let backend = create_test_backend().await;
-		let other_backend = create_test_backend().await;
-
+	async fn test_database_backend_log_event(
+		#[future(awt)] backend: DatabaseAuditBackend,
+		#[from(backend)]
+		#[future(awt)]
+		other_backend: DatabaseAuditBackend,
+	) {
 		let mut changes = HashMap::new();
 		changes.insert(
 			"test_key".to_string(),
@@ -412,10 +428,9 @@ mod tests {
 		assert_eq!(other_backend.get_events(None).await.unwrap().len(), 0);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_filter_by_type() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_filter_by_type(#[future(awt)] backend: DatabaseAuditBackend) {
 		for i in 0..5 {
 			let event_type = if i % 2 == 0 {
 				EventType::ConfigUpdate
@@ -447,10 +462,9 @@ mod tests {
 		assert_eq!(update_events.len(), 3);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_filter_by_user() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_filter_by_user(#[future(awt)] backend: DatabaseAuditBackend) {
 		for i in 0..5 {
 			let user = if i % 2 == 0 { "alice" } else { "bob" };
 

--- a/crates/reinhardt-conf/src/settings/audit/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/audit/backends/database.rs
@@ -335,23 +335,24 @@ mod tests {
 
 	async fn create_test_backend() -> DatabaseAuditBackend {
 		init_drivers();
-		// Use named in-memory SQLite database with shared cache
-		// The "file:" prefix with "mode=memory" and "cache=shared" ensures
-		// all connections in the pool share the same in-memory database
-		let db_url = "sqlite:file:memdb1?mode=memory&cache=shared";
+		// Give each backend its own database while sharing it across pooled connections.
+		let db_url = format!(
+			"sqlite:file:audit-{}?mode=memory&cache=shared",
+			uuid::Uuid::new_v4()
+		);
 
 		// Create backend with AnyPool
 		use sqlx::any::AnyPoolOptions;
 
 		let pool = AnyPoolOptions::new()
 			.max_connections(5)
-			.connect(db_url)
+			.connect(&db_url)
 			.await
 			.expect("Failed to connect to test database");
 
 		let backend = DatabaseAuditBackend {
 			pool: std::sync::Arc::new(pool),
-			database_url: db_url.to_string(),
+			database_url: db_url,
 		};
 		backend
 			.init_tables()
@@ -386,6 +387,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_database_backend_log_event() {
 		let backend = create_test_backend().await;
+		let other_backend = create_test_backend().await;
 
 		let mut changes = HashMap::new();
 		changes.insert(
@@ -407,6 +409,7 @@ mod tests {
 		let events = backend.get_events(None).await.unwrap();
 		assert_eq!(events.len(), 1);
 		assert_eq!(events[0].event_type, EventType::ConfigUpdate);
+		assert_eq!(other_backend.get_events(None).await.unwrap().len(), 0);
 	}
 
 	#[tokio::test]

--- a/crates/reinhardt-core/Cargo.toml
+++ b/crates/reinhardt-core/Cargo.toml
@@ -158,3 +158,7 @@ hyper = "1.0"
 tokio-test = "0.4"
 serial_test = { workspace = true }
 rstest = { workspace = true }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+# Path-only test dependency avoids changing release-plz publish ordering.
+reinhardt-test = { path = "../reinhardt-test", default-features = false }

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -960,6 +960,12 @@ let validator = ConditionalValidator::unless(
 );
 ```
 
+## Testing
+
+Reactive batching regressions inject `rstest` scope fixtures. Native fixtures use
+`reinhardt-test` teardown guards around the local runtime's `ReactiveScope`; WASM
+fixtures retain the same scope type and its existing automatic cleanup.
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-core/README.md
+++ b/crates/reinhardt-core/README.md
@@ -960,6 +960,19 @@ let validator = ConditionalValidator::unless(
 );
 ```
 
+## Reactive Batching
+
+`reactive::batch` defers effect callbacks triggered by reactive writes until the
+outermost batch returns, including when it returns an error. Layout effects settle
+their reactive writes before passive effects run. Automatic and explicit-dependency
+Memos invalidate immediately, so reads within nested batches observe current values.
+
+If a batch body panics, its queued callbacks wait until unwinding finishes. The
+next normal batch or explicit flush drains that work. A subsequent signal change
+runs retained Layout effects and schedules passive effects through the configured
+scheduler. If a callback itself panics, callbacks that have not run remain queued;
+the original panic is preserved and notification state is restored.
+
 ## Testing
 
 Reactive batching regressions inject `rstest` scope fixtures. Native fixtures use

--- a/crates/reinhardt-core/macros/tests/ui/model/fail/generated_relation_safe_construction.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/model/fail/generated_relation_safe_construction.stderr
@@ -27,4 +27,6 @@ note: if you're trying to build a new `RelationPath<Document, Project, Generated
            candidate #8: `parking_lot_core::thread_parker::ThreadParkerT`
            candidate #9: `rand::distr::uniform::UniformSampler`
            candidate #10: `ring::aead::BoundKey`
-           candidate #11: `typenum::marker_traits::Bit`
+           candidate #11: `simdutf8::basic::imp::ChunkedUtf8Validator`
+           candidate #12: `simdutf8::basic::imp::Utf8Validator`
+           candidate #13: `typenum::marker_traits::Bit`

--- a/crates/reinhardt-core/src/reactive/effect.rs
+++ b/crates/reinhardt-core/src/reactive/effect.rs
@@ -360,36 +360,6 @@ impl Effect {
 	}
 }
 
-// Update Runtime to support effect execution
-//
-// This extends the Runtime with the ability to execute effects when they're scheduled.
-impl super::runtime::Runtime {
-	/// Execute a scheduled effect
-	///
-	/// This is called internally when flushing pending updates.
-	fn execute_scheduled_effect(&self, effect_id: NodeId) {
-		Effect::execute_effect(effect_id);
-	}
-
-	/// Flush all pending updates
-	///
-	/// This executes all Effects that have been scheduled for update.
-	/// Skips effects that were disposed between scheduling and execution.
-	pub fn flush_updates(&self) {
-		*self.update_scheduled.borrow_mut() = false;
-
-		// Take all pending updates
-		let pending = core::mem::take(&mut *self.pending_updates.borrow_mut());
-
-		// Execute each pending effect (skip disposed ones)
-		for node_id in pending {
-			if get_effect_timing(node_id).is_some() {
-				self.execute_scheduled_effect(node_id);
-			}
-		}
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/reinhardt-core/src/reactive/memo.rs
+++ b/crates/reinhardt-core/src/reactive/memo.rs
@@ -52,7 +52,6 @@ type MemoFn<T> = Box<dyn FnMut() -> T + 'static>;
 struct MemoSlot<T: Clone + 'static> {
 	f: Option<MemoFn<T>>,
 	value: Option<T>,
-	deps_notifier: Option<super::effect::Effect>,
 	run_scope: Option<super::scope::ReactiveScope>,
 }
 
@@ -143,28 +142,16 @@ impl<T: Clone + 'static> Memo<T> {
 	where
 		F: FnMut() -> T + 'static,
 	{
-		let memo = Self::allocate(Box::new(move || {
+		Self::allocate(Box::new(move || {
+			// Register on the Memo itself so propagation invalidates it before
+			// consumers run, including reads inside an explicit batch.
+			with_runtime(|rt| {
+				for &dep in deps.as_slice() {
+					rt.track_dependency(dep);
+				}
+			});
 			super::runtime::run_without_observer(&mut f)
-		}));
-		let notifier = if deps.as_slice().is_empty() {
-			None
-		} else {
-			let memo_id = memo.id();
-			Some(super::effect::Effect::new_with_deps_and_timing::<_, fn()>(
-				move || {
-					mark_memo_dirty_by_id(memo_id);
-					None
-				},
-				deps,
-				EffectTiming::Layout,
-			))
-		};
-		with_node_mut::<MemoSlot<T>, _>(memo.key, |slot| {
-			slot.deps_notifier = notifier;
-		})
-		.unwrap_or_else(|err| panic!("{err}"));
-		set_node_dirty(memo.key, false).unwrap_or_else(|err| panic!("{err}"));
-		memo
+		}))
 	}
 
 	#[doc(hidden)]
@@ -185,7 +172,6 @@ impl<T: Clone + 'static> Memo<T> {
 			MemoSlot {
 				f: Some(f),
 				value: None,
-				deps_notifier: None,
 				run_scope: None,
 			},
 		);
@@ -304,27 +290,17 @@ impl<T: Clone + 'static> Memo<T> {
 		self.key.node_id()
 	}
 
-	/// Dispose this memo and its explicit dependency notifier.
+	/// Dispose this memo and unsubscribe its dependencies.
 	pub fn dispose(&self) {
-		let Ok((f, value, notifier, run_scope)) =
-			with_node_mut::<MemoSlot<T>, _>(self.key, |slot| {
-				(
-					slot.f.take(),
-					slot.value.take(),
-					slot.deps_notifier.take(),
-					slot.run_scope.take(),
-				)
-			})
-		else {
+		let Ok((f, value, run_scope)) = with_node_mut::<MemoSlot<T>, _>(self.key, |slot| {
+			(slot.f.take(), slot.value.take(), slot.run_scope.take())
+		}) else {
 			return;
 		};
 		let _ = mark_node_disposed(self.key);
 		drop(f);
 		drop(value);
 		drop(run_scope);
-		if let Some(notifier) = notifier {
-			notifier.dispose();
-		}
 		let _ = try_with_runtime(|rt| rt.remove_node(self.id()));
 	}
 }

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -761,8 +761,32 @@ pub(crate) fn subscribe_node_to_observer(node: NodeId, observer: NodeId) {
 mod tests {
 	use super::*;
 	use crate::reactive::{Effect, Memo, ReactiveScope, Signal};
+	#[cfg(native)]
+	use reinhardt_test::resource::{TeardownGuard, TestResource};
 	use serial_test::serial;
 	use std::{cell::Cell, rc::Rc};
+
+	#[cfg(native)]
+	impl TestResource for ReactiveScope {
+		fn setup() -> Self {
+			Self::new()
+		}
+
+		fn teardown(&mut self) {
+			self.dispose();
+		}
+	}
+
+	// Keep unit tests on this crate's runtime rather than the facade's compiled core.
+	#[cfg(native)]
+	type ReactiveScopeFixture = TeardownGuard<ReactiveScope>;
+	#[cfg(wasm)]
+	type ReactiveScopeFixture = ReactiveScope;
+
+	#[rstest::fixture]
+	fn reactive_scope() -> ReactiveScopeFixture {
+		ReactiveScopeFixture::default()
+	}
 
 	#[test]
 	#[serial]
@@ -1086,8 +1110,11 @@ mod tests {
 	#[case::layout(EffectTiming::Layout)]
 	#[case::passive(EffectTiming::Passive)]
 	#[serial(reactive_runtime)]
-	fn nested_batch_defers_effects_but_keeps_memo_reads_current(#[case] timing: EffectTiming) {
-		ReactiveScope::run(|| {
+	fn nested_batch_defers_effects_but_keeps_memo_reads_current(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] timing: EffectTiming,
+	) {
+		reactive_scope.enter(|| {
 			// Arrange
 			let source = Signal::new(0);
 			let derived = Memo::new(move || source.get() * 2);
@@ -1119,10 +1146,13 @@ mod tests {
 	#[case::layout(EffectTiming::Layout)]
 	#[case::passive(EffectTiming::Passive)]
 	#[serial(reactive_runtime)]
-	fn batch_releases_effects_after_error_and_unwind(#[case] timing: EffectTiming) {
+	fn batch_releases_effects_after_error_and_unwind(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] timing: EffectTiming,
+	) {
 		use std::panic::{AssertUnwindSafe, catch_unwind};
 
-		ReactiveScope::run(|| {
+		reactive_scope.enter(|| {
 			// Arrange
 			let source = Signal::new(0);
 			let observed = Rc::new(RefCell::new(Vec::new()));

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -299,14 +299,12 @@ impl Runtime {
 		drop(revisions);
 		match self.notification_phase.get() {
 			NotificationPhase::Idle => {
-				let recovery =
-					core::mem::take(&mut *self.notification_recovery_sources.borrow_mut());
 				let mut sources = self.notification_sources.borrow_mut();
-				sources.extend(recovery);
 				sources.extend(signal_ids.iter().copied());
 				drop(sources);
 				self.notification_phase.set(NotificationPhase::Propagating);
 				self.process_notification_epochs();
+				self.schedule_pending_flush();
 			}
 			NotificationPhase::Propagating => {
 				self.notification_sources
@@ -356,6 +354,9 @@ impl Runtime {
 						.notification_recovery_sources
 						.borrow_mut()
 						.extend(pending);
+					self.runtime.queue_updates(core::mem::take(
+						&mut *self.runtime.notification_passive.borrow_mut(),
+					));
 				}
 				self.runtime.notification_memos_seen.borrow_mut().clear();
 				self.runtime
@@ -376,6 +377,8 @@ impl Runtime {
 			completed: false,
 			discard_pending: false,
 		};
+		let recovery = core::mem::take(&mut *self.notification_recovery_sources.borrow_mut());
+		self.notification_sources.borrow_mut().extend(recovery);
 		let mut epoch_count = 0_usize;
 		loop {
 			epoch_count += 1;
@@ -390,6 +393,21 @@ impl Runtime {
 			self.notification_consumers_seen.borrow_mut().clear();
 			self.notification_layout_effects.borrow_mut().clear();
 			self.notification_passive.borrow_mut().clear();
+			if *self.batch_depth.borrow() == 0 {
+				// Deferred Layout effects join the same epoch as fresh sources.
+				// Retain passive work so new notifications cannot enqueue it twice.
+				self.pending_updates.borrow_mut().retain(|node_id| {
+					if super::effect::get_effect_timing(*node_id) == Some(EffectTiming::Layout) {
+						self.notification_consumers_seen
+							.borrow_mut()
+							.insert(*node_id);
+						self.notification_layout_effects.borrow_mut().push(*node_id);
+						false
+					} else {
+						true
+					}
+				});
+			}
 
 			loop {
 				let source_id = { self.notification_sources.borrow_mut().pop() };
@@ -402,25 +420,66 @@ impl Runtime {
 			self.notification_phase.set(NotificationPhase::Consuming);
 			let layout_effects =
 				core::mem::take(&mut *self.notification_layout_effects.borrow_mut());
-			for effect_id in layout_effects {
-				if *self.batch_depth.borrow() > 0 {
-					self.schedule_update(effect_id);
-				} else {
-					super::effect::Effect::execute_effect(effect_id);
-				}
+			if *self.batch_depth.borrow() > 0 {
+				self.queue_updates(layout_effects);
+			} else {
+				self.execute_pending_effects(layout_effects);
 			}
 			let passive = core::mem::take(&mut *self.notification_passive.borrow_mut());
-			for node_id in passive {
-				self.schedule_update(node_id);
-			}
+			self.queue_updates(passive);
 
 			let next_sources = core::mem::take(&mut *self.notification_next_sources.borrow_mut());
-			if next_sources.is_empty() {
+			let has_pending_layout = *self.batch_depth.borrow() == 0
+				&& self.pending_updates.borrow().iter().any(|&node_id| {
+					super::effect::get_effect_timing(node_id) == Some(EffectTiming::Layout)
+				});
+			if next_sources.is_empty() && !has_pending_layout {
 				break;
 			}
 			self.notification_sources.borrow_mut().extend(next_sources);
 		}
 		wave_guard.completed = true;
+	}
+
+	fn execute_pending_effects(&self, effects: Vec<NodeId>) {
+		struct PendingEffectsGuard<'a> {
+			runtime: &'a Runtime,
+			remaining: alloc::vec::IntoIter<NodeId>,
+		}
+
+		impl Drop for PendingEffectsGuard<'_> {
+			fn drop(&mut self) {
+				// Keep callbacks that did not run when an earlier callback panicked.
+				// Scheduling a flush here could execute user code during unwinding.
+				self.runtime.queue_updates(self.remaining.by_ref());
+			}
+		}
+
+		let mut pending = PendingEffectsGuard {
+			runtime: self,
+			remaining: effects.into_iter(),
+		};
+		for node_id in pending.remaining.by_ref() {
+			super::effect::Effect::execute_effect(node_id);
+		}
+	}
+
+	/// Flush pending Layout effects through notification epochs, then passive effects.
+	///
+	/// Layout writes converge before passive consumers run. A flush inside a batch,
+	/// an active notification, or panic unwinding is deferred. Unexecuted effects
+	/// survive a callback panic for the next normal batch, notification, or flush.
+	pub fn flush_updates(&self) {
+		if *self.batch_depth.borrow() > 0
+			|| self.notification_phase.get() != NotificationPhase::Idle
+			|| std::thread::panicking()
+		{
+			return;
+		}
+		*self.update_scheduled.borrow_mut() = false;
+		self.process_notification_epochs();
+		let pending = core::mem::take(&mut *self.pending_updates.borrow_mut());
+		self.execute_pending_effects(pending);
 	}
 
 	fn propagate_notification_source(&self, node_id: NodeId) {
@@ -467,13 +526,24 @@ impl Runtime {
 	///
 	/// * `node_id` - ID of the node to update
 	pub fn schedule_update(&self, node_id: NodeId) {
-		let mut pending = self.pending_updates.borrow_mut();
-		if !pending.contains(&node_id) {
-			pending.push(node_id);
-		}
-		drop(pending);
+		self.queue_updates([node_id]);
+		self.schedule_pending_flush();
+	}
 
-		if *self.batch_depth.borrow() > 0 {
+	fn queue_updates(&self, nodes: impl IntoIterator<Item = NodeId>) {
+		let mut pending = self.pending_updates.borrow_mut();
+		for node_id in nodes {
+			if !pending.contains(&node_id) {
+				pending.push(node_id);
+			}
+		}
+	}
+
+	fn schedule_pending_flush(&self) {
+		if *self.batch_depth.borrow() > 0
+			|| self.notification_phase.get() != NotificationPhase::Idle
+			|| self.pending_updates.borrow().is_empty()
+		{
 			return;
 		}
 
@@ -631,9 +701,14 @@ where
 
 /// Execute multiple reactive writes as a single update cycle.
 ///
-/// Layout and passive effects are queued, then flushed once the outermost batch
-/// exits. Nested batches share the same queue. Memos are invalidated immediately
-/// so reads inside the batch observe the current signal values.
+/// Effect re-executions are queued, then flushed once the outermost batch returns
+/// normally, including an `Err` result. Layout effects run before passive effects.
+/// Nested batches share the same queue. All Memos are invalidated immediately so
+/// reads inside the batch observe the current signal values.
+///
+/// During panic unwinding, callbacks remain queued to preserve the original panic.
+/// The next normal batch or flush drains them; a subsequent signal notification
+/// runs pending Layout effects and schedules passive work.
 pub fn batch<R>(f: impl FnOnce() -> R) -> R {
 	struct BatchGuard;
 
@@ -644,10 +719,12 @@ pub fn batch<R>(f: impl FnOnce() -> R) -> R {
 					let mut depth = rt.batch_depth.borrow_mut();
 					debug_assert!(*depth > 0, "reactive batch depth underflow");
 					*depth -= 1;
-					*depth == 0 && !rt.pending_updates.borrow().is_empty()
+					*depth == 0
+						&& (!rt.pending_updates.borrow().is_empty()
+							|| !rt.notification_recovery_sources.borrow().is_empty())
 				};
 
-				if should_flush {
+				if should_flush && !std::thread::panicking() {
 					rt.flush_updates();
 				}
 			});
@@ -1131,6 +1208,7 @@ mod tests {
 				assert_eq!(derived.get(), 2);
 				batch(|| source.set(2));
 				assert_eq!(derived.get(), 4);
+				with_runtime(|runtime| runtime.flush_updates());
 				assert_eq!(*observed.borrow(), vec![0]);
 			});
 
@@ -1143,18 +1221,22 @@ mod tests {
 	}
 
 	#[rstest::rstest]
-	#[case::layout(EffectTiming::Layout)]
-	#[case::passive(EffectTiming::Passive)]
+	#[case::layout_next_batch(EffectTiming::Layout, true)]
+	#[case::passive_next_batch(EffectTiming::Passive, true)]
+	#[case::layout_next_notification(EffectTiming::Layout, false)]
+	#[case::passive_next_notification(EffectTiming::Passive, false)]
 	#[serial(reactive_runtime)]
 	fn batch_releases_effects_after_error_and_unwind(
 		reactive_scope: ReactiveScopeFixture,
 		#[case] timing: EffectTiming,
+		#[case] recover_with_batch: bool,
 	) {
 		use std::panic::{AssertUnwindSafe, catch_unwind};
 
 		reactive_scope.enter(|| {
 			// Arrange
 			let source = Signal::new(0);
+			let unrelated = Signal::new(0);
 			let observed = Rc::new(RefCell::new(Vec::new()));
 			let effect_observed = Rc::clone(&observed);
 			let _effect = Effect::new_with_timing(
@@ -1179,6 +1261,18 @@ mod tests {
 
 			// Assert
 			assert!(panic.is_err());
+			assert_eq!(*observed.borrow(), vec![0, 1]);
+			if recover_with_batch {
+				batch(|| ());
+			} else {
+				unrelated.set(1);
+				let expected = match timing {
+					EffectTiming::Layout => vec![0, 1, 2],
+					EffectTiming::Passive => vec![0, 1],
+				};
+				assert_eq!(*observed.borrow(), expected);
+				with_runtime(|runtime| runtime.flush_updates());
+			}
 			assert_eq!(*observed.borrow(), vec![0, 1, 2]);
 			source.set(3);
 			with_runtime(|runtime| runtime.flush_updates());
@@ -1187,9 +1281,276 @@ mod tests {
 	}
 
 	#[rstest::rstest]
+	#[case::layout_first(true, false)]
+	#[case::passive_first(false, false)]
+	#[case::passive_already_pending(false, true)]
 	#[serial(reactive_runtime)]
-	fn layout_effect_write_runs_in_next_notification_epoch() {
-		ReactiveScope::run(|| {
+	fn batch_flushes_layout_before_passive(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] layout_first: bool,
+		#[case] passive_already_pending: bool,
+	) {
+		reactive_scope.enter(|| {
+			// Arrange
+			let layout_source = Signal::new(0);
+			let passive_source = Signal::new(0);
+			let rendered = Rc::new(Cell::new(0));
+			let observed = Rc::new(RefCell::new(Vec::new()));
+			let passive_rendered = Rc::clone(&rendered);
+			let passive_observed = Rc::clone(&observed);
+			let _passive = Effect::new(move || {
+				let _ = passive_source.get();
+				passive_observed
+					.borrow_mut()
+					.push((EffectTiming::Passive, passive_rendered.get()));
+			});
+			let layout_observed = Rc::clone(&observed);
+			let _layout = Effect::new_with_timing(
+				move || {
+					let value = layout_source.get();
+					rendered.set(value);
+					layout_observed
+						.borrow_mut()
+						.push((EffectTiming::Layout, value));
+				},
+				EffectTiming::Layout,
+			);
+			observed.borrow_mut().clear();
+			if passive_already_pending {
+				passive_source.set(1);
+			}
+
+			// Act
+			batch(|| {
+				if layout_first {
+					layout_source.set(1);
+				}
+				if !passive_already_pending {
+					passive_source.set(1);
+				}
+				if !layout_first {
+					layout_source.set(1);
+				}
+				assert_eq!(*observed.borrow(), Vec::new());
+			});
+
+			// Assert
+			assert_eq!(
+				*observed.borrow(),
+				vec![(EffectTiming::Layout, 1), (EffectTiming::Passive, 1)]
+			);
+			with_runtime(|runtime| runtime.flush_updates());
+			assert_eq!(observed.borrow().len(), 2);
+		});
+	}
+
+	#[rstest::rstest]
+	#[case::constructor(false)]
+	#[case::hook_mode(true)]
+	#[serial(reactive_runtime)]
+	fn batch_keeps_explicit_memo_reads_current(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] use_mode: bool,
+		#[values(EffectTiming::Layout, EffectTiming::Passive)] timing: EffectTiming,
+	) {
+		reactive_scope.enter(|| {
+			// Arrange
+			let source = Signal::new(0);
+			let unlisted = Signal::new(10);
+			let computations = Rc::new(Cell::new(0));
+			let memo_computations = Rc::clone(&computations);
+			let compute = move || {
+				memo_computations.set(memo_computations.get() + 1);
+				source.get() + unlisted.get()
+			};
+			let memo = if use_mode {
+				Memo::new_with_mode(compute, crate::deps![source].into())
+			} else {
+				Memo::new_with_deps(compute, crate::deps![source].into_deps())
+			};
+			let derived = Memo::new(move || memo.get() * 2);
+			let observed = Rc::new(RefCell::new(Vec::new()));
+			let effect_observed = Rc::clone(&observed);
+			let _effect = Effect::new_with_timing(
+				move || effect_observed.borrow_mut().push(derived.get()),
+				timing,
+			);
+
+			// Act
+			batch(|| {
+				source.set(1);
+				assert_eq!(derived.get(), 22);
+				unlisted.set(20);
+				assert_eq!(memo.get(), 11);
+				batch(|| source.set(2));
+				assert_eq!(derived.get(), 44);
+				assert_eq!(*observed.borrow(), vec![20]);
+			});
+
+			// Assert
+			assert_eq!(*observed.borrow(), vec![20, 44]);
+			source.set(3);
+			with_runtime(|runtime| runtime.flush_updates());
+			assert_eq!(*observed.borrow(), vec![20, 44, 46]);
+			assert_eq!(computations.get(), 4);
+		});
+	}
+
+	#[rstest::rstest]
+	#[case::dispose_memo(true)]
+	#[case::drop_owner(false)]
+	#[serial(reactive_runtime)]
+	fn explicit_memo_dependencies_remain_owned_after_recomputation(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] dispose_memo: bool,
+	) {
+		reactive_scope.enter(|| {
+			// Arrange
+			let source = Signal::new(1);
+			let owner = ReactiveScope::new();
+			let memo = owner.enter(|| {
+				Memo::new_with_deps(move || source.get() * 2, crate::deps![source].into_deps())
+			});
+
+			// Act
+			for value in [2, 3] {
+				source.set(value);
+				assert_eq!(memo.get(), value * 2);
+				assert_eq!(
+					with_runtime(|runtime| runtime.subscriber_count(source.id())),
+					1
+				);
+			}
+			if dispose_memo {
+				memo.dispose();
+				assert_eq!(
+					with_runtime(|runtime| runtime.subscriber_count(source.id())),
+					0
+				);
+			}
+			drop(owner);
+			source.set(4);
+
+			// Assert
+			assert_eq!(
+				with_runtime(|runtime| runtime.subscriber_count(source.id())),
+				0
+			);
+			assert_eq!(
+				with_runtime(|runtime| runtime.debug_pending_updates()),
+				Vec::new()
+			);
+		});
+	}
+
+	#[cfg(native)]
+	#[rstest::rstest]
+	#[serial(reactive_runtime)]
+	fn panicking_batch_preserves_body_panic_and_pending_effects(
+		reactive_scope: ReactiveScopeFixture,
+	) {
+		use std::panic::{AssertUnwindSafe, catch_unwind};
+		const CHILD_ENV: &str = "REINHARDT_BATCH_PANIC_TEST_CHILD";
+		const CHILD_DONE: &str = "reinhardt batch panic recovery completed";
+
+		// Isolate the double-panic regression so an abort cannot kill the test suite.
+		if std::env::var_os(CHILD_ENV).is_none() {
+			let output =
+				std::process::Command::new(std::env::current_exe().expect("test executable"))
+					.args([
+						"--exact",
+						"reactive::runtime::tests::panicking_batch_preserves_body_panic_and_pending_effects",
+						"--nocapture",
+					])
+					.env(CHILD_ENV, "1")
+					.env("RUST_BACKTRACE", "0")
+					.output()
+					.expect("run isolated panic test");
+			assert_eq!(
+				output.status.code(),
+				Some(0),
+				"isolated panic test failed:\n{}\n{}",
+				String::from_utf8_lossy(&output.stdout),
+				String::from_utf8_lossy(&output.stderr),
+			);
+			assert_eq!(
+				String::from_utf8_lossy(&output.stdout)
+					.lines()
+					.filter(|line| *line == CHILD_DONE)
+					.count(),
+				1,
+				"the child must execute the recovery assertions"
+			);
+			return;
+		}
+
+		reactive_scope.enter(|| {
+			// Arrange
+			let source = Signal::new(0);
+			let secondary = Signal::new(0);
+			let observed = Rc::new(RefCell::new(Vec::new()));
+			let secondary_observed = Rc::new(RefCell::new(Vec::new()));
+			let panic_next = Rc::new(Cell::new(false));
+			let effect_panic = Rc::clone(&panic_next);
+			let effect_observed = Rc::clone(&observed);
+			let _panicking = Effect::new_with_timing(
+				move || {
+					effect_observed.borrow_mut().push(source.get());
+					assert!(!effect_panic.replace(false), "layout callback panic");
+				},
+				EffectTiming::Layout,
+			);
+			let effect_secondary = Rc::clone(&secondary_observed);
+			let _secondary = Effect::new_with_timing(
+				move || effect_secondary.borrow_mut().push(secondary.get()),
+				EffectTiming::Layout,
+			);
+			panic_next.set(true);
+
+			// Act
+			let panic = catch_unwind(AssertUnwindSafe(|| {
+				batch(|| {
+					source.set(1);
+					secondary.set(1);
+					panic!("batch body panic");
+				});
+			}));
+
+			// Assert
+			let panic = panic.expect_err("the original body panic must escape");
+			assert_eq!(panic.downcast_ref::<&str>(), Some(&"batch body panic"));
+			assert_eq!(*observed.borrow(), vec![0]);
+			assert_eq!(*secondary_observed.borrow(), vec![0]);
+			let callback_panic = catch_unwind(AssertUnwindSafe(|| batch(|| ())));
+			let callback_panic =
+				callback_panic.expect_err("normal flush must surface callback panic");
+			assert_eq!(
+				callback_panic.downcast_ref::<&str>(),
+				Some(&"layout callback panic")
+			);
+			batch(|| ());
+			assert_eq!(*observed.borrow(), vec![0, 1]);
+			assert_eq!(*secondary_observed.borrow(), vec![0, 1]);
+			source.set(2);
+			assert_eq!(*observed.borrow(), vec![0, 1, 2]);
+			with_runtime(|runtime| {
+				assert_eq!(*runtime.batch_depth.borrow(), 0);
+				assert_eq!(runtime.debug_pending_updates(), Vec::new());
+				assert_eq!(runtime.current_observer(), None);
+			});
+		});
+		println!("\n{CHILD_DONE}");
+	}
+
+	#[rstest::rstest]
+	#[case::immediate(false)]
+	#[case::batched(true)]
+	#[serial(reactive_runtime)]
+	fn layout_effect_write_runs_in_next_notification_epoch(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] batched: bool,
+	) {
+		reactive_scope.enter(|| {
 			let source = Signal::new(0_i32);
 			let runs = std::rc::Rc::new(std::cell::Cell::new(0_u8));
 			let observed = std::rc::Rc::new(std::cell::Cell::new(-1_i32));
@@ -1210,7 +1571,11 @@ mod tests {
 				EffectTiming::Layout,
 			);
 
-			source.set(1);
+			if batched {
+				batch(|| source.set(1));
+			} else {
+				source.set(1);
+			}
 
 			assert_eq!(source.get(), 2);
 			assert_eq!(observed.get(), 2);
@@ -1263,11 +1628,16 @@ mod tests {
 	}
 
 	#[rstest::rstest]
+	#[case::empty_next_batch(true)]
+	#[case::unrelated_notification(false)]
 	#[serial(reactive_runtime)]
-	fn consumer_write_before_panic_recovers_on_unrelated_notification() {
+	fn consumer_write_before_panic_recovers_pending_notification(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] recover_with_batch: bool,
+	) {
 		use std::panic::{AssertUnwindSafe, catch_unwind};
 
-		ReactiveScope::run(|| {
+		reactive_scope.enter(|| {
 			let secondary = Signal::new(0_i32);
 			let observed = std::rc::Rc::new(std::cell::Cell::new(0_i32));
 			let _secondary_effect = Effect::new_with_timing(
@@ -1299,19 +1669,28 @@ mod tests {
 			assert_eq!(secondary.get(), 1);
 			assert_eq!(observed.get(), 0);
 
-			unrelated.set(1);
+			if recover_with_batch {
+				batch(|| ());
+			} else {
+				unrelated.set(1);
+			}
 
 			assert_eq!(observed.get(), 1);
 		});
 	}
 
 	#[rstest::rstest]
+	#[case::immediate(false)]
+	#[case::batched(true)]
 	#[serial(reactive_runtime)]
-	fn non_converging_layout_updates_panic_and_runtime_remains_reusable() {
+	fn non_converging_layout_updates_panic_and_runtime_remains_reusable(
+		reactive_scope: ReactiveScopeFixture,
+		#[case] batched: bool,
+	) {
 		use std::panic::{AssertUnwindSafe, catch_unwind};
 		const EXPECTED_MAX_NOTIFICATION_EPOCHS: usize = 32;
 
-		ReactiveScope::run(|| {
+		reactive_scope.enter(|| {
 			let looping = Signal::new(0_u32);
 			let loop_enabled = std::rc::Rc::new(std::cell::Cell::new(false));
 			let runs = std::rc::Rc::new(std::cell::Cell::new(0_usize));
@@ -1342,7 +1721,13 @@ mod tests {
 			);
 			loop_enabled.set(true);
 
-			let result = catch_unwind(AssertUnwindSafe(|| looping.set(1)));
+			let result = catch_unwind(AssertUnwindSafe(|| {
+				if batched {
+					batch(|| looping.set(1));
+				} else {
+					looping.set(1);
+				}
+			}));
 			let panic = result.expect_err("non-converging notification must panic");
 			let message = panic
 				.downcast_ref::<String>()

--- a/crates/reinhardt-core/src/reactive/runtime.rs
+++ b/crates/reinhardt-core/src/reactive/runtime.rs
@@ -403,7 +403,11 @@ impl Runtime {
 			let layout_effects =
 				core::mem::take(&mut *self.notification_layout_effects.borrow_mut());
 			for effect_id in layout_effects {
-				super::effect::Effect::execute_effect(effect_id);
+				if *self.batch_depth.borrow() > 0 {
+					self.schedule_update(effect_id);
+				} else {
+					super::effect::Effect::execute_effect(effect_id);
+				}
 			}
 			let passive = core::mem::take(&mut *self.notification_passive.borrow_mut());
 			for node_id in passive {
@@ -627,8 +631,9 @@ where
 
 /// Execute multiple reactive writes as a single update cycle.
 ///
-/// Updates scheduled while the batch is active are queued, then flushed once
-/// the outermost batch exits. Nested batches share the same queue.
+/// Layout and passive effects are queued, then flushed once the outermost batch
+/// exits. Nested batches share the same queue. Memos are invalidated immediately
+/// so reads inside the batch observe the current signal values.
 pub fn batch<R>(f: impl FnOnce() -> R) -> R {
 	struct BatchGuard;
 
@@ -1075,6 +1080,80 @@ mod tests {
 		super::subscribe_node_to_observer(node, observer);
 		let subs2 = super::with_runtime(|rt| rt.debug_subscribers(node));
 		assert_eq!(subs2.len(), 1, "subscribe must be idempotent");
+	}
+
+	#[rstest::rstest]
+	#[case::layout(EffectTiming::Layout)]
+	#[case::passive(EffectTiming::Passive)]
+	#[serial(reactive_runtime)]
+	fn nested_batch_defers_effects_but_keeps_memo_reads_current(#[case] timing: EffectTiming) {
+		ReactiveScope::run(|| {
+			// Arrange
+			let source = Signal::new(0);
+			let derived = Memo::new(move || source.get() * 2);
+			let observed = Rc::new(RefCell::new(Vec::new()));
+			let effect_observed = Rc::clone(&observed);
+			let _effect = Effect::new_with_timing(
+				move || effect_observed.borrow_mut().push(derived.get()),
+				timing,
+			);
+
+			// Act
+			batch(|| {
+				source.set(1);
+				assert_eq!(derived.get(), 2);
+				batch(|| source.set(2));
+				assert_eq!(derived.get(), 4);
+				assert_eq!(*observed.borrow(), vec![0]);
+			});
+
+			// Assert
+			assert_eq!(*observed.borrow(), vec![0, 4]);
+			source.set(3);
+			with_runtime(|runtime| runtime.flush_updates());
+			assert_eq!(*observed.borrow(), vec![0, 4, 6]);
+		});
+	}
+
+	#[rstest::rstest]
+	#[case::layout(EffectTiming::Layout)]
+	#[case::passive(EffectTiming::Passive)]
+	#[serial(reactive_runtime)]
+	fn batch_releases_effects_after_error_and_unwind(#[case] timing: EffectTiming) {
+		use std::panic::{AssertUnwindSafe, catch_unwind};
+
+		ReactiveScope::run(|| {
+			// Arrange
+			let source = Signal::new(0);
+			let observed = Rc::new(RefCell::new(Vec::new()));
+			let effect_observed = Rc::clone(&observed);
+			let _effect = Effect::new_with_timing(
+				move || effect_observed.borrow_mut().push(source.get()),
+				timing,
+			);
+
+			// Act
+			let result: Result<(), &str> = batch(|| {
+				source.set(1);
+				assert_eq!(*observed.borrow(), vec![0]);
+				Err("rejected")
+			});
+			assert_eq!(result, Err("rejected"));
+			assert_eq!(*observed.borrow(), vec![0, 1]);
+			let panic = catch_unwind(AssertUnwindSafe(|| {
+				batch(|| {
+					source.set(2);
+					panic!("batch interrupted");
+				});
+			}));
+
+			// Assert
+			assert!(panic.is_err());
+			assert_eq!(*observed.borrow(), vec![0, 1, 2]);
+			source.set(3);
+			with_runtime(|runtime| runtime.flush_updates());
+			assert_eq!(*observed.borrow(), vec![0, 1, 2, 3]);
+		});
 	}
 
 	#[rstest::rstest]

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -336,6 +336,10 @@ reinhardt-macros = { workspace = true }
 chrono = { workspace = true }
 base64 = { workspace = true }
 
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+# Path-only dependency keeps browser fixtures outside release-plz publish ordering.
+reinhardt-test = { path = "../reinhardt-test", default-features = false, features = ["wasm"] }
+
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 reinhardt-forms = { workspace = true }

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -304,6 +304,8 @@ edits made before hydration. The adopted value also becomes the browser reset
 default, so a later form reset preserves the pre-hydration control state. Later
 signal changes update the control. Password bindings set only the live value
 property and never expose the secret through an SSR or DOM `value` attribute.
+Reevaluating an unchanged condition retains the mounted branch's reactive scope,
+so its callbacks and controlled values remain active until the branch is replaced.
 Hydration failures preserve their specific error variant, including control
 attachment errors.
 Resetting a connected password form clears its bound signal in a deferred

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -1600,6 +1600,12 @@ fn counter() -> View {
 | `ast` | AST processing support |
 | `web-sys-full` | All required web-sys features for WASM applications |
 
+## Testing
+
+Controlled-input browser regressions inject `rstest` fixtures for reactive scopes,
+DOM roots, and SSR state. Queries use `reinhardt-test` screens scoped to each root;
+fixture teardown releases mounted owners before disposing their reactive scope.
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -304,6 +304,8 @@ edits made before hydration. The adopted value also becomes the browser reset
 default, so a later form reset preserves the pre-hydration control state. Later
 signal changes update the control. Password bindings set only the live value
 property and never expose the secret through an SSR or DOM `value` attribute.
+Hydration failures preserve their specific error variant, including control
+attachment errors.
 Resetting a connected password form clears its bound signal in a deferred
 task, after the browser reset completes. Cancelled resets preserve the
 value, and unmounting a control cancels its queued reset reconciliation.

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -304,6 +304,8 @@ edits made before hydration. The adopted value also becomes the browser reset
 default, so a later form reset preserves the pre-hydration control state. Later
 signal changes update the control. Password bindings set only the live value
 property and never expose the secret through an SSR or DOM `value` attribute.
+If adopting a control changes a reactive branch condition, hydration reconciles
+that branch before returning and releases the replaced controls' listeners.
 Reevaluating an unchanged condition retains the mounted branch's reactive scope,
 so its callbacks and controlled values remain active until the branch is replaced.
 Hydration failures preserve their specific error variant, including control
@@ -330,7 +332,8 @@ value is normalized. See the
 for event ordering, IME, numeric-error, and low-level escape-hatch details.
 For `input[type=number]`, the binding combines `beforeinput` metadata with the
 browser value so parse errors retain incomplete editor states when their edit
-position is known. Only unmodified Arrow/Home/End keyboard moves are predicted;
+position is known, including validation-driven reactive remounts. Only unmodified
+Arrow/Home/End keyboard moves are predicted;
 modifier-key commands and already-canceled key events are treated as unknown. Browsers
 do not expose number-input selection ranges; after
 a pointer move followed immediately by sanitization, the error safely reports

--- a/crates/reinhardt-pages/src/component/reactive_if.rs
+++ b/crates/reinhardt-pages/src/component/reactive_if.rs
@@ -374,16 +374,21 @@ impl ReactiveIfNode {
 						}
 					}
 
-					let new_nodes = with_reactive_node_store(&branch_reactive_node_store, || {
-						// Generate the appropriate view
-						let view = if new_condition {
-							then_view()
-						} else {
-							else_view()
-						};
-
-						// Mount new nodes before the marker
-						mount_before_marker(&marker_clone, view)
+					let ScopedRender { view, scope } =
+						render_in_reactive_scope(&branch_reactive_node_store, || {
+							if new_condition {
+								then_view()
+							} else {
+								else_view()
+							}
+						});
+					let new_nodes = scope.enter(|| {
+						with_reactive_node_store(&branch_reactive_node_store, || {
+							mount_before_marker(&marker_clone, view)
+						})
+					});
+					with_reactive_node_store(&branch_reactive_node_store, || {
+						store_reactive_scope(scope)
 					});
 					*current_nodes_clone.borrow_mut() = new_nodes;
 				});
@@ -483,15 +488,22 @@ impl ReactiveIfNode {
 							}
 						}
 
-						let new_nodes =
-							with_reactive_node_store(&branch_reactive_node_store, || {
-								let view = if new_condition {
+						let ScopedRender { view, scope } =
+							render_in_reactive_scope(&branch_reactive_node_store, || {
+								if new_condition {
 									then_view()
 								} else {
 									else_view()
-								};
-								mount_before_marker(&marker_clone, view)
+								}
 							});
+						let new_nodes = scope.enter(|| {
+							with_reactive_node_store(&branch_reactive_node_store, || {
+								mount_before_marker(&marker_clone, view)
+							})
+						});
+						with_reactive_node_store(&branch_reactive_node_store, || {
+							store_reactive_scope(scope)
+						});
 						*current_nodes_clone.borrow_mut() = new_nodes;
 					});
 				};

--- a/crates/reinhardt-pages/src/hydration/runtime.rs
+++ b/crates/reinhardt-pages/src/hydration/runtime.rs
@@ -311,9 +311,7 @@ pub fn hydrate<C: Component>(component: &C, root: &Element) -> Result<(), Hydrat
 			})
 		});
 		let batch_result = document_head_manager.end_batch(false);
-		installation_result.map_err(|error| {
-			HydrationError::StateParseError(format!("Document-head installation failed: {error}"))
-		})?;
+		installation_result?;
 		batch_result.map_err(|error| {
 			HydrationError::StateParseError(format!("Document-head reconciliation failed: {error}"))
 		})?;

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -12,7 +12,8 @@ use reinhardt_pages::dom::Element;
 use reinhardt_pages::prelude::defer_yield;
 use reinhardt_pages::reactive::{ReactiveScope, Signal, with_runtime};
 use reinhardt_pages::{PageElement, page};
-use rstest::rstest;
+use reinhardt_test::wasm::Screen;
+use rstest::{fixture, rstest};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
@@ -22,6 +23,37 @@ wasm_bindgen_test_configure!(run_in_browser);
 struct SsrStateElement(web_sys::Element);
 
 struct AttachedRootCleanup(web_sys::Element);
+
+struct ControlFixture {
+	// Tear down mounted owners before their reactive scope is disposed.
+	root: AttachedRootCleanup,
+	scope: ReactiveScope,
+	screen: Screen,
+}
+
+#[fixture]
+fn controls() -> ControlFixture {
+	let document = web_sys::window()
+		.expect("window")
+		.document()
+		.expect("document");
+	let root = document.create_element("div").expect("root");
+	let screen = Screen::within(&root);
+	ControlFixture {
+		root: AttachedRootCleanup(root),
+		scope: ReactiveScope::new(),
+		screen,
+	}
+}
+
+#[fixture]
+fn ssr_state() -> SsrStateElement {
+	let document = web_sys::window()
+		.expect("window")
+		.document()
+		.expect("document");
+	SsrStateElement::install(&document)
+}
 
 struct HydratedControlPage(Page);
 
@@ -509,14 +541,13 @@ fn shared_range_removal_reconciles_only_live_surviving_controls(
 #[case(false)]
 #[case(true)]
 #[wasm_bindgen_test]
-fn reactive_multiple_reconciles_email_value_sanitization(#[case] nested_in_reactive_if: bool) {
-	ReactiveScope::run(|| {
+fn reactive_multiple_reconciles_email_value_sanitization(
+	controls: ControlFixture,
+	#[case] nested_in_reactive_if: bool,
+) {
+	controls.scope.enter(|| {
 		// Arrange
-		let document = web_sys::window()
-			.expect("window")
-			.document()
-			.expect("document");
-		let root = Element::new(document.create_element("div").expect("root"));
+		let root = Element::new(controls.root.0.clone());
 		let value = Signal::new("a@example.test,  b@example.test ".to_owned());
 		let multiple = Signal::new(false);
 		let reactive_multiple = multiple.clone();
@@ -537,10 +568,10 @@ fn reactive_multiple_reconciles_email_value_sanitization(#[case] nested_in_react
 			email()
 		};
 		page.mount(&root).expect("mount");
-		let input: web_sys::HtmlInputElement = root
-			.as_web_sys()
-			.first_element_child()
-			.expect("email")
+		let input: web_sys::HtmlInputElement = controls
+			.screen
+			.query_selector("input")
+			.get_only()
 			.unchecked_into();
 
 		// Act
@@ -550,7 +581,6 @@ fn reactive_multiple_reconciles_email_value_sanitization(#[case] nested_in_react
 		// Assert
 		assert_eq!(value.get(), "a@example.test,b@example.test");
 		assert_eq!(input.value(), "a@example.test,b@example.test");
-		reinhardt_pages::cleanup_reactive_nodes();
 	});
 }
 
@@ -2553,14 +2583,11 @@ fn number_binding_recovers_incomplete_raw_from_sanitized_browser_input() {
 	});
 }
 
+#[rstest]
 #[wasm_bindgen_test]
-fn rejected_number_raw_survives_an_error_driven_reactive_remount() {
-	ReactiveScope::run(|| {
-		let document = web_sys::window()
-			.expect("window")
-			.document()
-			.expect("document");
-		let root = Element::new(document.create_element("div").expect("root"));
+fn rejected_number_raw_survives_an_error_driven_reactive_remount(controls: ControlFixture) {
+	controls.scope.enter(|| {
+		let root = Element::new(controls.root.0.clone());
 		let value = Signal::new(7_i32);
 		let error = Signal::new(None::<NumberParseError>);
 		let render_value = value.clone();
@@ -2585,11 +2612,10 @@ fn rejected_number_raw_survives_an_error_driven_reactive_remount() {
 		})
 		.mount(&root)
 		.expect("mount");
-		let input: web_sys::HtmlInputElement = root
-			.as_web_sys()
+		let input: web_sys::HtmlInputElement = controls
+			.screen
 			.query_selector("input")
-			.expect("query")
-			.expect("input")
+			.get_only()
 			.unchecked_into();
 
 		dispatch_keydown(&input, "Home", false);
@@ -2601,16 +2627,15 @@ fn rejected_number_raw_survives_an_error_driven_reactive_remount() {
 		assert_eq!(value.get(), 7);
 		assert_eq!(error.get().expect("rejected number").raw(), "1e-");
 		assert!(
-			root.as_web_sys()
+			controls
+				.screen
 				.query_selector("#number-validation")
-				.expect("query")
-				.is_some()
+				.exists()
 		);
-		let replacement: web_sys::HtmlInputElement = root
-			.as_web_sys()
+		let replacement: web_sys::HtmlInputElement = controls
+			.screen
 			.query_selector("input")
-			.expect("query")
-			.expect("replacement")
+			.get_only()
 			.unchecked_into();
 		dispatch_before_input(&replacement, Some("0"), "insertText");
 		replacement.set_value("");
@@ -2618,7 +2643,6 @@ fn rejected_number_raw_survives_an_error_driven_reactive_remount() {
 
 		assert_eq!(value.get(), 1);
 		assert_eq!(error.get(), None);
-		reinhardt_pages::cleanup_reactive_nodes();
 	});
 }
 
@@ -2992,14 +3016,15 @@ impl Component for FailingHydrationRoot {
 	}
 }
 
+#[rstest]
 #[wasm_bindgen_test]
-fn failed_root_hydration_rolls_back_earlier_reactive_siblings() {
-	ReactiveScope::run(|| {
-		let document = web_sys::window()
-			.expect("window")
-			.document()
-			.expect("document");
-		let raw_root = document.create_element("div").expect("root");
+fn failed_root_hydration_rolls_back_earlier_reactive_siblings(
+	controls: ControlFixture,
+	#[from(ssr_state)] _state: SsrStateElement,
+) {
+	controls.scope.enter(|| {
+		let raw_root = controls.root.0.clone();
+		let document = raw_root.owner_document().expect("document");
 		let raw_button = document.create_element("button").expect("button");
 		raw_button.set_id("reactive-sibling");
 		raw_button.set_text_content(Some("ready"));
@@ -3012,7 +3037,6 @@ fn failed_root_hydration_rolls_back_earlier_reactive_siblings() {
 		let trigger = Signal::new(0_u32);
 		let render_count = Rc::new(Cell::new(0));
 		let listener_count = Rc::new(Cell::new(0));
-		let _state = SsrStateElement::install(&document);
 
 		let error = reinhardt_pages::hydration::hydrate(
 			&FailingHydrationRoot {
@@ -3629,14 +3653,15 @@ impl Component for HydratedReactiveIfInput {
 	}
 }
 
+#[rstest]
 #[wasm_bindgen_test]
-fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
-	ReactiveScope::run(|| {
-		let document = web_sys::window()
-			.expect("window")
-			.document()
-			.expect("document");
-		let raw_root = document.create_element("div").expect("root");
+fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards(
+	controls: ControlFixture,
+	#[from(ssr_state)] _state: SsrStateElement,
+) {
+	controls.scope.enter(|| {
+		let raw_root = controls.root.0.clone();
+		let document = raw_root.owner_document().expect("document");
 		let raw_input = document.create_element("input").expect("input");
 		raw_input.set_id("primary");
 		let primary: web_sys::HtmlInputElement = raw_input.clone().unchecked_into();
@@ -3646,7 +3671,6 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 		let alternate = Signal::new(false);
 		let value = Signal::new("server".to_owned());
 		let observed = Rc::new(RefCell::new(String::new()));
-		let _state = SsrStateElement::install(&document);
 
 		reinhardt_pages::hydration::hydrate(
 			&HydratedReactiveIfInput {
@@ -3659,10 +3683,10 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 		.expect("hydrate");
 		assert_eq!(value.get(), "restored");
 		// Adoption changes the condition, so hydration converges before returning.
-		let converged: web_sys::HtmlInputElement = root
-			.as_web_sys()
-			.first_element_child()
-			.expect("converged false branch")
+		let converged: web_sys::HtmlInputElement = controls
+			.screen
+			.query_selector("input")
+			.get_only()
 			.unchecked_into();
 		assert_eq!(converged.id(), "replacement");
 		assert!(!raw_input.is_same_node(Some(&converged)));
@@ -3674,10 +3698,10 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 		assert_eq!(&*observed.borrow(), "");
 
 		alternate.set(true);
-		let switched: web_sys::HtmlInputElement = root
-			.as_web_sys()
-			.first_element_child()
-			.expect("switched branch")
+		let switched: web_sys::HtmlInputElement = controls
+			.screen
+			.query_selector("input")
+			.get_only()
 			.unchecked_into();
 		assert_eq!(switched.id(), "primary");
 		converged.set_value("stale");
@@ -3696,7 +3720,6 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 			.expect("dispatch");
 		assert_eq!(value.get(), "new branch");
 		assert_eq!(&*observed.borrow(), "new branch");
-		reinhardt_pages::cleanup_reactive_nodes();
 	});
 }
 
@@ -3704,12 +3727,14 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 #[case::mount(false)]
 #[case::hydrate(true)]
 #[wasm_bindgen_test]
-fn reactive_if_preserves_owners_when_the_condition_stays_true(#[case] hydrate: bool) {
-	ReactiveScope::run(|| {
+fn reactive_if_preserves_owners_when_the_condition_stays_true(
+	controls: ControlFixture,
+	#[from(ssr_state)] _state: SsrStateElement,
+	#[case] hydrate: bool,
+) {
+	controls.scope.enter(|| {
 		// Arrange
-		let document = web_sys::window().unwrap().document().unwrap();
-		let container = document.create_element("div").unwrap();
-		let _cleanup = AttachedRootCleanup(container.clone());
+		let container = controls.root.0.clone();
 		let condition = Signal::new(0);
 		let value = Signal::new("initial".to_owned());
 		let observed = Signal::new(String::new());
@@ -3728,23 +3753,19 @@ fn reactive_if_preserves_owners_when_the_condition_stays_true(#[case] hydrate: b
 				|| Page::Empty,
 			))
 			.into_page();
-		let root = if hydrate {
+		if hydrate {
 			container.set_inner_html(&page.render_to_string());
 			let root = Element::new(container.first_element_child().unwrap());
-			let _state = SsrStateElement::install(&document);
 			reinhardt_pages::hydration::hydrate(&HydratedControlPage(page), &root).unwrap();
-			root
 		} else {
 			let root = Element::new(container);
 			page.mount(&root).unwrap();
-			root
-		};
+		}
 		condition.set(1);
-		let input: web_sys::HtmlInputElement = root
-			.as_web_sys()
+		let input: web_sys::HtmlInputElement = controls
+			.screen
 			.query_selector("input")
-			.unwrap()
-			.unwrap()
+			.get_only()
 			.unchecked_into();
 
 		// Act: the condition re-evaluates without replacing the branch.
@@ -3753,14 +3774,7 @@ fn reactive_if_preserves_owners_when_the_condition_stays_true(#[case] hydrate: b
 
 		// Assert
 		assert_eq!(input.value(), "updated");
-		assert!(
-			input.is_same_node(
-				root.as_web_sys()
-					.query_selector("input")
-					.unwrap()
-					.as_deref()
-			)
-		);
+		assert!(input.is_same_node(controls.screen.query_selector("input").query().as_deref()));
 		input.set_value("edited");
 		input
 			.dispatch_event(&web_sys::InputEvent::new("input").unwrap())

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -545,6 +545,7 @@ fn reactive_multiple_reconciles_email_value_sanitization(#[case] nested_in_react
 
 		// Act
 		multiple.set(true);
+		with_runtime(|runtime| runtime.flush_updates());
 
 		// Assert
 		assert_eq!(value.get(), "a@example.test,b@example.test");
@@ -3657,8 +3658,7 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 		)
 		.expect("hydrate");
 		assert_eq!(value.get(), "restored");
-		assert!(raw_input.is_same_node(root.as_web_sys().first_element_child().as_deref(),));
-		with_runtime(|runtime| runtime.flush_updates());
+		// Adoption changes the condition, so hydration converges before returning.
 		let converged: web_sys::HtmlInputElement = root
 			.as_web_sys()
 			.first_element_child()

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -3034,8 +3034,10 @@ fn failed_root_hydration_rolls_back_earlier_reactive_siblings() {
 			.count();
 
 		assert_eq!(
-			error.to_string(),
-			"Event attachment failed: checkbox control does not support a <select> element"
+			error,
+			reinhardt_pages::hydration::HydrationError::EventAttachmentFailed(
+				"checkbox control does not support a <select> element".to_owned()
+			)
 		);
 		assert_eq!(
 			(render_count.get(), listener_count.get(), marker_count),

--- a/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/controlled_input_binding_wasm_test.rs
@@ -3699,3 +3699,75 @@ fn hydrated_reactive_if_adopts_before_subscribing_and_transfers_guards() {
 		reinhardt_pages::cleanup_reactive_nodes();
 	});
 }
+
+#[rstest]
+#[case::mount(false)]
+#[case::hydrate(true)]
+#[wasm_bindgen_test]
+fn reactive_if_preserves_owners_when_the_condition_stays_true(#[case] hydrate: bool) {
+	ReactiveScope::run(|| {
+		// Arrange
+		let document = web_sys::window().unwrap().document().unwrap();
+		let container = document.create_element("div").unwrap();
+		let _cleanup = AttachedRootCleanup(container.clone());
+		let condition = Signal::new(0);
+		let value = Signal::new("initial".to_owned());
+		let observed = Signal::new(String::new());
+		let page = PageElement::new("div")
+			.child(Page::reactive_if(
+				move || condition.get() > 0,
+				move || {
+					page!({
+						input {
+							a11y: off,
+							bind: value,
+							@input: move |_| observed.set(value.get()),
+						}
+					})
+				},
+				|| Page::Empty,
+			))
+			.into_page();
+		let root = if hydrate {
+			container.set_inner_html(&page.render_to_string());
+			let root = Element::new(container.first_element_child().unwrap());
+			let _state = SsrStateElement::install(&document);
+			reinhardt_pages::hydration::hydrate(&HydratedControlPage(page), &root).unwrap();
+			root
+		} else {
+			let root = Element::new(container);
+			page.mount(&root).unwrap();
+			root
+		};
+		condition.set(1);
+		let input: web_sys::HtmlInputElement = root
+			.as_web_sys()
+			.query_selector("input")
+			.unwrap()
+			.unwrap()
+			.unchecked_into();
+
+		// Act: the condition re-evaluates without replacing the branch.
+		condition.set(2);
+		value.set("updated".to_owned());
+
+		// Assert
+		assert_eq!(input.value(), "updated");
+		assert!(
+			input.is_same_node(
+				root.as_web_sys()
+					.query_selector("input")
+					.unwrap()
+					.as_deref()
+			)
+		);
+		input.set_value("edited");
+		input
+			.dispatch_event(&web_sys::InputEvent::new("input").unwrap())
+			.unwrap();
+		assert_eq!(
+			(value.get(), observed.get()),
+			("edited".to_owned(), "edited".to_owned())
+		);
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/server_fn/fail/server_fn_multipart_alias.rs
+++ b/crates/reinhardt-pages/tests/ui/server_fn/fail/server_fn_multipart_alias.rs
@@ -2,8 +2,9 @@ use reinhardt_pages_macros::server_fn;
 
 type Avatar = reinhardt_core::parsers::UploadedFile;
 
+// Restricted visibility keeps optional MSW metadata out of this alias diagnostic.
 #[server_fn]
-async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
+pub(crate) async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
 	let _ = avatar;
 	Ok(())
 }

--- a/crates/reinhardt-pages/tests/ui/server_fn/fail/server_fn_multipart_alias.stderr
+++ b/crates/reinhardt-pages/tests/ui/server_fn/fail/server_fn_multipart_alias.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `UploadedFile: serde::Deserialize<'de>` is not satisfied
- --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:6:23
+ --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:7:34
   |
-6 | async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
-  |                       ^^^^^^ the trait `_serde::Deserialize<'_>` is not implemented for `UploadedFile`
+7 | pub(crate) async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
+  |                                  ^^^^^^ the trait `_serde::Deserialize<'_>` is not implemented for `UploadedFile`
   |
   = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `UploadedFile` type
   = note: for types from other crates check whether the crate offers a `serde` feature flag
@@ -26,10 +26,10 @@ note: required by a bound in `next_element`
   |            ^^^^^^^^^^^^^^^^ required by this bound in `SeqAccess::next_element`
 
 error[E0277]: the trait bound `UploadedFile: serde::Deserialize<'de>` is not satisfied
- --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:6:23
+ --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:7:34
   |
-6 | async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
-  |                       ^^^^^^ the trait `_serde::Deserialize<'_>` is not implemented for `UploadedFile`
+7 | pub(crate) async fn save(avatar: Avatar) -> Result<(), reinhardt_pages::server_fn::ServerFnError> {
+  |                                  ^^^^^^ the trait `_serde::Deserialize<'_>` is not implemented for `UploadedFile`
   |
   = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `UploadedFile` type
   = note: for types from other crates check whether the crate offers a `serde` feature flag
@@ -53,9 +53,9 @@ note: required by a bound in `next_value`
   |            ^^^^^^^^^^^^^^^^ required by this bound in `MapAccess::next_value`
 
 error[E0277]: the trait bound `UploadedFile: serde::Deserialize<'de>` is not satisfied
- --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:5:1
+ --> tests/ui/server_fn/fail/server_fn_multipart_alias.rs:6:1
   |
-5 | #[server_fn]
+6 | #[server_fn]
   | ^^^^^^^^^^^^ the trait `_serde::Deserialize<'_>` is not implemented for `UploadedFile`
   |
   = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `UploadedFile` type

--- a/deny.toml
+++ b/deny.toml
@@ -84,7 +84,7 @@ skip = [
   { crate = "getrandom@0.2.17", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "getrandom@0.3.4", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "hashbrown@0.16.1", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
-  { crate = "hashlink@0.12.1", reason = "evcxr 0.22.0 salsa 0.28 (issue #5825)" },
+  { crate = "hashlink:>=0.12,<0.13", reason = "evcxr 0.22.0 uses salsa's 0.12 API while SQLx requires the incompatible 0.10 line (issue #5825); allow compatible patch updates." },
   { crate = "icu_collections@1.5.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "icu_provider@1.5.0", reason = "Duplicate line retained by upstream dependency constraints in the full feature graph." },
   { crate = "inout@0.1.4", reason = "The full feature graph retains inout 0.1.4 and 0.2.2 through incompatible transitive dependency requirements; tracked in issue #5665." },


### PR DESCRIPTION
## Summary

Restore regression checks on `develop/0.4.0` and fix reactive control lifetimes:

- Defer layout effects inside `batch`, flush them before passive effects through notification epochs, and keep both automatic and explicit-dependency memo reads current.
- Retain reactive branch owners when the condition re-evaluates without changing, and preserve specific hydration errors.
- Preserve queued work and the original panic during unwinding; recover pending callbacks at the next normal batch, signal notification, or flush.
- Compose command, audit, Core, and browser regression setup from `reinhardt-test` helpers and injected `rstest` fixtures, with RAII teardown.
- Isolate each audit-test backend's SQLite database while preserving sharing within its connection pool.
- Restore command tests' working directory and environment variables, stabilize compile-fail fixtures across dependency and MSW feature changes, and allow compatible `hashlink` 0.12 patch releases in the existing duplicate-dependency exception.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The controlled-input browser suite reproduced five failures on the unchanged base. Layout effects ran before batched control state settled, hydration replaced specific errors with a generic state error, and two assertions expected outdated scheduling. A further regression test exposed branch-owned callbacks and bindings being disposed when an unchanged condition was re-evaluated.

Command tests also left the process inside deleted temporary directories and raced over shared environment variables. Injected `reinhardt-test` resources now restore prior values on scope exit and unwind, including non-Unicode environment values. Tests that can use absolute paths no longer change the process working directory.

The wider workspace run also exposed audit tests sharing a fixed SQLite database name. Each async backend fixture now receives a unique name through `reinhardt_test::fixtures::random_test_key`. The event test verifies a second live backend remains empty, and initialization holds two live connections to prove sharing within one pool.

Batching also needs to preserve notification semantics: deferred layout callbacks now run in the existing epoch machinery, including self-notifications. Explicit dependencies subscribe to the memo node directly, so invalidation does not wait for a layout callback. Panic unwinding retains queued work without executing user callbacks; callback panics preserve the remaining work for recovery.

Dependency refreshes changed the model macro fixture's compiler suggestions without changing its expected error. The upload-alias fixture also captured extra MSW metadata errors under all features; restricted visibility now isolates its upload-alias rejection diagnostic. Dependency refreshes moved `hashlink` from 0.12.1 to 0.12.2; SQLx still requires the incompatible 0.10 line, so the existing exception now accepts only compatible 0.12 patches.

## How Was This Tested?

Final scheduler regression coverage:

- `cargo test -p reinhardt-core --no-default-features --features reactive --lib reactive:: -- --test-threads=4` — 112 passed. Coverage includes layout/passive ordering, explicit and chained memo invalidation, subscription cleanup, batched self-notifications, cycle limits, and panic recovery. Before the scheduler repair, the runtime harness reproduced 12 failures; the double-panic abort was isolated in a subprocess. A further focused check reproduced the recovery-only queue being skipped by an empty batch.
- Chrome 152: `cargo test -p reinhardt-pages --target wasm32-unknown-unknown --features testing,chrono --test controlled_input_binding_wasm_test` — all 85 browser cases passed again after the scheduler repair.
- `cargo clippy -p reinhardt-core --all-features --lib -- -D warnings` and `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-core --all-features --no-deps` — passed.
- `cargo make clippy-check` and `cargo make fmt-check` — passed on the final source; 3,800 files unchanged with zero formatting errors.

Fixture conversion verification:

- Default-feature command suites with eight test threads — 62 + 63 passed. This includes an initially absent settings variable, repeated nested writes during unwinding, non-Unicode restoration, and working-directory teardown.
- `cargo test -p reinhardt-conf --all-features --lib -- --test-threads=8` — 351 passed, two ignored, including separate backend isolation and two-connection pool sharing.
- `cargo deny --workspace --all-features check all` — advisories, bans, licenses, and sources passed after the path-only test dependency changes.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-commands -p reinhardt-conf -p reinhardt-core -p reinhardt-pages --all-features --no-deps` — passed; the full formatter and normal workspace Clippy also passed after fixture conversion.

Earlier validation of the underlying fixes passed full workspace check/build, 37 model compile-fail fixtures, nine all-feature Pages server-function compile-fail fixtures, and 28 browser control-binding unit tests. The unchanged browser base reproduced five failures.

Full `cargo test --workspace --all --all-features` compiled the workspace and completed 1,841 tests successfully before it was interrupted to address the separately reproduced audit-fixture failure. The corrected configuration library then passed all 351 active tests. The remaining workspace suites have not completed; neither fixture conversion nor the scheduler repair repeats that full sweep.

Additional Clippy scopes remain blocked by existing lints in unchanged code. Package-only command test checks hit admin partial-feature unused items in `server/form.rs`, `server/inline_edit.rs`, and `server/multipart.rs`. Selecting those test binaries with the full workspace exposed `large_enum_variant` in `reinhardt-core/macros/src/injectable_common.rs` and `model_derive.rs`. The earlier configuration test-target check also reported four boolean comparisons in the secrets tests and a literal `unwrap_err()` in `tests/composable/sanity.rs`. The normal workspace library Clippy gate remains the required check.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Affected regression tests pass locally with my changes
- [ ] Full workspace tests pass locally with my changes (remaining suites have not completed)
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have formatted the code with the repository formatter and passed `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- Refs #5825 for the existing `evcxr` / `salsa` dependency exception.

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `forms` - Form handling, validation, rendering
- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

Maintainer triage.

---

**Additional Context:**

No public API signatures change. The historical coverage job failed because its runner exhausted disk space; this PR does not claim to repair that infrastructure failure.

🤖 Generated with [Codex](https://openai.com/codex)

Co-Authored-By: GPT-6 <noreply@openai.com>
