### PR TITLE
fix: restore dependency audit and isolate regression tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -649,7 +649,7 @@ base64 = "0.22"
 
 # Template engine & syntax highlighting
 tera = { version = "1.20.1" }
-syntect = "5.3.0-rc.1-rc.1"
+syntect = { version = "5.3.0-rc.1-rc.1", default-features = false, features = ["default-syntaxes", "default-themes", "html", "regex-onig"] }
 
 # Proc macro dependencies
 syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }

--- a/crates/reinhardt-commands/Cargo.toml
+++ b/crates/reinhardt-commands/Cargo.toml
@@ -82,6 +82,7 @@ url = { workspace = true }
 nix = { version = "0.29", features = ["signal"] }
 
 [dev-dependencies]
+reinhardt-test = { path = "../reinhardt-test" }
 insta = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = "3.13"

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -585,10 +585,12 @@ Run the admin script regression suites with the default parallel test runner:
 cargo test -p reinhardt-commands --test admin_scripts_tests --test admin_scripts_additional_tests
 ```
 
-Tests that change the process working directory share the `current_dir` serial
-group. Their fixture restores the original directory before removing temporary
-files, including during unwinding. Environment-variable tests share the
-`reinhardt_settings` group and restore the previous values on scope exit.
+Admin script tests receive `rstest` fixtures composed from `reinhardt-test`'s
+`temp_dir`, `TestResource`, and `TeardownGuard` helpers. Tests that change the
+process working directory share the `current_dir` serial group; their fixture
+restores the original directory before removing temporary files, including during
+unwinding. Environment-variable fixtures share the `reinhardt_settings` group and
+restore previous values on scope exit, preserving non-Unicode values as well.
 
 ## License
 

--- a/crates/reinhardt-commands/README.md
+++ b/crates/reinhardt-commands/README.md
@@ -577,6 +577,19 @@ reinhardt-admin startproject myproject
 
 **Precedence:** `--template` > `--template-dir` CLI flag > `REINHARDT_TEMPLATE_DIR` env > embedded defaults.
 
+## Testing
+
+Run the admin script regression suites with the default parallel test runner:
+
+```bash
+cargo test -p reinhardt-commands --test admin_scripts_tests --test admin_scripts_additional_tests
+```
+
+Tests that change the process working directory share the `current_dir` serial
+group. Their fixture restores the original directory before removing temporary
+files, including during unwinding. Environment-variable tests share the
+`reinhardt_settings` group and restore the previous values on scope exit.
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
@@ -3,9 +3,14 @@
 //! Continuation of comprehensive test suite for reinhardt-admin
 //! This file contains the remaining test cases from Django's admin_scripts tests
 
+#[path = "support/environment.rs"]
+mod environment;
+
+use environment::EnvVarGuard;
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartProjectCommand,
 };
+use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -46,7 +51,6 @@ impl TestEnvironment {
 #[tokio::test]
 async fn test_manage_multiple_builtin_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "pub const DEBUG: bool = true;\n");
 	env.create_file("settings2.rs", "pub const DEBUG: bool = false;\n");
@@ -58,7 +62,6 @@ async fn test_manage_multiple_builtin_command() {
 #[tokio::test]
 async fn test_manage_multiple_builtin_with_settings() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "// Settings 1\n");
 	env.create_file("settings2.rs", "// Settings 2\n");
@@ -68,21 +71,37 @@ async fn test_manage_multiple_builtin_with_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "settings1");
+	// Arrange
+	let original = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+	{
+		let mut env_guard = EnvVarGuard::new();
+		env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
+
+		// Act
+		let result = std::panic::catch_unwind(|| {
+			let mut nested_guard = EnvVarGuard::new();
+			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
+			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
+			panic!("exercise environment restoration during unwinding");
+		});
+
+		// Assert
+		assert!(result.is_err());
+		assert_eq!(
+			std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
+			"settings1"
+		);
 	}
-	assert_eq!(
-		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
-		"settings1"
-	);
+	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), original);
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_bad_settings() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "bad_settings");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad_settings");
 	assert_eq!(
 		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
 		"bad_settings"
@@ -90,32 +109,30 @@ async fn test_manage_multiple_builtin_with_bad_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_builtin_with_bad_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 	assert_eq!(std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(), "");
 }
 
 #[tokio::test]
 async fn test_manage_multiple_custom_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 	assert!(env.path().exists());
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_custom_command_with_settings() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings1.rs", "pub const DB: &str = \"db1\";\n");
 	env.create_file("settings2.rs", "pub const DB: &str = \"db2\";\n");
 
 	// Test with explicit settings parameter
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "settings1");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
 
 	assert!(env.file_exists("settings1.rs"));
 	assert!(env.file_exists("settings2.rs"));
@@ -126,11 +143,11 @@ async fn test_manage_multiple_custom_command_with_settings() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_multiple_custom_command_with_environment() {
-	unsafe {
-		std::env::set_var("REINHARDT_SETTINGS_MODULE", "custom.settings");
-		std::env::set_var("CUSTOM_ENV_VAR", "test_value");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "custom.settings");
+	env_guard.set("CUSTOM_ENV_VAR", "test_value");
 
 	// Test that environment variables are respected
 	assert_eq!(
@@ -147,7 +164,6 @@ async fn test_manage_multiple_custom_command_with_environment() {
 #[tokio::test]
 async fn test_manage_check_broken_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create broken app structure
 	env.create_file("apps/broken/mod.rs", "// Broken syntax");
@@ -157,7 +173,6 @@ async fn test_manage_check_broken_app() {
 #[tokio::test]
 async fn test_manage_check_complex_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -177,7 +192,6 @@ async fn test_manage_check_complex_app() {
 #[tokio::test]
 async fn test_manage_check_app_with_import() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -194,7 +208,6 @@ async fn test_manage_check_app_with_import() {
 #[tokio::test]
 async fn test_manage_check_warning_does_not_halt() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -229,7 +242,6 @@ async fn test_manage_runserver_zero_ip_addr() {
 #[tokio::test]
 async fn test_manage_runserver_on_bind() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -294,7 +306,6 @@ async fn test_manage_runserver_runner_ambiguous() {
 #[tokio::test]
 async fn test_manage_runserver_no_database() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -308,7 +319,6 @@ async fn test_manage_runserver_no_database() {
 #[tokio::test]
 async fn test_manage_runserver_readonly_database() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -340,7 +350,6 @@ async fn test_manage_runserver_custom_system_checks() {
 #[tokio::test]
 async fn test_manage_runserver_migration_warning_one_app() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -355,7 +364,6 @@ async fn test_manage_runserver_migration_warning_one_app() {
 #[tokio::test]
 async fn test_manage_runserver_migration_warning_multiple_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"Cargo.toml",
@@ -370,10 +378,10 @@ async fn test_manage_runserver_migration_warning_multiple_apps() {
 }
 
 #[tokio::test]
+#[serial(reinhardt_settings)]
 async fn test_manage_runserver_empty_allowed_hosts_error() {
-	unsafe {
-		std::env::set_var("ALLOWED_HOSTS", "");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("ALLOWED_HOSTS", "");
 
 	// Empty ALLOWED_HOSTS in production should error
 	assert_eq!(std::env::var("ALLOWED_HOSTS").unwrap(), "");
@@ -604,7 +612,6 @@ async fn test_commandtypes_base_command_no_label() {
 #[tokio::test]
 async fn test_commandtypes_app_command() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create app structure
 	env.create_file("apps/testapp/mod.rs", "// Test app\n");
@@ -614,7 +621,6 @@ async fn test_commandtypes_app_command() {
 #[tokio::test]
 async fn test_commandtypes_app_command_no_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test app command with no apps
 	assert!(env.path().exists());
@@ -623,7 +629,6 @@ async fn test_commandtypes_app_command_no_apps() {
 #[tokio::test]
 async fn test_commandtypes_app_command_multiple_apps() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("apps/app1/mod.rs", "// App 1\n");
 	env.create_file("apps/app2/mod.rs", "// App 2\n");
@@ -639,7 +644,6 @@ async fn test_commandtypes_app_command_multiple_apps() {
 #[tokio::test]
 async fn test_discovery_precedence() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test command discovery precedence
 	env.create_file("commands/custom.rs", "// Custom command\n");
@@ -684,7 +688,6 @@ async fn test_argumentorder_setting_then_option() {
 #[tokio::test]
 async fn test_diffsettings_basic() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file("settings.rs", "pub const DEBUG: bool = true;\n");
 	// Test basic diff settings
@@ -694,7 +697,6 @@ async fn test_diffsettings_basic() {
 #[tokio::test]
 async fn test_diffsettings_settings_configured() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	env.create_file(
 		"settings.rs",
@@ -711,7 +713,6 @@ async fn test_diffsettings_settings_configured() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_non_python_files_not_formatted() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test that non-Rust files are not template-formatted
 	assert!(env.path().exists());
@@ -720,9 +721,14 @@ async fn test_startproject_custom_project_template_non_python_files_not_formatte
 #[tokio::test]
 async fn test_startproject_template_dir_with_trailing_slash() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
-	let mut ctx = CommandContext::new(vec!["testproject".to_string()]);
+	let mut ctx = CommandContext::new(vec![
+		"testproject".to_owned(),
+		env.path()
+			.join("testproject")
+			.to_string_lossy()
+			.into_owned(),
+	]);
 	ctx.set_option("template".to_string(), "/path/to/template/".to_string());
 
 	let cmd = StartProjectCommand;
@@ -750,7 +756,6 @@ async fn test_startproject_template_dir_with_trailing_slash() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_with_non_ascii_templates() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test with non-ASCII template content
 	assert!(env.path().exists());
@@ -759,7 +764,6 @@ async fn test_startproject_custom_project_template_with_non_ascii_templates() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_hidden_directory_default_excluded() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test that hidden directories are excluded by default
 	assert!(env.path().exists());
@@ -768,7 +772,6 @@ async fn test_startproject_custom_project_template_hidden_directory_default_excl
 #[tokio::test]
 async fn test_startproject_custom_project_template_hidden_directory_included() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test including hidden directories
 	assert!(env.path().exists());
@@ -777,7 +780,6 @@ async fn test_startproject_custom_project_template_hidden_directory_included() {
 #[tokio::test]
 async fn test_startproject_custom_project_template_exclude_directory() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test excluding specific directories
 	assert!(env.path().exists());
@@ -786,7 +788,6 @@ async fn test_startproject_custom_project_template_exclude_directory() {
 #[tokio::test]
 async fn test_startproject_failure_to_format_code() {
 	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test handling of code formatting failures
 	assert!(env.path().exists());

--- a/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_additional_tests.rs
@@ -6,10 +6,13 @@
 #[path = "support/environment.rs"]
 mod environment;
 
-use environment::EnvVarGuard;
+use environment::{EnvVars, env_vars};
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartProjectCommand,
 };
+use reinhardt_test::TeardownGuard;
+use reinhardt_test::fixtures::temp_dir;
+use rstest::{fixture, rstest};
 use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
@@ -20,13 +23,12 @@ struct TestEnvironment {
 	temp_dir: TempDir,
 }
 
-impl TestEnvironment {
-	fn new() -> Self {
-		Self {
-			temp_dir: TempDir::new().expect("Failed to create temp directory"),
-		}
-	}
+#[fixture]
+fn test_env(temp_dir: TempDir) -> TestEnvironment {
+	TestEnvironment { temp_dir }
+}
 
+impl TestEnvironment {
 	fn path(&self) -> PathBuf {
 		self.temp_dir.path().to_path_buf()
 	}
@@ -48,10 +50,9 @@ impl TestEnvironment {
 // ManageMultipleSettings Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_builtin_command() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_builtin_command(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings1.rs", "pub const DEBUG: bool = true;\n");
 	env.create_file("settings2.rs", "pub const DEBUG: bool = false;\n");
 
@@ -59,10 +60,9 @@ async fn test_manage_multiple_builtin_command() {
 	assert!(env.file_exists("settings2.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_builtin_with_settings() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_builtin_with_settings(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings1.rs", "// Settings 1\n");
 	env.create_file("settings2.rs", "// Settings 2\n");
 
@@ -70,37 +70,51 @@ async fn test_manage_multiple_builtin_with_settings() {
 	assert!(env.file_exists("settings2.rs"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_environment() {
+async fn test_manage_multiple_builtin_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+	#[from(env_vars)] mut nested_guard: TeardownGuard<EnvVars>,
+) {
 	// Arrange
 	let original = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
+	assert_eq!(
+		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
+		"settings1"
+	);
+
+	#[cfg(unix)]
 	{
-		let mut env_guard = EnvVarGuard::new();
-		env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
-
-		// Act
-		let result = std::panic::catch_unwind(|| {
-			let mut nested_guard = EnvVarGuard::new();
-			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
-			nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
-			panic!("exercise environment restoration during unwinding");
-		});
-
-		// Assert
-		assert!(result.is_err());
-		assert_eq!(
-			std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
-			"settings1"
+		use std::os::unix::ffi::OsStringExt;
+		env_guard.set(
+			"REINHARDT_SETTINGS_MODULE",
+			std::ffi::OsString::from_vec(vec![b's', 0xff]),
 		);
 	}
+	let before_unwind = std::env::var_os("REINHARDT_SETTINGS_MODULE");
+
+	// Act
+	let result = std::panic::catch_unwind(move || {
+		nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings2");
+		nested_guard.set("REINHARDT_SETTINGS_MODULE", "settings3");
+		panic!("exercise environment restoration during unwinding");
+	});
+
+	// Assert
+	assert!(result.is_err());
+	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), before_unwind);
+	drop(env_guard);
 	assert_eq!(std::env::var_os("REINHARDT_SETTINGS_MODULE"), original);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_bad_settings() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_builtin_with_bad_settings(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad_settings");
 	assert_eq!(
 		std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(),
@@ -108,30 +122,33 @@ async fn test_manage_multiple_builtin_with_bad_settings() {
 	);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_builtin_with_bad_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 	assert_eq!(std::env::var("REINHARDT_SETTINGS_MODULE").unwrap(), "");
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_multiple_custom_command() {
-	let env = TestEnvironment::new();
+async fn test_manage_multiple_custom_command(#[from(test_env)] env: TestEnvironment) {
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_custom_command_with_settings() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_multiple_custom_command_with_settings(
+	#[from(test_env)] env: TestEnvironment,
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env.create_file("settings1.rs", "pub const DB: &str = \"db1\";\n");
 	env.create_file("settings2.rs", "pub const DB: &str = \"db2\";\n");
 
 	// Test with explicit settings parameter
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "settings1");
 
 	assert!(env.file_exists("settings1.rs"));
@@ -142,10 +159,12 @@ async fn test_manage_multiple_custom_command_with_settings() {
 	);
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_multiple_custom_command_with_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_multiple_custom_command_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "custom.settings");
 	env_guard.set("CUSTOM_ENV_VAR", "test_value");
 
@@ -161,19 +180,17 @@ async fn test_manage_multiple_custom_command_with_environment() {
 // ManageCheck Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_broken_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_broken_app(#[from(test_env)] env: TestEnvironment) {
 	// Create broken app structure
 	env.create_file("apps/broken/mod.rs", "// Broken syntax");
 	assert!(env.file_exists("apps/broken/mod.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_complex_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_complex_app(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -189,10 +206,9 @@ async fn test_manage_check_complex_app() {
 	// Complex app structure for testing check command
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_app_with_import() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_app_with_import(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -205,10 +221,9 @@ async fn test_manage_check_app_with_import() {
 	// App with import issues for testing check command
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_check_warning_does_not_halt() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_check_warning_does_not_halt(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -239,10 +254,9 @@ async fn test_manage_runserver_zero_ip_addr() {
 	assert_eq!(ctx.arg(0), Some(&"0.0.0.0:8000".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_on_bind() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_on_bind(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -303,10 +317,9 @@ async fn test_manage_runserver_runner_ambiguous() {
 	assert_eq!(ctx.arg(0), Some(&"8000".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_no_database() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_no_database(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -316,10 +329,9 @@ async fn test_manage_runserver_no_database() {
 	assert!(env.file_exists("Cargo.toml"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_readonly_database() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_readonly_database(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -347,10 +359,9 @@ async fn test_manage_runserver_custom_system_checks() {
 	assert_eq!(ctx.option("check"), Some(&"custom.checks".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_migration_warning_one_app() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_migration_warning_one_app(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -361,10 +372,11 @@ async fn test_manage_runserver_migration_warning_one_app() {
 	assert!(env.file_exists("apps/myapp/migrations/001_initial.sql"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_manage_runserver_migration_warning_multiple_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_manage_runserver_migration_warning_multiple_apps(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	env.create_file(
 		"Cargo.toml",
 		"[package]\nname = \"test\"\nversion = \"0.1.0\"",
@@ -377,10 +389,12 @@ async fn test_manage_runserver_migration_warning_multiple_apps() {
 	assert!(env.file_exists("apps/app2/migrations/001.sql"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_manage_runserver_empty_allowed_hosts_error() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_manage_runserver_empty_allowed_hosts_error(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("ALLOWED_HOSTS", "");
 
 	// Empty ALLOWED_HOSTS in production should error
@@ -609,27 +623,24 @@ async fn test_commandtypes_base_command_no_label() {
 // CommandTypes Tests - App Commands
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command(#[from(test_env)] env: TestEnvironment) {
 	// Create app structure
 	env.create_file("apps/testapp/mod.rs", "// Test app\n");
 	assert!(env.file_exists("apps/testapp/mod.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command_no_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command_no_apps(#[from(test_env)] env: TestEnvironment) {
 	// Test app command with no apps
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_commandtypes_app_command_multiple_apps() {
-	let env = TestEnvironment::new();
-
+async fn test_commandtypes_app_command_multiple_apps(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("apps/app1/mod.rs", "// App 1\n");
 	env.create_file("apps/app2/mod.rs", "// App 2\n");
 
@@ -641,10 +652,9 @@ async fn test_commandtypes_app_command_multiple_apps() {
 // Discovery Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_discovery_precedence() {
-	let env = TestEnvironment::new();
-
+async fn test_discovery_precedence(#[from(test_env)] env: TestEnvironment) {
 	// Test command discovery precedence
 	env.create_file("commands/custom.rs", "// Custom command\n");
 	assert!(env.file_exists("commands/custom.rs"));
@@ -685,19 +695,17 @@ async fn test_argumentorder_setting_then_option() {
 // DiffSettings Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_diffsettings_basic() {
-	let env = TestEnvironment::new();
-
+async fn test_diffsettings_basic(#[from(test_env)] env: TestEnvironment) {
 	env.create_file("settings.rs", "pub const DEBUG: bool = true;\n");
 	// Test basic diff settings
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_diffsettings_settings_configured() {
-	let env = TestEnvironment::new();
-
+async fn test_diffsettings_settings_configured(#[from(test_env)] env: TestEnvironment) {
 	env.create_file(
 		"settings.rs",
 		"pub const DEBUG: bool = true;\npub const SECRET_KEY: &str = \"test\";\n",
@@ -710,18 +718,20 @@ async fn test_diffsettings_settings_configured() {
 // Additional StartProject Tests
 // ============================================================================
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_non_python_files_not_formatted() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_non_python_files_not_formatted(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test that non-Rust files are not template-formatted
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_template_dir_with_trailing_slash() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_template_dir_with_trailing_slash(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	let mut ctx = CommandContext::new(vec![
 		"testproject".to_owned(),
 		env.path()
@@ -753,42 +763,45 @@ async fn test_startproject_template_dir_with_trailing_slash() {
 // Removed empty test: test_startproject_project_template_tarball_url
 // This test was empty and will be implemented when needed
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_with_non_ascii_templates() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_with_non_ascii_templates(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test with non-ASCII template content
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_hidden_directory_default_excluded() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_hidden_directory_default_excluded(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test that hidden directories are excluded by default
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_hidden_directory_included() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_hidden_directory_included(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test including hidden directories
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_custom_project_template_exclude_directory() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_custom_project_template_exclude_directory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Test excluding specific directories
 	assert!(env.path().exists());
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_startproject_failure_to_format_code() {
-	let env = TestEnvironment::new();
-
+async fn test_startproject_failure_to_format_code(#[from(test_env)] env: TestEnvironment) {
 	// Test handling of code formatting failures
 	assert!(env.path().exists());
 }

--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -5,6 +5,10 @@
 //!
 //! Reference: <https://github.com/django/django/blob/main/tests/admin_scripts/tests.py>
 
+#[path = "support/environment.rs"]
+mod environment;
+
+use environment::EnvVarGuard;
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartAppCommand, StartProjectCommand,
 };
@@ -15,12 +19,9 @@ use tempfile::TempDir;
 
 /// Helper struct for setting up test environments
 struct TestEnvironment {
+	// Restore the working directory before the temporary directory is removed.
+	_cwd: CurrentDirGuard,
 	temp_dir: TempDir,
-}
-
-/// RAII guard for environment variables - automatically cleans up on drop
-struct EnvVarGuard {
-	vars: Vec<String>,
 }
 
 struct CurrentDirGuard {
@@ -41,32 +42,12 @@ impl Drop for CurrentDirGuard {
 	}
 }
 
-impl EnvVarGuard {
-	fn new() -> Self {
-		Self { vars: Vec::new() }
-	}
-
-	fn set(&mut self, key: &str, value: &str) {
-		unsafe {
-			std::env::set_var(key, value);
-		}
-		self.vars.push(key.to_string());
-	}
-}
-
-impl Drop for EnvVarGuard {
-	fn drop(&mut self) {
-		for key in &self.vars {
-			unsafe {
-				std::env::remove_var(key);
-			}
-		}
-	}
-}
-
 impl TestEnvironment {
 	fn new() -> Self {
 		Self {
+			_cwd: CurrentDirGuard {
+				original: std::env::current_dir().expect("read current directory"),
+			},
 			temp_dir: TempDir::new().expect("Failed to create temp directory"),
 		}
 	}
@@ -96,7 +77,7 @@ impl TestEnvironment {
 // StartProject Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_creates_project_structure() {
 	let env = TestEnvironment::new();
@@ -117,7 +98,7 @@ async fn test_startproject_creates_project_structure() {
 	assert!(env.file_exists(&format!("{}/src/bin/manage.rs", project_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_with_custom_directory() {
 	let env = TestEnvironment::new();
@@ -136,7 +117,7 @@ async fn test_startproject_with_custom_directory() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", custom_dir)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_missing_name() {
 	let ctx = CommandContext::new(vec![]);
@@ -152,7 +133,7 @@ async fn test_startproject_missing_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_mtv_style() {
 	let env = TestEnvironment::new();
@@ -171,7 +152,7 @@ async fn test_startproject_mtv_style() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", project_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_restful_style() {
 	let env = TestEnvironment::new();
@@ -190,7 +171,7 @@ async fn test_startproject_restful_style() {
 }
 
 // Translation of Django's StartProject tests
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_wrong_args() {
 	// Test wrong number of arguments
@@ -200,19 +181,31 @@ async fn test_startproject_wrong_args() {
 	assert!(result.is_err());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_simple_project() {
-	let env = TestEnvironment::new();
-	std::env::set_current_dir(env.path()).expect("Failed to change directory");
+	// Arrange
+	let original_dir = std::env::current_dir().expect("read current directory");
 
-	let ctx = CommandContext::new(vec!["testproject".to_string()]);
-	let cmd = StartProjectCommand;
-	let result = cmd.execute(&ctx).await;
-	assert!(result.is_ok());
+	// Act
+	{
+		let env = TestEnvironment::new();
+		std::env::set_current_dir(env.path()).expect("Failed to change directory");
+
+		let ctx = CommandContext::new(vec!["testproject".to_string()]);
+		let cmd = StartProjectCommand;
+		let result = cmd.execute(&ctx).await;
+		assert!(result.is_ok());
+	}
+
+	// Assert
+	assert_eq!(
+		std::env::current_dir().expect("read restored current directory"),
+		original_dir
+	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_importable_project_name() {
 	// Test that reserved keywords fail
@@ -228,7 +221,7 @@ async fn test_startproject_importable_project_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_command_does_not_import() {
 	// Verify command doesn't import project code
@@ -241,7 +234,7 @@ async fn test_startproject_command_does_not_import() {
 	assert!(result.is_ok());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_simple_project_different_directory() {
 	let env = TestEnvironment::new();
@@ -253,7 +246,7 @@ async fn test_startproject_simple_project_different_directory() {
 	assert!(result.is_ok());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_template() {
 	// Test with custom template path
@@ -267,7 +260,7 @@ async fn test_startproject_custom_project_template() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_file_without_extension() {
 	let env = TestEnvironment::new();
@@ -300,7 +293,7 @@ async fn test_startproject_file_without_extension() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_template_context_variables() {
 	let env = TestEnvironment::new();
@@ -331,7 +324,7 @@ async fn test_startproject_custom_project_template_context_variables() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_no_escaping_of_project_variables() {
 	let env = TestEnvironment::new();
@@ -362,7 +355,7 @@ async fn test_startproject_no_escaping_of_project_variables() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_custom_project_destination_missing() {
 	let env = TestEnvironment::new();
@@ -399,7 +392,7 @@ async fn test_startproject_custom_project_destination_missing() {
 	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_honor_umask() {
 	#[cfg(unix)]
@@ -432,7 +425,7 @@ async fn test_startproject_honor_umask() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_overlay_preserves_unrelated_existing_files() {
 	// Arrange
@@ -461,7 +454,7 @@ async fn startproject_overlay_preserves_unrelated_existing_files() {
 	assert!(destination.join("Cargo.toml").is_file());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_rejects_file_destinations_without_mutating_them() {
 	// Arrange
@@ -483,7 +476,7 @@ async fn startproject_rejects_file_destinations_without_mutating_them() {
 	assert!(!env.file_exists("destination/Cargo.toml"));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it() {
 	// Arrange
@@ -512,7 +505,7 @@ async fn startproject_rejects_destinations_below_a_regular_file_without_mutating
 // StartApp Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_creates_app_structure() {
 	let env = TestEnvironment::new();
@@ -538,7 +531,7 @@ async fn test_startapp_creates_app_structure() {
 	assert!(env.file_exists(&format!("src/apps/{}/services.rs", app_name)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_with_custom_directory() {
 	let env = TestEnvironment::new();
@@ -562,7 +555,7 @@ async fn test_startapp_with_custom_directory() {
 	assert!(env.file_exists(&format!("{}/lib.rs", custom_dir)));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_missing_name() {
 	let ctx = CommandContext::new(vec![]);
@@ -578,7 +571,7 @@ async fn test_startapp_missing_name() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_mtv_style() {
 	let env = TestEnvironment::new();
@@ -600,7 +593,7 @@ async fn test_startapp_mtv_style() {
 	assert!(result.is_ok(), "MTV app creation failed");
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_restful_style() {
 	let env = TestEnvironment::new();
@@ -657,7 +650,7 @@ async fn test_startapp_restful_style() {
 	);
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_workspace_mode() {
 	let env = TestEnvironment::new();
@@ -688,7 +681,7 @@ async fn test_startapp_workspace_mode() {
 }
 
 // Translation of Django's StartApp tests
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_invalid_name() {
 	let env = TestEnvironment::new();
@@ -699,7 +692,7 @@ async fn test_startapp_invalid_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_importable_name() {
 	let env = TestEnvironment::new();
@@ -710,7 +703,7 @@ async fn test_startapp_importable_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_invalid_target_name() {
 	let env = TestEnvironment::new();
@@ -721,7 +714,7 @@ async fn test_startapp_invalid_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_importable_target_name() {
 	let env = TestEnvironment::new();
@@ -732,7 +725,7 @@ async fn test_startapp_importable_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let env = TestEnvironment::new();
@@ -743,7 +736,7 @@ async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_overlaying_app() {
 	let env = TestEnvironment::new();
@@ -770,7 +763,7 @@ async fn test_startapp_overlaying_app() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_template() {
 	let env = TestEnvironment::new();
@@ -806,7 +799,7 @@ async fn test_startapp_template() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	let env = TestEnvironment::new();
@@ -829,7 +822,7 @@ async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory() {
 	let env = TestEnvironment::new();
@@ -855,7 +848,7 @@ async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory()
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_name_with_app_within_other_app() {
 	let env = TestEnvironment::new();
@@ -884,7 +877,7 @@ async fn test_startapp_custom_name_with_app_within_other_app() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_custom_app_directory_creation_error_handling() {
 	let env = TestEnvironment::new();
@@ -938,7 +931,7 @@ fn test_admin_scripts_context_options() {
 // Base Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_base_command_lifecycle() {
 	struct TestCommand {
@@ -1035,7 +1028,7 @@ fn test_command_option_value() {
 // Template Command Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_template_rendering() {
 	use reinhardt_commands::{TemplateCommand, TemplateContext};
@@ -1090,7 +1083,7 @@ fn test_command_error_variants() {
 // Integration Tests
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_full_project_and_app_workflow() {
 	let env = TestEnvironment::new();
@@ -1169,7 +1162,7 @@ fn test_admin_scripts_to_camel_case() {
 // Translation of DjangoAdminNoSettings test class
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_builtin_command() {
 	// Test builtin command execution without settings
@@ -1179,7 +1172,7 @@ async fn test_djangoadmin_nosettings_builtin_command() {
 }
 
 #[tokio::test]
-#[serial(reinhardt_settings)]
+#[serial(current_dir, reinhardt_settings)]
 async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// Test builtin command with bad settings
 	let env = TestEnvironment::new();
@@ -1197,19 +1190,18 @@ async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
-#[serial]
+#[serial(reinhardt_settings)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_builtin_with_bad_environment() {
 	// Test builtin command with bad environment
-	unsafe {
-		std::env::set_var("PYTHONPATH", "/invalid/path");
-	}
+	let mut env_guard = EnvVarGuard::new();
+	env_guard.set("PYTHONPATH", "/invalid/path");
 
 	// Should still work for commands that don't need settings
 	assert_eq!(std::env::var("PYTHONPATH").unwrap(), "/invalid/path");
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 	// Test commands with invalid settings
@@ -1224,7 +1216,7 @@ async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 // Translation of DjangoAdminDefaultSettings test class
 // ============================================================================
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_builtin_command() {
 	let env = TestEnvironment::new();
@@ -1235,7 +1227,7 @@ async fn test_djangoadmin_defaultsettings_builtin_command() {
 	assert!(env.file_exists("settings.rs"));
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_builtin_with_settings() {
 	let env = TestEnvironment::new();
@@ -1284,7 +1276,7 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
 	// env_guard automatically cleans up on drop
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_custom_command() {
 	let env = TestEnvironment::new();
@@ -1294,7 +1286,7 @@ async fn test_djangoadmin_defaultsettings_custom_command() {
 	assert!(env.path().exists());
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_djangoadmin_defaultsettings_custom_command_with_settings() {
 	// Test custom command with explicit settings
@@ -1324,7 +1316,7 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
 
 // ===== Reserved namespace validation (#3502) =====
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startproject_rejects_reinhardt_prefix() {
 	let env = TestEnvironment::new();
@@ -1341,7 +1333,7 @@ async fn test_startproject_rejects_reinhardt_prefix() {
 	}
 }
 
-#[serial]
+#[serial(current_dir)]
 #[tokio::test]
 async fn test_startapp_rejects_reinhardt_prefix() {
 	let env = TestEnvironment::new();

--- a/crates/reinhardt-commands/tests/admin_scripts_tests.rs
+++ b/crates/reinhardt-commands/tests/admin_scripts_tests.rs
@@ -8,10 +8,13 @@
 #[path = "support/environment.rs"]
 mod environment;
 
-use environment::EnvVarGuard;
+use environment::{EnvVars, env_vars};
 use reinhardt_commands::{
 	BaseCommand, CommandContext, CommandError, CommandResult, StartAppCommand, StartProjectCommand,
 };
+use reinhardt_test::fixtures::temp_dir;
+use reinhardt_test::{TeardownGuard, TestResource};
+use rstest::{fixture, rstest};
 use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
@@ -20,38 +23,40 @@ use tempfile::TempDir;
 /// Helper struct for setting up test environments
 struct TestEnvironment {
 	// Restore the working directory before the temporary directory is removed.
-	_cwd: CurrentDirGuard,
+	_cwd: TeardownGuard<CurrentDir>,
 	temp_dir: TempDir,
 }
 
-struct CurrentDirGuard {
+struct CurrentDir {
 	original: PathBuf,
 }
 
-impl CurrentDirGuard {
-	fn change_to(path: &std::path::Path) -> Self {
-		let original = std::env::current_dir().expect("read current directory");
-		std::env::set_current_dir(path).expect("change current directory");
-		Self { original }
+impl TestResource for CurrentDir {
+	fn setup() -> Self {
+		Self {
+			original: std::env::current_dir().expect("read current directory"),
+		}
 	}
-}
 
-impl Drop for CurrentDirGuard {
-	fn drop(&mut self) {
+	fn teardown(&mut self) {
 		std::env::set_current_dir(&self.original).expect("restore current directory");
 	}
 }
 
-impl TestEnvironment {
-	fn new() -> Self {
-		Self {
-			_cwd: CurrentDirGuard {
-				original: std::env::current_dir().expect("read current directory"),
-			},
-			temp_dir: TempDir::new().expect("Failed to create temp directory"),
-		}
-	}
+#[fixture]
+fn current_dir() -> TeardownGuard<CurrentDir> {
+	TeardownGuard::new()
+}
 
+#[fixture]
+fn test_env(temp_dir: TempDir, current_dir: TeardownGuard<CurrentDir>) -> TestEnvironment {
+	TestEnvironment {
+		_cwd: current_dir,
+		temp_dir,
+	}
+}
+
+impl TestEnvironment {
 	fn path(&self) -> PathBuf {
 		self.temp_dir.path().to_path_buf()
 	}
@@ -77,10 +82,10 @@ impl TestEnvironment {
 // StartProject Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_creates_project_structure() {
-	let env = TestEnvironment::new();
+async fn test_startproject_creates_project_structure(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "myproject";
 
 	// Change to temp directory
@@ -98,10 +103,10 @@ async fn test_startproject_creates_project_structure() {
 	assert!(env.file_exists(&format!("{}/src/bin/manage.rs", project_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_with_custom_directory() {
-	let env = TestEnvironment::new();
+async fn test_startproject_with_custom_directory(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "myproject";
 	let custom_dir = "custom_location";
 
@@ -133,10 +138,10 @@ async fn test_startproject_missing_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_mtv_style() {
-	let env = TestEnvironment::new();
+async fn test_startproject_mtv_style(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "mtv_project";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -152,10 +157,10 @@ async fn test_startproject_mtv_style() {
 	assert!(env.file_exists(&format!("{}/Cargo.toml", project_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_restful_style() {
-	let env = TestEnvironment::new();
+async fn test_startproject_restful_style(#[from(test_env)] env: TestEnvironment) {
 	let project_name = "api_project";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -181,16 +186,17 @@ async fn test_startproject_wrong_args() {
 	assert!(result.is_err());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_simple_project() {
+async fn test_startproject_simple_project(#[from(test_env)] env: TestEnvironment) {
 	// Arrange
 	let original_dir = std::env::current_dir().expect("read current directory");
 
 	// Act
 	{
-		let env = TestEnvironment::new();
-		std::env::set_current_dir(env.path()).expect("Failed to change directory");
+		let scoped_env = env;
+		std::env::set_current_dir(scoped_env.path()).expect("Failed to change directory");
 
 		let ctx = CommandContext::new(vec!["testproject".to_string()]);
 		let cmd = StartProjectCommand;
@@ -205,11 +211,11 @@ async fn test_startproject_simple_project() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_importable_project_name() {
+async fn test_startproject_importable_project_name(#[from(test_env)] env: TestEnvironment) {
 	// Test that reserved keywords fail
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let reserved_names = vec!["test", "mod", "use", "fn", "struct"];
@@ -221,11 +227,11 @@ async fn test_startproject_importable_project_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_command_does_not_import() {
+async fn test_startproject_command_does_not_import(#[from(test_env)] env: TestEnvironment) {
 	// Verify command doesn't import project code
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -234,10 +240,12 @@ async fn test_startproject_command_does_not_import() {
 	assert!(result.is_ok());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_simple_project_different_directory() {
-	let env = TestEnvironment::new();
+async fn test_startproject_simple_project_different_directory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["testproject".to_string(), "other_dir".to_string()]);
@@ -246,11 +254,11 @@ async fn test_startproject_simple_project_different_directory() {
 	assert!(result.is_ok());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_template() {
+async fn test_startproject_custom_project_template(#[from(test_env)] env: TestEnvironment) {
 	// Test with custom template path
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let mut ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -260,10 +268,10 @@ async fn test_startproject_custom_project_template() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_file_without_extension() {
-	let env = TestEnvironment::new();
+async fn test_startproject_file_without_extension(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a template directory with files without extensions
@@ -293,10 +301,12 @@ async fn test_startproject_file_without_extension() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_template_context_variables() {
-	let env = TestEnvironment::new();
+async fn test_startproject_custom_project_template_context_variables(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a template with context variables
@@ -324,10 +334,12 @@ async fn test_startproject_custom_project_template_context_variables() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_no_escaping_of_project_variables() {
-	let env = TestEnvironment::new();
+async fn test_startproject_no_escaping_of_project_variables(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create template with special characters
@@ -355,10 +367,12 @@ async fn test_startproject_no_escaping_of_project_variables() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_custom_project_destination_missing() {
-	let env = TestEnvironment::new();
+async fn test_startproject_custom_project_destination_missing(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Specify a custom destination that doesn't exist
@@ -392,14 +406,14 @@ async fn test_startproject_custom_project_destination_missing() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_honor_umask() {
+async fn test_startproject_honor_umask(#[from(test_env)] env: TestEnvironment) {
 	#[cfg(unix)]
 	{
 		use std::os::unix::fs::PermissionsExt;
 
-		let env = TestEnvironment::new();
 		std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 		let ctx = CommandContext::new(vec!["testproject".to_string()]);
@@ -421,19 +435,22 @@ async fn test_startproject_honor_umask() {
 
 	#[cfg(not(unix))]
 	{
-		// Test is Unix-specific
+		// Retain the fixture until this platform-specific test ends.
+		let _env = env;
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_overlay_preserves_unrelated_existing_files() {
+async fn startproject_overlay_preserves_unrelated_existing_files(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	let destination = env.path().join("existing-project");
 	fs::create_dir_all(&destination).expect("create existing destination");
 	fs::write(destination.join("custom.txt"), "keep this file\n").expect("write existing file");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec![
 		"demo_project".to_string(),
 		"existing-project".to_string(),
@@ -454,14 +471,16 @@ async fn startproject_overlay_preserves_unrelated_existing_files() {
 	assert!(destination.join("Cargo.toml").is_file());
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_rejects_file_destinations_without_mutating_them() {
+async fn startproject_rejects_file_destinations_without_mutating_them(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	env.create_file("destination", "existing destination file\n");
 	let before = env.read_file("destination");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec!["demo_project".to_string(), "destination".to_string()]);
 
 	// Act
@@ -476,14 +495,16 @@ async fn startproject_rejects_file_destinations_without_mutating_them() {
 	assert!(!env.file_exists("destination/Cargo.toml"));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it() {
+async fn startproject_rejects_destinations_below_a_regular_file_without_mutating_it(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	// Arrange
-	let env = TestEnvironment::new();
 	env.create_file("blocked", "regular parent\n");
 	let before = env.read_file("blocked");
-	let _cwd = CurrentDirGuard::change_to(&env.path());
+	std::env::set_current_dir(env.path()).expect("change current directory");
 	let ctx = CommandContext::new(vec![
 		"demo_project".to_string(),
 		"blocked/project".to_string(),
@@ -505,10 +526,10 @@ async fn startproject_rejects_destinations_below_a_regular_file_without_mutating
 // StartApp Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_creates_app_structure() {
-	let env = TestEnvironment::new();
+async fn test_startapp_creates_app_structure(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "myapp";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -531,10 +552,10 @@ async fn test_startapp_creates_app_structure() {
 	assert!(env.file_exists(&format!("src/apps/{}/services.rs", app_name)));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_with_custom_directory() {
-	let env = TestEnvironment::new();
+async fn test_startapp_with_custom_directory(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "myapp";
 	let custom_dir = "my_apps";
 
@@ -571,10 +592,10 @@ async fn test_startapp_missing_name() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_mtv_style() {
-	let env = TestEnvironment::new();
+async fn test_startapp_mtv_style(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "mtv_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -593,10 +614,10 @@ async fn test_startapp_mtv_style() {
 	assert!(result.is_ok(), "MTV app creation failed");
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_restful_style() {
-	let env = TestEnvironment::new();
+async fn test_startapp_restful_style(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "api_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -650,10 +671,10 @@ async fn test_startapp_restful_style() {
 	);
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_workspace_mode() {
-	let env = TestEnvironment::new();
+async fn test_startapp_workspace_mode(#[from(test_env)] env: TestEnvironment) {
 	let app_name = "workspace_app";
 
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
@@ -681,10 +702,10 @@ async fn test_startapp_workspace_mode() {
 }
 
 // Translation of Django's StartApp tests
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_invalid_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_invalid_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["1invalid".to_string()]);
@@ -692,10 +713,10 @@ async fn test_startapp_invalid_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_importable_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_importable_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["test".to_string()]);
@@ -703,10 +724,10 @@ async fn test_startapp_importable_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_invalid_target_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_invalid_target_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "1invalid".to_string()]);
@@ -714,10 +735,10 @@ async fn test_startapp_invalid_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_importable_target_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_importable_target_name(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "test".to_string()]);
@@ -725,10 +746,12 @@ async fn test_startapp_importable_target_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_trailing_slash_in_target_app_directory_name() {
-	let env = TestEnvironment::new();
+async fn test_startapp_trailing_slash_in_target_app_directory_name(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	let ctx = CommandContext::new(vec!["app".to_string(), "testapp/".to_string()]);
@@ -736,10 +759,10 @@ async fn test_startapp_trailing_slash_in_target_app_directory_name() {
 	let _result = cmd.execute(&ctx).await;
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_overlaying_app() {
-	let env = TestEnvironment::new();
+async fn test_startapp_overlaying_app(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -763,10 +786,10 @@ async fn test_startapp_overlaying_app() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_template() {
-	let env = TestEnvironment::new();
+async fn test_startapp_template(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -799,10 +822,12 @@ async fn test_startapp_template() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
-	let env = TestEnvironment::new();
+async fn test_startapp_creates_directory_when_custom_app_destination_missing(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -822,10 +847,12 @@ async fn test_startapp_creates_directory_when_custom_app_destination_missing() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -848,10 +875,12 @@ async fn test_startapp_custom_app_destination_missing_with_nested_subdirectory()
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_name_with_app_within_other_app() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_name_with_app_within_other_app(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -877,10 +906,12 @@ async fn test_startapp_custom_name_with_app_within_other_app() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_custom_app_directory_creation_error_handling() {
-	let env = TestEnvironment::new();
+async fn test_startapp_custom_app_directory_creation_error_handling(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	fs::create_dir_all(env.path().join("src")).expect("Failed to create src directory");
@@ -1028,12 +1059,12 @@ fn test_command_option_value() {
 // Template Command Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_template_rendering() {
+async fn test_template_rendering(#[from(test_env)] env: TestEnvironment) {
 	use reinhardt_commands::{TemplateCommand, TemplateContext};
 
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create a simple template directory
@@ -1083,10 +1114,10 @@ fn test_command_error_variants() {
 // Integration Tests
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_full_project_and_app_workflow() {
-	let env = TestEnvironment::new();
+async fn test_full_project_and_app_workflow(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Step 1: Create project
@@ -1171,15 +1202,17 @@ async fn test_djangoadmin_nosettings_builtin_command() {
 	assert_eq!(ctx.arg(0), Some(&"--version".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(current_dir, reinhardt_settings)]
-async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
+async fn test_djangoadmin_nosettings_builtin_with_bad_settings(
+	#[from(test_env)] env: TestEnvironment,
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test builtin command with bad settings
-	let env = TestEnvironment::new();
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Set invalid settings environment variable
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "bad.settings");
 
 	// Command should handle bad settings gracefully
@@ -1190,11 +1223,13 @@ async fn test_djangoadmin_nosettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[serial(reinhardt_settings)]
 #[tokio::test]
-async fn test_djangoadmin_nosettings_builtin_with_bad_environment() {
+async fn test_djangoadmin_nosettings_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test builtin command with bad environment
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("PYTHONPATH", "/invalid/path");
 
 	// Should still work for commands that don't need settings
@@ -1216,10 +1251,10 @@ async fn test_djangoadmin_nosettings_commands_with_invalid_settings() {
 // Translation of DjangoAdminDefaultSettings test class
 // ============================================================================
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_builtin_command() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_builtin_command(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Create default settings file
@@ -1227,20 +1262,24 @@ async fn test_djangoadmin_defaultsettings_builtin_command() {
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_builtin_with_settings() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_settings(
+	#[from(test_env)] env: TestEnvironment,
+) {
 	env.create_file("settings.rs", "// Settings content\n");
 
 	// Test with explicit settings parameter
 	assert!(env.file_exists("settings.rs"));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "test.settings");
 
 	// Test command execution with environment variable
@@ -1251,10 +1290,12 @@ async fn test_djangoadmin_defaultsettings_builtin_with_environment() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "nonexistent.settings");
 
 	// Should fail with appropriate error
@@ -1265,10 +1306,12 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_settings() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
-	let mut env_guard = EnvVarGuard::new();
+async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "");
 
 	// Should handle empty settings gracefully
@@ -1276,10 +1319,10 @@ async fn test_djangoadmin_defaultsettings_builtin_with_bad_environment() {
 	// env_guard automatically cleans up on drop
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_djangoadmin_defaultsettings_custom_command() {
-	let env = TestEnvironment::new();
+async fn test_djangoadmin_defaultsettings_custom_command(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	// Test custom command execution
@@ -1298,11 +1341,13 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_settings() {
 	assert_eq!(ctx.arg(1), Some(&"custom.settings".to_string()));
 }
 
+#[rstest]
 #[tokio::test]
 #[serial(reinhardt_settings)]
-async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
+async fn test_djangoadmin_defaultsettings_custom_command_with_environment(
+	#[from(env_vars)] mut env_guard: TeardownGuard<EnvVars>,
+) {
 	// Test custom command with environment settings
-	let mut env_guard = EnvVarGuard::new();
 	env_guard.set("REINHARDT_SETTINGS_MODULE", "env.settings");
 	env_guard.set("CUSTOM_VAR", "value");
 
@@ -1316,10 +1361,10 @@ async fn test_djangoadmin_defaultsettings_custom_command_with_environment() {
 
 // ===== Reserved namespace validation (#3502) =====
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startproject_rejects_reinhardt_prefix() {
-	let env = TestEnvironment::new();
+async fn test_startproject_rejects_reinhardt_prefix(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	for name in ["reinhardt_myapp", "reinhardt-myapp"] {
@@ -1333,10 +1378,10 @@ async fn test_startproject_rejects_reinhardt_prefix() {
 	}
 }
 
+#[rstest]
 #[serial(current_dir)]
 #[tokio::test]
-async fn test_startapp_rejects_reinhardt_prefix() {
-	let env = TestEnvironment::new();
+async fn test_startapp_rejects_reinhardt_prefix(#[from(test_env)] env: TestEnvironment) {
 	std::env::set_current_dir(env.path()).expect("Failed to change directory");
 
 	for name in ["reinhardt_myapp", "reinhardt-myapp"] {

--- a/crates/reinhardt-commands/tests/support/environment.rs
+++ b/crates/reinhardt-commands/tests/support/environment.rs
@@ -1,17 +1,15 @@
-//! Environment restoration for serial-protected command tests.
+//! Environment fixtures for serial-protected command tests.
 
-use std::ffi::OsString;
+use reinhardt_test::{TeardownGuard, TestResource};
+use rstest::fixture;
+use std::ffi::{OsStr, OsString};
 
-pub(super) struct EnvVarGuard {
+pub(super) struct EnvVars {
 	vars: Vec<(String, Option<OsString>)>,
 }
 
-impl EnvVarGuard {
-	pub(super) fn new() -> Self {
-		Self { vars: Vec::new() }
-	}
-
-	pub(super) fn set(&mut self, key: &str, value: &str) {
+impl EnvVars {
+	pub(super) fn set(&mut self, key: &str, value: impl AsRef<OsStr>) {
 		self.vars.push((key.to_owned(), std::env::var_os(key)));
 		// SAFETY: environment-changing callers share a serial test group.
 		unsafe {
@@ -20,8 +18,12 @@ impl EnvVarGuard {
 	}
 }
 
-impl Drop for EnvVarGuard {
-	fn drop(&mut self) {
+impl TestResource for EnvVars {
+	fn setup() -> Self {
+		Self { vars: Vec::new() }
+	}
+
+	fn teardown(&mut self) {
 		for (key, original) in self.vars.iter().rev() {
 			// SAFETY: the caller retains its serial test guard during cleanup.
 			unsafe {
@@ -32,4 +34,9 @@ impl Drop for EnvVarGuard {
 			}
 		}
 	}
+}
+
+#[fixture]
+pub(super) fn env_vars() -> TeardownGuard<EnvVars> {
+	TeardownGuard::new()
 }

--- a/crates/reinhardt-commands/tests/support/environment.rs
+++ b/crates/reinhardt-commands/tests/support/environment.rs
@@ -1,0 +1,35 @@
+//! Environment restoration for serial-protected command tests.
+
+use std::ffi::OsString;
+
+pub(super) struct EnvVarGuard {
+	vars: Vec<(String, Option<OsString>)>,
+}
+
+impl EnvVarGuard {
+	pub(super) fn new() -> Self {
+		Self { vars: Vec::new() }
+	}
+
+	pub(super) fn set(&mut self, key: &str, value: &str) {
+		self.vars.push((key.to_owned(), std::env::var_os(key)));
+		// SAFETY: environment-changing callers share a serial test group.
+		unsafe {
+			std::env::set_var(key, value);
+		}
+	}
+}
+
+impl Drop for EnvVarGuard {
+	fn drop(&mut self) {
+		for (key, original) in self.vars.iter().rev() {
+			// SAFETY: the caller retains its serial test guard during cleanup.
+			unsafe {
+				match original {
+					Some(value) => std::env::set_var(key, value),
+					None => std::env::remove_var(key),
+				}
+			}
+		}
+	}
+}

--- a/crates/reinhardt-conf/Cargo.toml
+++ b/crates/reinhardt-conf/Cargo.toml
@@ -77,6 +77,7 @@ hot-reload = ["notify", "tokio", "async"]
 caching = ["moka", "async"]
 
 [dev-dependencies]
+reinhardt-test = { path = "../reinhardt-test" }
 insta = { workspace = true }
 futures = { workspace = true }
 tempfile = "3.8"

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -338,6 +338,18 @@ These fields exist for Django settings compatibility but are **not yet consumed*
 use reinhardt::conf::settings::{SettingsBuilder, SettingsConfig};
 ```
 
+## Testing
+
+Run the database audit regression tests with a parallel test runner:
+
+```bash
+cargo test -p reinhardt-conf --all-features --lib settings::audit::backends::database -- --test-threads=8
+```
+
+Each audit backend fixture uses a unique named in-memory SQLite database.
+Connections within its pool share that database, while concurrently active
+fixtures keep their audit records separate.
+
 ## License
 
 Licensed under the BSD 3-Clause License.

--- a/crates/reinhardt-conf/README.md
+++ b/crates/reinhardt-conf/README.md
@@ -346,9 +346,10 @@ Run the database audit regression tests with a parallel test runner:
 cargo test -p reinhardt-conf --all-features --lib settings::audit::backends::database -- --test-threads=8
 ```
 
-Each audit backend fixture uses a unique named in-memory SQLite database.
-Connections within its pool share that database, while concurrently active
-fixtures keep their audit records separate.
+Audit tests receive asynchronous `rstest` backend fixtures whose in-memory SQLite
+database names use `reinhardt-test`'s `random_test_key` helper. Connections within
+each pool share that database, while independently injected backend fixtures keep
+their audit records separate.
 
 ## License
 

--- a/crates/reinhardt-conf/src/settings/audit/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/audit/backends/database.rs
@@ -335,23 +335,25 @@ mod tests {
 
 	async fn create_test_backend() -> DatabaseAuditBackend {
 		init_drivers();
-		// Use named in-memory SQLite database with shared cache
-		// The "file:" prefix with "mode=memory" and "cache=shared" ensures
-		// all connections in the pool share the same in-memory database
-		let db_url = "sqlite:file:memdb1?mode=memory&cache=shared";
+		// Share one in-memory database within the pool, while isolating each
+		// backend's audit records from concurrently active test backends.
+		let db_url = format!(
+			"sqlite:file:audit-{}?mode=memory&cache=shared",
+			uuid::Uuid::new_v4()
+		);
 
 		// Create backend with AnyPool
 		use sqlx::any::AnyPoolOptions;
 
 		let pool = AnyPoolOptions::new()
 			.max_connections(5)
-			.connect(db_url)
+			.connect(&db_url)
 			.await
 			.expect("Failed to connect to test database");
 
 		let backend = DatabaseAuditBackend {
 			pool: std::sync::Arc::new(pool),
-			database_url: db_url.to_string(),
+			database_url: db_url,
 		};
 		backend
 			.init_tables()
@@ -385,7 +387,9 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_database_backend_log_event() {
+		// Arrange
 		let backend = create_test_backend().await;
+		let independent_backend = create_test_backend().await;
 
 		let mut changes = HashMap::new();
 		changes.insert(
@@ -402,11 +406,14 @@ mod tests {
 			changes,
 		);
 
+		// Act
 		backend.log_event(event).await.unwrap();
 
+		// Assert
 		let events = backend.get_events(None).await.unwrap();
 		assert_eq!(events.len(), 1);
 		assert_eq!(events[0].event_type, EventType::ConfigUpdate);
+		assert_eq!(independent_backend.get_events(None).await.unwrap().len(), 0);
 	}
 
 	#[tokio::test]

--- a/crates/reinhardt-conf/src/settings/audit/backends/database.rs
+++ b/crates/reinhardt-conf/src/settings/audit/backends/database.rs
@@ -322,6 +322,8 @@ impl AuditBackend for DatabaseAuditBackend {
 mod tests {
 	use super::*;
 	use reinhardt_query::Func;
+	use reinhardt_test::fixtures::random_test_key;
+	use rstest::{fixture, rstest};
 	use serde_json::json;
 	use std::sync::Once;
 
@@ -333,27 +335,29 @@ mod tests {
 		});
 	}
 
-	async fn create_test_backend() -> DatabaseAuditBackend {
-		init_drivers();
+	#[fixture]
+	fn database_url() -> String {
 		// Share one in-memory database within the pool, while isolating each
 		// backend's audit records from concurrently active test backends.
-		let db_url = format!(
-			"sqlite:file:audit-{}?mode=memory&cache=shared",
-			uuid::Uuid::new_v4()
-		);
+		format!("sqlite:file:{}?mode=memory&cache=shared", random_test_key())
+	}
+
+	#[fixture]
+	async fn backend(database_url: String) -> DatabaseAuditBackend {
+		init_drivers();
 
 		// Create backend with AnyPool
 		use sqlx::any::AnyPoolOptions;
 
 		let pool = AnyPoolOptions::new()
 			.max_connections(5)
-			.connect(&db_url)
+			.connect(&database_url)
 			.await
 			.expect("Failed to connect to test database");
 
 		let backend = DatabaseAuditBackend {
 			pool: std::sync::Arc::new(pool),
-			database_url: db_url,
+			database_url,
 		};
 		backend
 			.init_tables()
@@ -362,10 +366,9 @@ mod tests {
 		backend
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_init() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_init(#[future(awt)] backend: DatabaseAuditBackend) {
 		// Verify tables were created
 		let stmt = Query::select()
 			.expr_as(
@@ -376,6 +379,16 @@ mod tests {
 			.to_owned();
 		let sql = stmt.to_string(SqliteQueryBuilder);
 
+		// Keep one connection checked out so the pool must use a second one.
+		let mut connection = backend.pool.acquire().await.unwrap();
+		let first_count: i64 = sqlx::query(&sql)
+			.fetch_one(&mut *connection)
+			.await
+			.unwrap()
+			.try_get("count")
+			.unwrap();
+		assert_eq!(first_count, 0);
+
 		let rows = sqlx::query(&sql)
 			.fetch_all(backend.pool.as_ref())
 			.await
@@ -385,12 +398,15 @@ mod tests {
 		assert_eq!(count, 0);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_log_event() {
+	async fn test_database_backend_log_event(
+		#[future(awt)] backend: DatabaseAuditBackend,
+		#[from(backend)]
+		#[future(awt)]
+		independent_backend: DatabaseAuditBackend,
+	) {
 		// Arrange
-		let backend = create_test_backend().await;
-		let independent_backend = create_test_backend().await;
-
 		let mut changes = HashMap::new();
 		changes.insert(
 			"test_key".to_string(),
@@ -416,10 +432,9 @@ mod tests {
 		assert_eq!(independent_backend.get_events(None).await.unwrap().len(), 0);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_filter_by_type() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_filter_by_type(#[future(awt)] backend: DatabaseAuditBackend) {
 		for i in 0..5 {
 			let event_type = if i % 2 == 0 {
 				EventType::ConfigUpdate
@@ -451,10 +466,9 @@ mod tests {
 		assert_eq!(update_events.len(), 3);
 	}
 
+	#[rstest]
 	#[tokio::test]
-	async fn test_database_backend_filter_by_user() {
-		let backend = create_test_backend().await;
-
+	async fn test_database_backend_filter_by_user(#[future(awt)] backend: DatabaseAuditBackend) {
 		for i in 0..5 {
 			let user = if i % 2 == 0 { "alice" } else { "bob" };
 

--- a/crates/reinhardt-views/README.md
+++ b/crates/reinhardt-views/README.md
@@ -119,6 +119,9 @@ applications wire persistence behavior through their serializers and managers.
 #### Browsable API
 
 - Basic rendering infrastructure (minimal stub)
+- Syntax highlighting uses syntect's bundled syntaxes and themes with the
+  Oniguruma regex backend. External plist/YAML syntax and theme loading is
+  disabled to avoid unused parser dependencies.
 
 #### Admin Integration
 


### PR DESCRIPTION
## Summary

Restore the main branch's dependency audit and isolate regression test fixtures:

- Enable syntect's bundled syntax/theme, HTML, and Oniguruma features without the unused external plist/YAML loaders.
- Restore the working directory before deleting temporary project fixtures, and serialize directory-changing tests in one group.
- Inject `rstest` fixtures composed from `reinhardt-test` temporary directories and `TestResource` / `TeardownGuard`, restoring process state even during unwinding.
- Inject asynchronous audit backend fixtures with unique database names from `reinhardt-test::fixtures::random_test_key`, preserving sharing between connections in each pool.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Code quality improvements

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Fresh main-branch dependency resolution reproduces the [dependency policy failure](https://github.com/kent8192/reinhardt-web/actions/runs/34122516050/job/101745050614): unused syntect plist loading adds quick-xml 0.42 alongside the existing 0.41 graph. Browsable API highlighting only uses bundled definitions, so removing the unused loaders resolves the duplicate without adding a policy exception.

The original admin script suite reproduced two failures when a test inherited a working directory already removed by an earlier fixture. The additional suite also reproduced a settings-variable race. RAII restoration and shared serial groups eliminate these process-state leaks while preserving the default parallel runner. The fixture lifecycle uses the existing `reinhardt-test` helpers; path-only development dependencies make them available in default-feature tests without changing release dependency ordering.

Database audit fixtures also reused one named SQLite memory database, allowing simultaneously active backends to read one another's events. Unique names isolate each fixture. The event test injects two independent backends and verifies that the second remains empty; it fails with the original helper even when run alone with one test thread. The initialization test also holds one pooled connection while reading from another to verify within-pool sharing.

## How Was This Tested?

After converting to injected fixtures:

- Passed both admin script suites with default features and 8 test threads: 125 tests. The checks cover working-directory restoration, an initially absent environment variable, repeated nested updates during unwinding, and non-Unicode value restoration on Unix.
- Passed the complete `reinhardt-conf` library suite with all features and 8 test threads: 342 passed, 2 ignored, including all four audit cases. These verify independent backend isolation and sharing between two simultaneously checked-out connections in one pool.
- Passed `cargo deny --workspace --all-features check all`: advisories, bans, licenses, and sources.
- Passed targeted Clippy for both admin script test binaries with default features and `-D warnings`, plus `cargo make clippy-check` for the full workspace.
- Passed `RUSTDOCFLAGS='-D warnings' cargo doc -p reinhardt-commands -p reinhardt-conf --all-features --no-deps`.
- Passed `cargo make fmt-check`: 3,006 files unchanged, zero formatting errors. `git diff --check` is clean.

Earlier validation of the underlying regression fixes also passed the 31 Browsable API highlighting tests, `cargo check --workspace --all --all-features`, and `cargo build --workspace --all --all-features`. Dependency inspection confirmed one quick-xml version and no syntect plist/YAML loader features.

The initial `cargo test --workspace --all --all-features` run compiled all test targets and completed 62 suite results with 3,454 passed, 3 failed, and 2 ignored. It stopped at the shared SQLite fixture failures now fixed and verified by the complete configuration library suite above. The remaining workspace suites were not rerun, and the fixture conversion did not repeat that full sweep.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Affected regression tests pass locally with my changes
- [ ] Full workspace tests pass locally with my changes (the broad run stopped at the fixed audit-fixture regression; remaining suites were not rerun)
- [x] I have checked the code with `cargo make fmt-check`
- [x] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Labels to Apply

- [x] `bug` - Bug fix
- [x] `dependencies` - Dependency feature selection

---

🤖 Generated with [OpenAI Codex](https://openai.com/codex)
