### PR TITLE
fix(ci): grant PR access to breaking-change warnings

### DIFF
--- a/.github/workflows/warn-invalid-breaking-change.yml
+++ b/.github/workflows/warn-invalid-breaking-change.yml
@@ -12,6 +12,8 @@ concurrency:
 
 permissions:
   issues: write
+  # The issue-comment endpoint also requires access to the PR conversation.
+  pull-requests: write
 
 jobs:
   warn:

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -485,6 +485,14 @@ cargo make fmt-check
 cargo make clippy-check
 ```
 
+**Breaking-change warning check:**
+`Warn Invalid Breaking Change Target` posts to the PR conversation through the
+issue-comment API and requires `pull-requests: write` alongside `issues: write`.
+A `403 Resource not accessible by integration` during comment creation is a
+workflow permission failure. This `pull_request_target` workflow runs from the
+base branch, so permission repairs must reach that branch before a new PR event
+can validate them; changing only the affected PR head does not update the workflow.
+
 ### RP-2 (SHOULD): Self-Review
 
 - Review your own PR before requesting review from others


### PR DESCRIPTION
## Summary

The breaking-change warning workflow fails with HTTP 403 when it creates a PR conversation comment. Grant `pull-requests: write` alongside its existing issue permission and document why this repair must reach the base branch before the affected PR can validate it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Refs #6276. Job [101963404024](https://github.com/kent8192/reinhardt-web/actions/runs/34195889373/job/101963404024) reaches `issues.createComment` and receives `Resource not accessible by integration`. Its token has issue write access but no pull-request access.

The warning runs on `pull_request_target`, so it consumes the base branch workflow. This separate repair allows the permission correction to land before another PR event runs the warning. It preserves the warning criteria, trigger, pagination, and duplicate-comment guard.

## How Was This Tested?

- `actionlint .github/workflows/warn-invalid-breaking-change.yml` passed.
- `git diff --check` passed.
- Compared the failure's request and token permissions with the workflow permissions.

No Rust code changes. The live warning can be verified after this repair is merged into `main` and a new event triggers the affected PR workflow.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

Rust formatting, Clippy, database tests, and application unit tests do not apply to this workflow-permission change.

## Related Issues

- #6276

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `ci-cd` - CI/CD workflow changes

### Priority Label (for maintainers)

- [ ] `critical` - Blocks release or major functionality
- [ ] `high` - Important fix or feature
- [ ] `medium` - Normal priority
- [ ] `low` - Minor fix or enhancement

---

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex/)
