### PR TITLE
fix(ci): enforce the required breaking-change target check

### DIFF
--- a/.github/workflows/warn-invalid-breaking-change.yml
+++ b/.github/workflows/warn-invalid-breaking-change.yml
@@ -3,7 +3,7 @@ name: Warn Invalid Breaking Change Target
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, edited, synchronize, reopened, labeled]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, ready_for_review]
 
 # Use the PR number because pull_request_target runs on the base branch ref.
 concurrency:
@@ -24,17 +24,29 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
+            // Read current metadata so queued title, label, or base changes
+            // cannot leave an obsolete policy result on the current commit.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
             const sourceBranch = pr.head.ref;
             const labels = pr.labels.map(label => label.name);
             const breakingTitle = /^(?:[a-z][a-z0-9-]*!(?:\([^)]*\))?|[a-z][a-z0-9-]*\([^)]*\)!)\s*:/i.test(pr.title);
             const breakingChange = labels.includes('breaking-change') || breakingTitle;
             const validDevelopBranch = /^develop\/\d+\.\d+\.\d+$/.test(sourceBranch);
 
-            if (!breakingChange || validDevelopBranch) {
+            if (pr.base.ref !== 'main' || !breakingChange || validDevelopBranch) {
               core.info('No invalid breaking-change target detected.');
               return;
             }
+
+            // Fail before comment delivery or deduplication: neither approves
+            // a breaking change targeting the stable branch.
+            core.setFailed(
+              `Breaking change from '${sourceBranch}' must target a versioned develop/X.Y.Z branch, not main.`
+            );
 
             const marker = '<!-- invalid-breaking-change-target-warning -->';
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -58,7 +70,7 @@ jobs:
               `- Source branch: \`${sourceBranch}\``,
               `- Detected by: ${labels.includes('breaking-change') ? '`breaking-change` label' : 'breaking Conventional Commit title'}`,
               '',
-              'Breaking changes should target the appropriate versioned `develop/X.Y.Z` branch. Please retarget this PR or confirm the exception with the maintainers.',
+              'Breaking changes must target the appropriate versioned `develop/X.Y.Z` branch. This required check fails until the target or breaking-change classification is corrected.',
             ].join('\n');
 
             await github.rest.issues.createComment({
@@ -68,4 +80,4 @@ jobs:
               body,
             });
 
-            core.warning(`Posted invalid breaking-change target warning for PR #${pr.number}.`);
+            core.info(`Posted invalid breaking-change target warning for PR #${pr.number}.`);

--- a/.github/workflows/warn-invalid-breaking-change.yml
+++ b/.github/workflows/warn-invalid-breaking-change.yml
@@ -11,13 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  checks: write
   issues: write
   # The issue-comment endpoint also requires access to the PR conversation.
   pull-requests: write
 
 jobs:
   warn:
-    name: Warn Invalid Breaking Change Target
+    # Only the explicitly published PR-head check uses the required check name.
+    name: Publish Breaking Change Target Check
     runs-on: ubuntu-latest
     steps:
       - name: Check breaking-change target
@@ -36,17 +38,35 @@ jobs:
             const breakingTitle = /^(?:[a-z][a-z0-9-]*!(?:\([^)]*\))?|[a-z][a-z0-9-]*\([^)]*\)!)\s*:/i.test(pr.title);
             const breakingChange = labels.includes('breaking-change') || breakingTitle;
             const validDevelopBranch = /^develop\/\d+\.\d+\.\d+$/.test(sourceBranch);
+            const invalidTarget = pr.base.ref === 'main' && breakingChange && !validDevelopBranch;
+            const summary = invalidTarget
+              ? `Breaking change from '${sourceBranch}' must target a versioned develop/X.Y.Z branch, not main.`
+              : 'No invalid breaking-change target detected.';
 
-            if (pr.base.ref !== 'main' || !breakingChange || validDevelopBranch) {
-              core.info('No invalid breaking-change target detected.');
+            // pull_request_target's automatic job check belongs to the base
+            // commit. Publish both policy outcomes on the current PR head before
+            // attempting optional warning delivery.
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Warn Invalid Breaking Change Target',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion: invalidTarget ? 'failure' : 'success',
+              output: {
+                title: invalidTarget ? 'Invalid breaking-change target' : 'Valid breaking-change target',
+                summary,
+              },
+            });
+
+            if (!invalidTarget) {
+              core.info(summary);
               return;
             }
 
             // Fail before comment delivery or deduplication: neither approves
             // a breaking change targeting the stable branch.
-            core.setFailed(
-              `Breaking change from '${sourceBranch}' must target a versioned develop/X.Y.Z branch, not main.`
-            );
+            core.setFailed(summary);
 
             const marker = '<!-- invalid-breaking-change-target-warning -->';
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -486,12 +486,25 @@ cargo make clippy-check
 ```
 
 **Breaking-change warning check:**
+`Warn Invalid Breaking Change Target` is required alongside `CI Success` on
+`main`. A breaking title or `breaking-change` label fails this check unless the
+source is a versioned `develop/X.Y.Z` branch. It reads current PR metadata on
+title, label, base, and source changes, including label removal. The failed
+result is independent of warning-comment delivery or deduplication; an existing
+warning never makes an invalid target pass. Retarget the breaking change to the
+appropriate develop branch, or correct an inaccurate classification.
+
 `Warn Invalid Breaking Change Target` posts to the PR conversation through the
 issue-comment API and requires `pull-requests: write` alongside `issues: write`.
 A `403 Resource not accessible by integration` during comment creation is a
 workflow permission failure. This `pull_request_target` workflow runs from the
 base branch, so permission repairs must reach that branch before a new PR event
 can validate them; changing only the affected PR head does not update the workflow.
+
+Run `node --test scripts/tests/test-breaking-change-target.cjs` and
+`actionlint .github/workflows/warn-invalid-breaking-change.yml` after changing
+the policy. Keep its check name synchronized with the required status check in
+the main-branch ruleset.
 
 ### RP-2 (SHOULD): Self-Review
 

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -494,8 +494,14 @@ result is independent of warning-comment delivery or deduplication; an existing
 warning never makes an invalid target pass. Retarget the breaking change to the
 appropriate develop branch, or correct an inaccurate classification.
 
-`Warn Invalid Breaking Change Target` posts to the PR conversation through the
-issue-comment API and requires `pull-requests: write` alongside `issues: write`.
+The trusted `pull_request_target` workflow publishes this named check explicitly
+on the current `pr.head.sha` through the Checks API with `checks: write`. Both
+success and failure are published before comment delivery. The automatic job
+check belongs to the base commit and has a distinct name,
+`Publish Breaking Change Target Check`; it is not the required PR check.
+
+The workflow also posts to the PR conversation through the issue-comment API
+and requires `pull-requests: write` alongside `issues: write`.
 A `403 Resource not accessible by integration` during comment creation is a
 workflow permission failure. This `pull_request_target` workflow runs from the
 base branch, so permission repairs must reach that branch before a new PR event

--- a/instructions/PR_GUIDELINE.md
+++ b/instructions/PR_GUIDELINE.md
@@ -507,7 +507,9 @@ workflow permission failure. This `pull_request_target` workflow runs from the
 base branch, so permission repairs must reach that branch before a new PR event
 can validate them; changing only the affected PR head does not update the workflow.
 
-Run `node --test scripts/tests/test-breaking-change-target.cjs` and
+CI runs the policy suite through `scripts/tests/test-breaking-change-target.sh`,
+which is discovered by `bash scripts/tests/run-all.sh` in the Version Markers
+Lint job. Run `node --test scripts/tests/test-breaking-change-target.cjs` and
 `actionlint .github/workflows/warn-invalid-breaking-change.yml` after changing
 the policy. Keep its check name synchronized with the required status check in
 the main-branch ruleset.

--- a/scripts/tests/test-breaking-change-target.cjs
+++ b/scripts/tests/test-breaking-change-target.cjs
@@ -1,0 +1,172 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+	encoding: 'utf8',
+}).trim();
+const workflow = readFileSync(
+	path.join(root, '.github/workflows/warn-invalid-breaking-change.yml'),
+	'utf8',
+);
+const script = workflow.split('          script: |\n')[1];
+assert.ok(script, 'the test must execute the actual workflow policy');
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const policy = new AsyncFunction('github', 'context', 'core', script);
+const marker = '<!-- invalid-breaking-change-target-warning -->';
+
+function pullRequest(overrides = {}) {
+	return {
+		number: 6276,
+		title: 'fix(pages): support RadioInput',
+		labels: [],
+		base: { ref: 'main' },
+		head: { ref: 'fix/issue-6270-form-radio-input' },
+		...overrides,
+	};
+}
+
+async function run(pr, options = {}) {
+	const result = { failures: [], comments: [], listed: 0, reads: [] };
+	const context = {
+		repo: { owner: 'kent8192', repo: 'reinhardt-web' },
+		payload: { pull_request: options.payload ?? pr },
+	};
+	const github = {
+		rest: {
+			pulls: {
+				get: async (request) => {
+					result.reads.push(request);
+					return { data: pr };
+				},
+			},
+			issues: {
+				listComments: Symbol('listComments'),
+				createComment: async (comment) => {
+					assert.equal(result.failures.length, 1, 'fail before posting');
+					if (options.postError) throw new Error('HTTP 403');
+					result.comments.push(comment);
+				},
+			},
+		},
+		paginate: async (endpoint, request) => {
+			assert.equal(endpoint, github.rest.issues.listComments);
+			assert.deepEqual(request, {
+				owner: 'kent8192', repo: 'reinhardt-web',
+				issue_number: 6276, per_page: 100,
+			});
+			assert.equal(result.failures.length, 1, 'fail before deduplication');
+			result.listed += 1;
+			return options.comments ?? [];
+		},
+	};
+	const core = {
+		setFailed: (message) => result.failures.push(message),
+		info: () => {},
+	};
+	try {
+		await policy(github, context, core);
+	} catch (error) {
+		result.error = error.message;
+	}
+	assert.deepEqual(result.reads, [{
+		owner: 'kent8192', repo: 'reinhardt-web', pull_number: 6276,
+	}]);
+	return result;
+}
+
+for (const title of [
+	'fix!: support RadioInput',
+	'fix!(pages): support RadioInput',
+	'fix(pages)!: support RadioInput',
+]) {
+	test(`rejects a main-targeting breaking title: ${title}`, async () => {
+		const result = await run(pullRequest({ title }));
+		assert.equal(result.error, undefined);
+		assert.equal(result.failures.length, 1);
+		assert.equal(result.comments.length, 1);
+		assert.equal(result.comments[0].issue_number, 6276);
+		assert.ok(result.comments[0].body.startsWith(marker));
+	});
+}
+
+test('a breaking-change label fails even without a breaking title', async () => {
+	const result = await run(pullRequest({ labels: [{ name: 'breaking-change' }] }));
+	assert.equal(result.failures.length, 1);
+	assert.equal(result.comments.length, 1);
+});
+
+test('an existing warning still fails without posting a duplicate', async () => {
+	const result = await run(pullRequest({ title: 'fix!(pages): support RadioInput' }), {
+		comments: [{ body: 'unrelated' }, { body: `${marker}\nExisting warning` }],
+	});
+	assert.equal(result.error, undefined);
+	assert.equal(result.failures.length, 1);
+	assert.equal(result.listed, 1);
+	assert.deepEqual(result.comments, []);
+});
+
+test('comment delivery failure cannot turn an invalid target green', async () => {
+	const result = await run(pullRequest({ title: 'fix!: support RadioInput' }), {
+		postError: true,
+	});
+	assert.equal(result.error, 'HTTP 403');
+	assert.equal(result.failures.length, 1);
+});
+
+for (const pr of [
+	pullRequest(),
+	pullRequest({ title: 'fix!: support RadioInput', base: { ref: 'develop/0.4.0' } }),
+	pullRequest({ title: 'feat!: release transition', head: { ref: 'develop/0.4.0' } }),
+]) {
+	test(`accepts ${pr.head.ref} -> ${pr.base.ref}: ${pr.title}`, async () => {
+		const result = await run(pr);
+		assert.equal(result.error, undefined);
+		assert.deepEqual(result.failures, []);
+		assert.deepEqual(result.comments, []);
+		assert.equal(result.listed, 0);
+	});
+}
+
+test('an unversioned develop branch does not bypass the check', async () => {
+	const result = await run(pullRequest({
+		title: 'feat!: change API', head: { ref: 'develop/next' },
+	}));
+	assert.equal(result.failures.length, 1);
+});
+
+test('current breaking metadata overrides a stale nonbreaking event', async () => {
+	const result = await run(pullRequest({ title: 'fix!: support RadioInput' }), {
+		payload: pullRequest(),
+	});
+	assert.equal(result.failures.length, 1);
+});
+
+test('removing a mistaken label clears failure despite an old warning', async () => {
+	const result = await run(pullRequest(), {
+		payload: pullRequest({ labels: [{ name: 'breaking-change' }] }),
+		comments: [{ body: marker }],
+	});
+	assert.deepEqual(result.failures, []);
+	assert.equal(result.listed, 0);
+});
+
+test('retargeted current metadata overrides an old main event', async () => {
+	const result = await run(pullRequest({
+		title: 'fix!: support RadioInput', base: { ref: 'develop/0.4.0' },
+	}), { payload: pullRequest({ title: 'fix!: support RadioInput' }) });
+	assert.deepEqual(result.failures, []);
+});
+
+test('metadata changes trigger the trusted required check', () => {
+	assert.match(workflow, /pull_request_target:/);
+	const events = workflow.match(/types: \[([^\]]+)\]/)[1].split(',').map(s => s.trim());
+	for (const event of ['edited', 'labeled', 'unlabeled', 'synchronize', 'ready_for_review']) {
+		assert.ok(events.includes(event), `missing ${event} trigger`);
+	}
+	assert.doesNotMatch(workflow, /actions\/checkout/);
+});

--- a/scripts/tests/test-breaking-change-target.cjs
+++ b/scripts/tests/test-breaking-change-target.cjs
@@ -18,6 +18,8 @@ assert.ok(script, 'the test must execute the actual workflow policy');
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 const policy = new AsyncFunction('github', 'context', 'core', script);
 const marker = '<!-- invalid-breaking-change-target-warning -->';
+const headSha = '1111111111111111111111111111111111111111';
+const baseSha = '2222222222222222222222222222222222222222';
 
 function pullRequest(overrides = {}) {
 	return {
@@ -25,15 +27,16 @@ function pullRequest(overrides = {}) {
 		title: 'fix(pages): support RadioInput',
 		labels: [],
 		base: { ref: 'main' },
-		head: { ref: 'fix/issue-6270-form-radio-input' },
+		head: { ref: 'fix/issue-6270-form-radio-input', sha: headSha },
 		...overrides,
 	};
 }
 
 async function run(pr, options = {}) {
-	const result = { failures: [], comments: [], listed: 0, reads: [] };
+	const result = { failures: [], comments: [], checks: [], listed: 0, reads: [] };
 	const context = {
 		repo: { owner: 'kent8192', repo: 'reinhardt-web' },
+		sha: baseSha,
 		payload: { pull_request: options.payload ?? pr },
 	};
 	const github = {
@@ -41,13 +44,23 @@ async function run(pr, options = {}) {
 			pulls: {
 				get: async (request) => {
 					result.reads.push(request);
+					if (options.readError) throw new Error('HTTP 403 reading PR');
 					return { data: pr };
+				},
+			},
+			checks: {
+				create: async (check) => {
+					assert.equal(result.listed, 0, 'publish before comment lookup');
+					assert.deepEqual(result.comments, [], 'publish before comment delivery');
+					if (options.checkError) throw new Error('HTTP 403 creating check');
+					result.checks.push(check);
 				},
 			},
 			issues: {
 				listComments: Symbol('listComments'),
 				createComment: async (comment) => {
 					assert.equal(result.failures.length, 1, 'fail before posting');
+					assertCheck(result, 'failure', pr.head.sha);
 					if (options.postError) throw new Error('HTTP 403');
 					result.comments.push(comment);
 				},
@@ -60,7 +73,9 @@ async function run(pr, options = {}) {
 				issue_number: 6276, per_page: 100,
 			});
 			assert.equal(result.failures.length, 1, 'fail before deduplication');
+			assertCheck(result, 'failure', pr.head.sha);
 			result.listed += 1;
+			if (options.listError) throw new Error('HTTP 403 listing comments');
 			return options.comments ?? [];
 		},
 	};
@@ -79,6 +94,21 @@ async function run(pr, options = {}) {
 	return result;
 }
 
+function assertCheck(result, conclusion, sha = headSha) {
+	assert.equal(result.checks.length, 1);
+	const { output, ...check } = result.checks[0];
+	assert.deepEqual(check, {
+		owner: 'kent8192',
+		repo: 'reinhardt-web',
+		name: 'Warn Invalid Breaking Change Target',
+		head_sha: sha,
+		status: 'completed',
+		conclusion,
+	});
+	assert.equal(output.title, conclusion === 'failure'
+		? 'Invalid breaking-change target' : 'Valid breaking-change target');
+}
+
 for (const title of [
 	'fix!: support RadioInput',
 	'fix!(pages): support RadioInput',
@@ -87,6 +117,7 @@ for (const title of [
 	test(`rejects a main-targeting breaking title: ${title}`, async () => {
 		const result = await run(pullRequest({ title }));
 		assert.equal(result.error, undefined);
+		assertCheck(result, 'failure');
 		assert.equal(result.failures.length, 1);
 		assert.equal(result.comments.length, 1);
 		assert.equal(result.comments[0].issue_number, 6276);
@@ -96,6 +127,7 @@ for (const title of [
 
 test('a breaking-change label fails even without a breaking title', async () => {
 	const result = await run(pullRequest({ labels: [{ name: 'breaking-change' }] }));
+	assertCheck(result, 'failure');
 	assert.equal(result.failures.length, 1);
 	assert.equal(result.comments.length, 1);
 });
@@ -105,6 +137,7 @@ test('an existing warning still fails without posting a duplicate', async () => 
 		comments: [{ body: 'unrelated' }, { body: `${marker}\nExisting warning` }],
 	});
 	assert.equal(result.error, undefined);
+	assertCheck(result, 'failure');
 	assert.equal(result.failures.length, 1);
 	assert.equal(result.listed, 1);
 	assert.deepEqual(result.comments, []);
@@ -115,17 +148,19 @@ test('comment delivery failure cannot turn an invalid target green', async () =>
 		postError: true,
 	});
 	assert.equal(result.error, 'HTTP 403');
+	assertCheck(result, 'failure');
 	assert.equal(result.failures.length, 1);
 });
 
 for (const pr of [
 	pullRequest(),
 	pullRequest({ title: 'fix!: support RadioInput', base: { ref: 'develop/0.4.0' } }),
-	pullRequest({ title: 'feat!: release transition', head: { ref: 'develop/0.4.0' } }),
+	pullRequest({ title: 'feat!: release transition', head: { ref: 'develop/0.4.0', sha: headSha } }),
 ]) {
 	test(`accepts ${pr.head.ref} -> ${pr.base.ref}: ${pr.title}`, async () => {
 		const result = await run(pr);
 		assert.equal(result.error, undefined);
+		assertCheck(result, 'success');
 		assert.deepEqual(result.failures, []);
 		assert.deepEqual(result.comments, []);
 		assert.equal(result.listed, 0);
@@ -134,8 +169,9 @@ for (const pr of [
 
 test('an unversioned develop branch does not bypass the check', async () => {
 	const result = await run(pullRequest({
-		title: 'feat!: change API', head: { ref: 'develop/next' },
+		title: 'feat!: change API', head: { ref: 'develop/next', sha: headSha },
 	}));
+	assertCheck(result, 'failure');
 	assert.equal(result.failures.length, 1);
 });
 
@@ -143,6 +179,7 @@ test('current breaking metadata overrides a stale nonbreaking event', async () =
 	const result = await run(pullRequest({ title: 'fix!: support RadioInput' }), {
 		payload: pullRequest(),
 	});
+	assertCheck(result, 'failure');
 	assert.equal(result.failures.length, 1);
 });
 
@@ -151,6 +188,7 @@ test('removing a mistaken label clears failure despite an old warning', async ()
 		payload: pullRequest({ labels: [{ name: 'breaking-change' }] }),
 		comments: [{ body: marker }],
 	});
+	assertCheck(result, 'success');
 	assert.deepEqual(result.failures, []);
 	assert.equal(result.listed, 0);
 });
@@ -159,7 +197,47 @@ test('retargeted current metadata overrides an old main event', async () => {
 	const result = await run(pullRequest({
 		title: 'fix!: support RadioInput', base: { ref: 'develop/0.4.0' },
 	}), { payload: pullRequest({ title: 'fix!: support RadioInput' }) });
+	assertCheck(result, 'success');
 	assert.deepEqual(result.failures, []);
+});
+
+test('publishes to the current fork head instead of the base or stale event SHA', async () => {
+	const currentSha = '3333333333333333333333333333333333333333';
+	const result = await run(pullRequest({
+		head: {
+			ref: 'fix/fork-change', sha: currentSha,
+			repo: { full_name: 'contributor/reinhardt-web' },
+		},
+	}), { payload: pullRequest() });
+	assert.equal(result.error, undefined);
+	assertCheck(result, 'success', currentSha);
+});
+
+test('comment lookup failure preserves the published failure', async () => {
+	const result = await run(pullRequest({ title: 'fix!: support RadioInput' }), {
+		listError: true,
+	});
+	assert.equal(result.error, 'HTTP 403 listing comments');
+	assertCheck(result, 'failure');
+	assert.deepEqual(result.comments, []);
+});
+
+test('check publication errors propagate without posting a warning', async () => {
+	const result = await run(pullRequest({ title: 'fix!: support RadioInput' }), {
+		checkError: true,
+	});
+	assert.equal(result.error, 'HTTP 403 creating check');
+	assert.deepEqual(result.checks, []);
+	assert.deepEqual(result.comments, []);
+	assert.equal(result.listed, 0);
+});
+
+test('metadata read errors propagate without publishing a policy result', async () => {
+	const result = await run(pullRequest(), { readError: true });
+	assert.equal(result.error, 'HTTP 403 reading PR');
+	assert.deepEqual(result.checks, []);
+	assert.deepEqual(result.comments, []);
+	assert.equal(result.listed, 0);
 });
 
 test('metadata changes trigger the trusted required check', () => {
@@ -169,4 +247,10 @@ test('metadata changes trigger the trusted required check', () => {
 		assert.ok(events.includes(event), `missing ${event} trigger`);
 	}
 	assert.doesNotMatch(workflow, /actions\/checkout/);
+});
+
+test('the publisher has check permission and a distinct automatic job name', () => {
+	assert.match(workflow, /^  checks: write$/m);
+	assert.match(workflow, /^    name: Publish Breaking Change Target Check$/m);
+	assert.doesNotMatch(workflow, /^    name: Warn Invalid Breaking Change Target$/m);
 });

--- a/scripts/tests/test-breaking-change-target.sh
+++ b/scripts/tests/test-breaking-change-target.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Run the Node policy suite through the shared shell-test entry point.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+cd "$ROOT_DIR"
+exec node --test "$SCRIPT_DIR/test-breaking-change-target.cjs"


### PR DESCRIPTION
## Summary

Breaking changes targeting `main` currently produce a warning but a successful check. Publish `Warn Invalid Breaking Change Target` on the current PR head SHA, with an explicit success or failure based on live metadata, before warning delivery or deduplication.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [x] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

Refs #6276. A previously posted warning must not approve an invalid target. The trusted `pull_request_target` workflow publishes the required check through the Checks API with `checks: write`, using the current `pr.head.sha`. Its automatic base-commit job is separately named `Publish Breaking Change Target Check`. Both policy outcomes are published before listing or creating comments, and stale event metadata does not determine the result. Label removal and Ready transitions also trigger reevaluation.

A discovered shell wrapper runs the Node policy suite through the existing `scripts/tests/run-all.sh` CI entry point.

The main branch ruleset now requires this existing check name alongside `CI Success`; strict checking, other rules, and bypass actors are preserved. The failure behavior takes effect after this workflow repair reaches the base branch because it runs on `pull_request_target`.

## How Was This Tested?

- `bash scripts/tests/run-all.sh`: all script suites passed, including the 19 policy tests executed through the new shell wrapper.
- `node --test scripts/tests/test-breaking-change-target.cjs`: 19 tests passed against the actual workflow script. The added publication assertions failed against the original workflow before the fix.
- Covers all supported breaking-title forms, label detection, existing comments, comment lookup/delivery errors, metadata and check-publication errors, current PR head versus base/stale event SHAs, fork-head metadata, corrected classifications, retargeting, versioned develop sources, check permissions, and distinct publisher/required-check names.
- `shellcheck scripts/tests/test-breaking-change-target.sh` and `bash -n scripts/tests/test-breaking-change-target.sh` passed.
- `actionlint .github/workflows/warn-invalid-breaking-change.yml` passed.
- `git diff --check` passed.
- Read back ruleset 12082357 and verified both required checks and preservation of every other submitted field.

Rust code is unchanged; Cargo compilation and database tests do not exercise this policy.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [ ] I have formatted the code with `cargo make fmt-fix`
- [ ] I have checked the code with `cargo make clippy-check`
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6276

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- [x] `ci-cd` - CI/CD workflow changes

---

**Additional Context:**

🤖 Generated with [Codex](https://openai.com/codex/)
