### PR TITLE
fix: install and invoke ExceptionHandler across the request path

### DIFF
--- a/crates/reinhardt-commands/src/builtin.rs
+++ b/crates/reinhardt-commands/src/builtin.rs
@@ -2491,6 +2491,12 @@ impl RunServerCommand {
 			crate::CommandError::ExecutionError("Failed to get registered router".to_string())
 		})?;
 
+		// Forward any exception handler installed on the router to the server, so
+		// errors raised by server-level middleware use the same handler as the
+		// router's own 404/405 and view errors. Read before the router is wrapped
+		// and moved into `HttpServer`. (Issue #6294)
+		let router_exception_handler = base_router.exception_handler().cloned();
+
 		// Wrap with OpenAPI endpoints if enabled
 		#[cfg(feature = "openapi-router")]
 		let router = if !no_docs {
@@ -2610,6 +2616,12 @@ impl RunServerCommand {
 		let mut server = HttpServer::new(router)
 			.with_di_context(di_context)
 			.with_middleware(reinhardt_middleware::LoggingMiddleware::new());
+
+		// Errors raised by the server-level middleware registered above, or by the
+		// static-file middleware below, must use the router's handler too.
+		if let Some(exception_handler) = router_exception_handler {
+			server = server.with_exception_handler(exception_handler);
+		}
 
 		// Add static files middleware for WASM frontend if enabled
 		if with_pages {

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -81,6 +81,11 @@ Users should depend on `` `reinhardt-graphql` `` (this facade crate) for all Gra
   - `execute_query()`: Execute GraphQL queries via unary RPC
   - `execute_mutation()`: Execute GraphQL mutations via unary RPC
   - `execute_subscription()`: Execute GraphQL subscriptions via server streaming RPC
+- **Operation-Class Enforcement**: Each RPC validates the selected operation before
+  execution. Malformed documents, invalid or ambiguous operation selections, and
+  operation-class mismatches return gRPC `INVALID_ARGUMENT` before any resolver
+  runs. Subscription failures are reported as stream errors. Multiple operations
+  require an exact `operation_name`; a single operation may omit it or use an empty name.
 - **Protocol Buffers**: Complete proto definitions in `reinhardt-grpc` crate
   - `GraphQLRequest`: query, variables, operation_name
   - `GraphQLResponse`: data, errors, extensions
@@ -250,8 +255,20 @@ async fn handler(
 
 ### GraphQL over gRPC Server
 
+**Migration:** Replace `Schema::build(...)` or `Schema::new(...)` with
+`GraphQLGrpcService::schema_builder(...).finish()` (keep existing builder calls
+before `finish`). `GraphQLGrpcService::new` rejects schemas without the guard at
+construction time. The built-in `create_schema` helpers install it automatically
+when `graphql-grpc` is enabled.
+
+The guard runs after all `prepare_request` and `parse_query` extensions. Request
+rewrites, persisted documents, and parsing limits therefore retain their normal
+order, while the final selected operation must match the RPC. Schema validation
+and resolver authorization still apply. The finished schema can also serve HTTP
+requests without a gRPC operation restriction.
+
 ```rust
-use async_graphql::{EmptySubscription, Schema};
+use async_graphql::EmptySubscription;
 use reinhardt::graphql::grpc_service::GraphQLGrpcService;
 use reinhardt::graphql::schema::{Mutation, Query, UserStorage};
 use reinhardt::grpc::proto::graphql::graph_ql_service_server::GraphQlServiceServer;
@@ -260,7 +277,7 @@ use tonic::transport::Server;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let storage = UserStorage::new();
-    let schema = Schema::build(Query, Mutation, EmptySubscription)
+    let schema = GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription)
         .data(storage)
         .finish();
 

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -33,11 +33,19 @@ resolver arguments are attacker-controlled.
   resolver and subscription execution. Protected deployments must fork a
   request context for each GraphQL request; the schema-level
   `with_di_context` helper reuses one context and does not provide request
-  isolation automatically. GraphQL-over-gRPC preserves the same GraphQL and
-  gRPC authorization, validation, isolation, and resource limits only when
-  each RPC rejects documents whose operation type does not match the RPC and
-  applies the corresponding controls; the current service forwards documents
-  to schema execution without enforcing that operation-type match.
+  isolation automatically.
+- GraphQL-over-gRPC binds the selected document operation to the advertised RPC
+  class before execution. Malformed documents, invalid or ambiguous operation
+  selections, and class mismatches fail with gRPC `INVALID_ARGUMENT` before
+  resolver execution or resolver subscription creation. Subscription errors are
+  delivered through the response stream. Validation applies to the final document
+  and operation name produced by schema extensions, without parsing before their
+  preparation checks. Custom schemas must use `GraphQLGrpcService::schema_builder`
+  to register the guard before user extensions; service construction rejects
+  unguarded schemas. The built-in schema helpers install the guard automatically
+  when `graphql-grpc` is enabled.
+  Deployments must still configure and enforce schema and resolver authorization,
+  request isolation, and resource limits.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-graphql/src/grpc_service.rs
+++ b/crates/reinhardt-graphql/src/grpc_service.rs
@@ -1,7 +1,16 @@
 //! GraphQL over gRPC service implementation
 
+mod operation_guard;
+
+#[cfg(test)]
+mod tests;
+
+use operation_guard::{GuardedSchema, OperationCheck, OperationGuard};
+
 #[cfg(feature = "graphql-grpc")]
-use async_graphql::Schema;
+use async_graphql::parser::types::OperationType;
+#[cfg(feature = "graphql-grpc")]
+use async_graphql::{Schema, SchemaBuilder};
 #[cfg(feature = "graphql-grpc")]
 use reinhardt_grpc::proto::graphql::{
 	GraphQlRequest, GraphQlResponse, SubscriptionEvent, graph_ql_service_server::GraphQlService,
@@ -13,7 +22,12 @@ use tokio_stream::{Stream, StreamExt};
 #[cfg(feature = "graphql-grpc")]
 use tonic::{Request, Response, Status};
 
-/// GraphQL service implementation for gRPC
+/// GraphQL service implementation for gRPC.
+///
+/// Build the schema with [`Self::schema_builder`] so operation checks run after
+/// request preparation and document transformations, before any resolver runs.
+/// Invalid documents, operation selections, and class mismatches return gRPC
+/// `INVALID_ARGUMENT`. Subscriptions report these errors through their stream.
 #[cfg(feature = "graphql-grpc")]
 pub struct GraphQLGrpcService<Query, Mutation, Subscription> {
 	schema: Arc<Schema<Query, Mutation, Subscription>>,
@@ -26,16 +40,60 @@ where
 	Mutation: async_graphql::ObjectType + 'static,
 	Subscription: async_graphql::SubscriptionType + 'static,
 {
-	/// Create a new GraphQL gRPC service
+	/// Create a new GraphQL gRPC service.
+	///
+	/// # Panics
+	///
+	/// Panics if the schema was not created with [`Self::schema_builder`] (or the
+	/// built-in `create_schema` helpers with `graphql-grpc` enabled). A completed
+	/// schema cannot be retrofitted with the operation guard.
 	pub fn new(schema: Schema<Query, Mutation, Subscription>) -> Self {
+		assert!(
+			schema.data::<GuardedSchema>().is_some(),
+			"GraphQLGrpcService requires a schema built with GraphQLGrpcService::schema_builder"
+		);
 		Self {
 			schema: Arc::new(schema),
 		}
 	}
 
-	/// Convert GraphQL request to async-graphql request
-	fn convert_request(&self, req: GraphQlRequest) -> async_graphql::Request {
-		let mut gql_req = async_graphql::Request::new(&req.query);
+	/// Build a schema with transport validation surrounding all user extensions.
+	///
+	/// Replace `Schema::build` with this method and keep subsequent builder calls.
+	/// The finished schema can be shared with HTTP handlers; ordinary requests are
+	/// unaffected by the gRPC operation constraint.
+	///
+	/// ```
+	/// use async_graphql::{EmptyMutation, EmptySubscription, Object};
+	/// use reinhardt_graphql::GraphQLGrpcService;
+	/// struct Query;
+	/// #[Object]
+	/// impl Query {
+	///     async fn value(&self) -> i32 { 7 }
+	/// }
+	/// let schema = GraphQLGrpcService::schema_builder(Query, EmptyMutation, EmptySubscription)
+	///     .limit_depth(10)
+	///     .finish();
+	/// let service = GraphQLGrpcService::new(schema);
+	/// ```
+	pub fn schema_builder(
+		query: Query,
+		mutation: Mutation,
+		subscription: Subscription,
+	) -> SchemaBuilder<Query, Mutation, Subscription> {
+		Schema::build(query, mutation, subscription)
+			.extension(OperationGuard)
+			.data(GuardedSchema)
+	}
+
+	/// Convert the request without parsing ahead of schema preparation hooks.
+	fn convert_request(
+		&self,
+		req: GraphQlRequest,
+		expected: OperationType,
+	) -> (async_graphql::Request, Arc<OperationCheck>) {
+		let check = OperationCheck::new(expected);
+		let mut gql_req = async_graphql::Request::new(req.query).data(Arc::clone(&check));
 
 		// Add variables if present
 		if let Some(variables) = req.variables
@@ -52,7 +110,7 @@ where
 			gql_req = gql_req.operation_name(operation_name);
 		}
 
-		gql_req
+		(gql_req, check)
 	}
 
 	/// Convert async-graphql response to gRPC response
@@ -151,10 +209,13 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<GraphQlResponse>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Query);
 
 		// Execute query
 		let gql_resp = self.schema.execute(gql_req).await;
+		if let Some(error) = check.error() {
+			return Err(error);
+		}
 
 		// Convert response
 		let grpc_resp = self.convert_response(gql_resp);
@@ -168,10 +229,13 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<GraphQlResponse>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Mutation);
 
 		// Execute mutation
 		let gql_resp = self.schema.execute(gql_req).await;
+		if let Some(error) = check.error() {
+			return Err(error);
+		}
 
 		// Convert response
 		let grpc_resp = self.convert_response(gql_resp);
@@ -188,7 +252,7 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<Self::ExecuteSubscriptionStream>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Subscription);
 
 		// Clone schema for 'static lifetime requirement
 		let schema = Arc::clone(&self.schema);
@@ -200,6 +264,10 @@ where
 
 			let mut event_id = 0u64;
 			while let Some(resp) = stream.next().await {
+				if let Some(error) = check.error() {
+					yield Err(error);
+					return;
+				}
 				event_id += 1;
 
 				let grpc_resp = GraphQlResponse {

--- a/crates/reinhardt-graphql/src/grpc_service/operation_guard.rs
+++ b/crates/reinhardt-graphql/src/grpc_service/operation_guard.rs
@@ -1,0 +1,143 @@
+//! Enforce the transport constraint on the document produced by schema extensions.
+
+use async_graphql::extensions::{
+	Extension, ExtensionContext, ExtensionFactory, NextParseQuery, NextPrepareRequest,
+};
+use async_graphql::parser::types::{DocumentOperations, ExecutableDocument, OperationType};
+use async_graphql::{Request, ServerError, ServerResult, Variables};
+use std::any::TypeId;
+use std::sync::{Arc, OnceLock};
+use tonic::Status;
+
+pub(super) struct GuardedSchema;
+
+pub(super) struct OperationCheck {
+	expected: OperationType,
+	error: OnceLock<Status>,
+}
+
+impl OperationCheck {
+	pub(super) fn new(expected: OperationType) -> Arc<Self> {
+		Arc::new(Self {
+			expected,
+			error: OnceLock::new(),
+		})
+	}
+
+	pub(super) fn error(&self) -> Option<Status> {
+		self.error.get().cloned()
+	}
+
+	fn reject(&self, status: Status) -> ServerError {
+		let error = ServerError::new(status.message(), None);
+		let _ = self.error.set(status);
+		error
+	}
+}
+
+pub(super) struct OperationGuard;
+
+impl ExtensionFactory for OperationGuard {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(OperationGuardExtension::default())
+	}
+}
+
+struct PreparedOperation {
+	check: Arc<OperationCheck>,
+	operation_name: Option<String>,
+}
+
+#[derive(Default)]
+struct OperationGuardExtension {
+	prepared: OnceLock<PreparedOperation>,
+}
+
+#[async_trait::async_trait]
+impl Extension for OperationGuardExtension {
+	async fn prepare_request(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		request: Request,
+		next: NextPrepareRequest<'_>,
+	) -> ServerResult<Request> {
+		// Keep the RPC constraint even when an extension replaces the entire request.
+		let check = request
+			.data
+			.get(&TypeId::of::<Arc<OperationCheck>>())
+			.and_then(|data| data.downcast_ref::<Arc<OperationCheck>>())
+			.cloned();
+		let request = next.run(ctx, request).await?;
+		if let Some(check) = check {
+			let _ = self.prepared.set(PreparedOperation {
+				check,
+				operation_name: request.operation_name.clone(),
+			});
+		}
+		Ok(request)
+	}
+
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &Variables,
+		next: NextParseQuery<'_>,
+	) -> ServerResult<ExecutableDocument> {
+		// This is the first registered extension, so all request and document
+		// transformations finish before the transport constraint is checked.
+		let result = next.run(ctx, query, variables).await;
+		let Some(prepared) = self.prepared.get() else {
+			// The same schema can also serve ordinary GraphQL requests.
+			return result;
+		};
+		let document = result.map_err(|error| {
+			prepared.check.reject(Status::invalid_argument(format!(
+				"Invalid GraphQL document: {}",
+				error.message
+			)))
+		})?;
+		validate_operation(
+			&document,
+			prepared.operation_name.as_deref(),
+			prepared.check.expected,
+		)
+		.map_err(|status| prepared.check.reject(status))?;
+		Ok(document)
+	}
+}
+
+fn validate_operation(
+	document: &ExecutableDocument,
+	operation_name: Option<&str>,
+	expected: OperationType,
+) -> Result<(), Status> {
+	// Match async-graphql's operation selection, including a lone named operation.
+	let operation = match (&document.operations, operation_name) {
+		(DocumentOperations::Single(operation), None) => operation,
+		(DocumentOperations::Single(_), Some(_)) => {
+			return Err(Status::invalid_argument(
+				"operation_name cannot select an anonymous operation",
+			));
+		}
+		(DocumentOperations::Multiple(operations), Some(name)) => operations
+			.get(name)
+			.ok_or_else(|| Status::invalid_argument("operation_name was not found"))?,
+		(DocumentOperations::Multiple(operations), None) if operations.len() == 1 => operations
+			.values()
+			.next()
+			.expect("single operation was checked"),
+		(DocumentOperations::Multiple(_), None) => {
+			return Err(Status::invalid_argument(
+				"operation_name is required for documents with multiple operations",
+			));
+		}
+	};
+	if operation.node.ty != expected {
+		return Err(Status::invalid_argument(format!(
+			"Expected a {expected} operation, received {}",
+			operation.node.ty
+		)));
+	}
+	Ok(())
+}

--- a/crates/reinhardt-graphql/src/grpc_service/tests.rs
+++ b/crates/reinhardt-graphql/src/grpc_service/tests.rs
@@ -1,0 +1,633 @@
+use super::*;
+use async_graphql::extensions::{
+	Extension, ExtensionContext, ExtensionFactory, NextParseQuery, NextPrepareRequest,
+};
+use async_graphql::parser::types::ExecutableDocument;
+use async_graphql::parser::types::OperationType;
+use rstest::{fixture, rstest};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Default)]
+struct RequestExtension {
+	replacement: Option<String>,
+	operation_name: Option<String>,
+	max_bytes: Option<usize>,
+	replace_entire: bool,
+	prepared: Arc<AtomicUsize>,
+	parsed: Arc<AtomicUsize>,
+}
+
+impl ExtensionFactory for RequestExtension {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(self.clone())
+	}
+}
+
+#[async_trait::async_trait]
+impl Extension for RequestExtension {
+	async fn prepare_request(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		mut request: async_graphql::Request,
+		next: NextPrepareRequest<'_>,
+	) -> async_graphql::ServerResult<async_graphql::Request> {
+		self.prepared.fetch_add(1, Ordering::SeqCst);
+		if self
+			.max_bytes
+			.is_some_and(|limit| request.query.len() > limit)
+		{
+			return Err(async_graphql::ServerError::new(
+				"Document size limit exceeded",
+				None,
+			));
+		}
+		if let Some(query) = &self.replacement {
+			// Replacing the whole request must not discard the transport's constraint.
+			if self.replace_entire {
+				let variables = request.variables;
+				request = async_graphql::Request::new(query).variables(variables);
+			} else {
+				request.query.clone_from(query);
+			}
+			request.operation_name = self.operation_name.clone();
+		}
+		next.run(ctx, request).await
+	}
+
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &async_graphql::Variables,
+		next: NextParseQuery<'_>,
+	) -> async_graphql::ServerResult<ExecutableDocument> {
+		self.parsed.fetch_add(1, Ordering::SeqCst);
+		next.run(ctx, query, variables).await
+	}
+}
+
+fn service_with_extension(extension: RequestExtension) -> (TestService, Arc<Calls>) {
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.extension(extension)
+	.finish();
+	(TestService::new(schema), calls)
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_executes_prepared_document(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[values(false, true)] invalid_original: bool,
+	#[values(false, true)] replace_entire: bool,
+) {
+	// Arrange: preparation replaces the document, selected name, and request data.
+	let prepared = Arc::new(AtomicUsize::new(0));
+	let parsed = Arc::new(AtomicUsize::new(0));
+	let (service, calls) = service_with_extension(RequestExtension {
+		replacement: Some(format!(
+			"{rpc} Prepared($amount: Int!) {{ value(amount: $amount) }}"
+		)),
+		operation_name: Some("Prepared".into()),
+		max_bytes: None,
+		replace_entire,
+		prepared: Arc::clone(&prepared),
+		parsed: Arc::clone(&parsed),
+	});
+	let original = if invalid_original {
+		"not a GraphQL document".into()
+	} else {
+		format!("{rpc} Original {{ value(amount: 1) }}")
+	};
+
+	// Act
+	let response = dispatch(&service, rpc, request(&original, Some("Original")))
+		.await
+		.unwrap();
+
+	// Assert: only the prepared document executes, and hooks run once.
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts().iter().sum::<usize>(), 1);
+	assert_eq!(prepared.load(Ordering::SeqCst), 1);
+	assert_eq!(parsed.load(Ordering::SeqCst), 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_runs_preparation_limits_before_parsing(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+) {
+	// Arrange: this invalid document must be rejected by preparation, before parsing.
+	let prepared = Arc::new(AtomicUsize::new(0));
+	let parsed = Arc::new(AtomicUsize::new(0));
+	let (service, calls) = service_with_extension(RequestExtension {
+		replacement: None,
+		operation_name: None,
+		max_bytes: Some(8),
+		replace_entire: false,
+		prepared: Arc::clone(&prepared),
+		parsed: Arc::clone(&parsed),
+	});
+
+	// Act
+	let response = dispatch(&service, rpc, request("not a GraphQL document", None))
+		.await
+		.unwrap();
+
+	// Assert: preserve the extension's rejection and never run a resolver.
+	assert_eq!(response.data, None);
+	assert_eq!(response.errors.len(), 1);
+	assert_eq!(response.errors[0].message, "Document size limit exceeded");
+	assert_eq!(calls.counts(), [0, 0, 0]);
+	assert_eq!(prepared.load(Ordering::SeqCst), 1);
+	assert_eq!(parsed.load(Ordering::SeqCst), 0);
+}
+
+#[derive(Clone)]
+struct ReplaceDocument(String);
+
+impl ExtensionFactory for ReplaceDocument {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(self.clone())
+	}
+}
+
+#[async_trait::async_trait]
+impl Extension for ReplaceDocument {
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &async_graphql::Variables,
+		next: NextParseQuery<'_>,
+	) -> async_graphql::ServerResult<ExecutableDocument> {
+		next.run(ctx, query, variables).await?;
+		// A user extension can return a different AST after the parser finishes.
+		async_graphql::parser::parse_query(&self.0).map_err(Into::into)
+	}
+}
+
+#[rstest]
+#[case(OperationType::Query, OperationType::Mutation)]
+#[case(OperationType::Query, OperationType::Subscription)]
+#[case(OperationType::Mutation, OperationType::Query)]
+#[case(OperationType::Mutation, OperationType::Subscription)]
+#[case(OperationType::Subscription, OperationType::Query)]
+#[case(OperationType::Subscription, OperationType::Mutation)]
+#[tokio::test]
+async fn rpc_rejects_class_changes_from_extensions(
+	#[case] rpc: OperationType,
+	#[case] replacement: OperationType,
+	#[values(false, true)] replace_at_parse: bool,
+) {
+	// Arrange: the original document matches the RPC, but the final one does not.
+	let calls = Arc::new(Calls::default());
+	let builder = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	);
+	let query = format!("{replacement} {{ value(amount: 7) }}");
+	let schema = if replace_at_parse {
+		builder.extension(ReplaceDocument(query)).finish()
+	} else {
+		builder
+			.extension(RequestExtension {
+				replacement: Some(query),
+				replace_entire: true,
+				..Default::default()
+			})
+			.finish()
+	};
+	let service = TestService::new(schema);
+	let original = format!("{rpc} {{ value(amount: 1) }}");
+
+	// Act
+	let error = dispatch(&service, rpc, request(&original, None))
+		.await
+		.unwrap_err();
+
+	// Assert: every transformed mismatch is rejected before side effects.
+	assert_eq!(error.code(), tonic::Code::InvalidArgument);
+	assert_eq!(
+		error.message(),
+		format!("Expected a {rpc} operation, received {replacement}")
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_executes_document_returned_by_parse_extension(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+) {
+	// Arrange
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.extension(ReplaceDocument(format!("{rpc} {{ value(amount: 7) }}")))
+	.finish();
+	let service = TestService::new(schema);
+
+	// Act
+	let response = dispatch(
+		&service,
+		rpc,
+		request(&format!("{rpc} {{ value(amount: 1) }}"), None),
+	)
+	.await
+	.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts().iter().sum::<usize>(), 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn schema_remains_shareable_with_ordinary_graphql_requests(
+	service: (TestService, Arc<Calls>),
+) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act: ordinary requests do not carry an RPC operation constraint.
+	let response = service
+		.schema
+		.execute("mutation { value(amount: 7) }")
+		.await;
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data, async_graphql::value!({"value": 7}));
+	assert_eq!(calls.counts(), [0, 1, 0]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn concurrent_rpcs_keep_independent_constraints(service: (TestService, Arc<Calls>)) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act
+	let (query, mutation, subscription) = tokio::join!(
+		dispatch(
+			&service,
+			OperationType::Query,
+			request("mutation { value(amount: 1) }", None)
+		),
+		dispatch(
+			&service,
+			OperationType::Mutation,
+			request("mutation { value(amount: 7) }", None)
+		),
+		dispatch(
+			&service,
+			OperationType::Subscription,
+			request("subscription { value(amount: 7) }", None)
+		),
+	);
+
+	// Assert
+	assert_eq!(query.unwrap_err().code(), tonic::Code::InvalidArgument);
+	assert_eq!(mutation.unwrap().data.as_deref(), Some("{value: 7}"));
+	assert_eq!(subscription.unwrap().data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts(), [0, 1, 1]);
+}
+
+#[rstest]
+#[should_panic(
+	expected = "GraphQLGrpcService requires a schema built with GraphQLGrpcService::schema_builder"
+)]
+fn service_rejects_schema_without_operation_guard() {
+	// Arrange
+	let calls = Arc::new(Calls::default());
+	let schema = Schema::new(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(calls),
+	);
+
+	// Act / Assert: an unguarded schema cannot become an executable gRPC service.
+	TestService::new(schema);
+}
+
+#[derive(Default)]
+struct Calls([AtomicUsize; 3]);
+
+impl Calls {
+	fn counts(&self) -> [usize; 3] {
+		self.0.each_ref().map(|count| count.load(Ordering::SeqCst))
+	}
+}
+
+struct Query(Arc<Calls>);
+struct Mutation(Arc<Calls>);
+struct Subscription(Arc<Calls>);
+
+#[async_graphql::Object]
+impl Query {
+	async fn value(&self, amount: i32) -> i32 {
+		self.0.0[0].fetch_add(1, Ordering::SeqCst);
+		amount
+	}
+}
+
+#[async_graphql::Object]
+impl Mutation {
+	async fn value(&self, amount: i32) -> i32 {
+		self.0.0[1].fetch_add(1, Ordering::SeqCst);
+		amount
+	}
+}
+
+#[async_graphql::Subscription]
+impl Subscription {
+	async fn value(&self, amount: i32) -> impl Stream<Item = i32> {
+		self.0.0[2].fetch_add(1, Ordering::SeqCst);
+		tokio_stream::iter([amount])
+	}
+}
+
+type TestService = GraphQLGrpcService<Query, Mutation, Subscription>;
+
+#[fixture]
+fn service() -> (TestService, Arc<Calls>) {
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.finish();
+	(TestService::new(schema), calls)
+}
+
+fn request(query: &str, operation_name: Option<&str>) -> Request<GraphQlRequest> {
+	Request::new(GraphQlRequest {
+		query: query.into(),
+		operation_name: operation_name.map(str::to_owned),
+		variables: Some(r#"{"amount":7}"#.into()),
+	})
+}
+
+async fn dispatch(
+	service: &TestService,
+	rpc: OperationType,
+	request: Request<GraphQlRequest>,
+) -> Result<GraphQlResponse, Status> {
+	match rpc {
+		OperationType::Query => service
+			.execute_query(request)
+			.await
+			.map(Response::into_inner),
+		OperationType::Mutation => service
+			.execute_mutation(request)
+			.await
+			.map(Response::into_inner),
+		OperationType::Subscription => {
+			let mut stream = service.execute_subscription(request).await?.into_inner();
+			let event = stream.next().await.expect("one subscription event")?;
+			assert_eq!(event.event_type, "data");
+			assert_eq!(event.id, "1");
+			assert_eq!(stream.next().await.map(|_| ()), None);
+			Ok(event.payload.expect("subscription payload"))
+		}
+	}
+}
+
+#[rstest]
+#[case(OperationType::Query, "mutation", None)]
+#[case(OperationType::Query, "subscription", None)]
+#[case(OperationType::Mutation, "query", None)]
+#[case(OperationType::Mutation, "subscription", None)]
+#[case(OperationType::Subscription, "query", None)]
+#[case(OperationType::Subscription, "mutation", None)]
+#[case(OperationType::Query, "mutation", Some("Selected"))]
+#[case(OperationType::Query, "subscription", Some("Selected"))]
+#[case(OperationType::Mutation, "query", Some("Selected"))]
+#[case(OperationType::Mutation, "subscription", Some("Selected"))]
+#[case(OperationType::Subscription, "query", Some("Selected"))]
+#[case(OperationType::Subscription, "mutation", Some("Selected"))]
+#[tokio::test]
+async fn rpc_rejects_mismatched_operation_before_resolver_execution(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] submitted: &str,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange: include a matching decoy before the selected mismatched operation.
+	let (service, calls) = service;
+	let query = if operation_name.is_some() {
+		format!("{rpc} Decoy {{ value(amount: 1) }} {submitted} Selected {{ value(amount: 7) }}")
+	} else {
+		format!("{submitted} {{ value(amount: 7) }}")
+	};
+	let request = request(&query, operation_name);
+
+	// Act: drive subscription preparation without allowing a resolver to run.
+	let result = dispatch(&service, rpc, request).await;
+
+	// Assert: no query, mutation, or subscription resolver ran.
+	assert_eq!(calls.counts(), [0, 0, 0]);
+	let error = result.expect_err("RPC must reject the selected operation class");
+	assert_eq!(error.code(), tonic::Code::InvalidArgument);
+	assert_eq!(
+		error.message(),
+		format!("Expected a {rpc} operation, received {submitted}")
+	);
+}
+
+#[rstest]
+#[case("", None)]
+#[case("query {", None)]
+#[case("fragment Fields on Query { value(amount: 7) }", None)]
+#[case(
+	"query Same { value(amount: 7) } mutation Same { value(amount: 7) }",
+	Some("Same")
+)]
+#[case("{ value(amount: 7) } query Read { value(amount: 7) }", None)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	None
+)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	Some("")
+)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	Some("Missing")
+)]
+#[case("query Read { value(amount: 7) }", Some("read"))]
+#[case("query Read { value(amount: 7) }", Some(" Read "))]
+#[case("{ value(amount: 7) }", Some("Read"))]
+#[tokio::test]
+async fn rpc_rejects_invalid_or_ambiguous_selection(
+	service: (TestService, Arc<Calls>),
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[case] query: &str,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let request = request(query, operation_name);
+
+	// Act
+	let result = dispatch(&service, rpc, request).await;
+
+	// Assert
+	assert_eq!(
+		result.expect_err("invalid operation selection").code(),
+		tonic::Code::InvalidArgument
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}
+
+#[rstest]
+#[case(false, None)]
+#[case(false, Some(""))]
+#[case(true, None)]
+#[case(true, Some(""))]
+#[case(true, Some("Selected"))]
+#[tokio::test]
+async fn rpc_accepts_single_operation(
+	service: (TestService, Arc<Calls>),
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[case] named: bool,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let name = if named { "Selected" } else { "" };
+	let query = format!("{rpc} {name}($amount: Int!) {{ value(amount: $amount) }}");
+
+	// Act
+	let response = dispatch(&service, rpc, request(&query, operation_name))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(
+		calls.counts(),
+		match rpc {
+			OperationType::Query => [1, 0, 0],
+			OperationType::Mutation => [0, 1, 0],
+			OperationType::Subscription => [0, 0, 1],
+		}
+	);
+}
+
+#[rstest]
+#[case(OperationType::Query, "Read", [1, 0, 0])]
+#[case(OperationType::Mutation, "Change", [0, 1, 0])]
+#[case(OperationType::Subscription, "Watch", [0, 0, 1])]
+#[tokio::test]
+async fn rpc_selects_matching_operation_with_variables_aliases_and_fragments(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] operation_name: &str,
+	#[case] expected_calls: [usize; 3],
+) {
+	// Arrange: only the selected operation may execute, regardless of document order.
+	let (service, calls) = service;
+	let query = "mutation Change($amount: Int!) { ...MutationFields }
+		subscription Watch($amount: Int!) { result: value(amount: $amount) }
+		query Read($amount: Int!) { ...QueryFields }
+		fragment QueryFields on Query { result: value(amount: $amount) }
+		fragment MutationFields on Mutation { result: value(amount: $amount) }";
+
+	// Act
+	let response = dispatch(&service, rpc, request(query, Some(operation_name)))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{result: 7}"));
+	assert_eq!(calls.counts(), expected_calls);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_accepts_shorthand_query(service: (TestService, Arc<Calls>)) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act
+	let response = service
+		.execute_query(request("{ value(amount: 7) }", None))
+		.await
+		.unwrap()
+		.into_inner();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts(), [1, 0, 0]);
+}
+
+#[rstest]
+#[case(OperationType::Query, "Query")]
+#[case(OperationType::Mutation, "Mutation")]
+#[case(OperationType::Subscription, "Subscription")]
+#[tokio::test]
+async fn rpc_preserves_schema_validation_errors(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] root_type: &str,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let query = format!("{rpc} {{ missing }}");
+
+	// Act: valid operation selection still reaches schema validation.
+	let response = dispatch(&service, rpc, request(&query, None))
+		.await
+		.unwrap();
+
+	// Assert: schema errors retain their GraphQL response shape.
+	assert_eq!(response.data, None);
+	assert_eq!(response.errors.len(), 1);
+	assert_eq!(
+		response.errors[0].message,
+		format!("Unknown field \"missing\" on type \"{root_type}\".")
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}

--- a/crates/reinhardt-graphql/src/lib.rs
+++ b/crates/reinhardt-graphql/src/lib.rs
@@ -10,6 +10,22 @@
 //! - **di**: Dependency injection support for GraphQL resolvers
 //! - **full**: All features enabled
 //!
+//! # GraphQL over gRPC
+//!
+//! Each RPC accepts only its advertised query, mutation, or subscription operation.
+//! The adapter returns gRPC `INVALID_ARGUMENT` for malformed documents, invalid or
+//! ambiguous operation selections, and operation-class mismatches before execution.
+//! Documents with multiple operations require an exact operation name. A single
+//! operation may omit the name or pass an empty name. Schema validation and resolver
+//! authorization still apply after this transport-level check. Subscription errors
+//! are delivered through the response stream.
+//!
+//! Build custom gRPC schemas with `GraphQLGrpcService::schema_builder` instead of
+//! `Schema::build` / `Schema::new`. This installs the operation guard before user
+//! extensions, so preparation limits and document rewrites run in their normal
+//! order. `GraphQLGrpcService::new` panics for unguarded schemas. The built-in
+//! `create_schema` helpers install the guard when `graphql-grpc` is enabled.
+//!
 //! # Dependency Injection
 //!
 //! Enable the `di` feature to use dependency injection in GraphQL resolvers:

--- a/crates/reinhardt-graphql/src/schema.rs
+++ b/crates/reinhardt-graphql/src/schema.rs
@@ -653,7 +653,11 @@ pub fn create_schema(storage: UserStorage) -> AppSchema {
 /// * `storage` - User data storage
 /// * `limits` - Query protection limits configuration
 pub fn create_schema_with_limits(storage: UserStorage, limits: QueryLimits) -> AppSchema {
-	Schema::build(Query, Mutation, EmptySubscription)
+	#[cfg(feature = "graphql-grpc")]
+	let builder = crate::GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription);
+	#[cfg(not(feature = "graphql-grpc"))]
+	let builder = Schema::build(Query, Mutation, EmptySubscription);
+	builder
 		.data(storage)
 		.limit_depth(limits.max_depth)
 		.limit_complexity(limits.max_complexity)

--- a/crates/reinhardt-graphql/tests/di_integration.rs
+++ b/crates/reinhardt-graphql/tests/di_integration.rs
@@ -1,7 +1,8 @@
 //! Integration tests for GraphQL dependency injection
 //!
 //! These tests verify that the `#[graphql_handler]` macro correctly integrates
-//! with the DI system.
+//! with the DI system. Shared mock factories are registered once so parallel
+//! fixtures can safely create independent request contexts.
 
 #![cfg(feature = "di")]
 
@@ -11,7 +12,7 @@ use reinhardt_di::{
 };
 use reinhardt_graphql::{SchemaBuilderExt, graphql_handler};
 use rstest::*;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
 /// Mock database connection for testing
 #[derive(Clone)]
@@ -111,17 +112,17 @@ impl User {
 
 /// Register mock types in the global registry for DI resolution.
 fn register_mock_types() {
-	let registry = global_registry();
-	if !registry.is_registered::<MockDatabase>() {
+	static REGISTER: Once = Once::new();
+	// Test fixtures run concurrently; checking and registering must be atomic.
+	REGISTER.call_once(|| {
+		let registry = global_registry();
 		registry.register_async::<MockDatabase, _, _>(DependencyScope::Request, |_ctx| async {
 			Ok(MockDatabase::new())
 		});
-	}
-	if !registry.is_registered::<MockCache>() {
 		registry.register_async::<MockCache, _, _>(DependencyScope::Request, |_ctx| async {
 			Ok(MockCache::new())
 		});
-	}
+	});
 }
 
 /// Fixture: Injection context with database and cache

--- a/crates/reinhardt-http/README.md
+++ b/crates/reinhardt-http/README.md
@@ -80,6 +80,14 @@ Core HTTP abstractions for the Reinhardt framework. Provides comprehensive reque
 
 - Re-exports `reinhardt_core::exception::Error` and `Result` for consistent error handling
 
+#### Exception Handling
+
+- `ExceptionHandler` converts dispatch errors into application-defined responses and can be installed on a router, server, or `MiddlewareChain` with `with_exception_handler`
+- The hook receives the request context and the framework error, covering handler, middleware, and routing failures that reach the configured chain
+- A custom handler owns the response body and all security headers; the default conversion is safer because it omits internal error details and sets `Content-Type: text/plain; charset=utf-8` plus `X-Content-Type-Options: nosniff`
+
+Do not interpolate an error's `Display` output into a public response unless the details have been reviewed for disclosure of internal paths, credentials, or other sensitive data.
+
 ## Installation
 
 Add `reinhardt` to your `Cargo.toml`:

--- a/crates/reinhardt-http/src/exception.rs
+++ b/crates/reinhardt-http/src/exception.rs
@@ -1,0 +1,381 @@
+//! Exception handling extension point for dispatch errors.
+//!
+//! This module provides the [`ExceptionHandler`] hook and
+//! [`ExceptionHandlingHandler`], the adapter that applies it to a handler chain.
+//!
+//! Without an installed handler every error is converted by
+//! `impl From<Error> for Response`, which omits internal details and emits a
+//! plain-text body. Installing a handler replaces that conversion so an
+//! application can present a fixed error shape to its clients.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::{Error, Handler, Request, Response};
+
+/// A strategy for turning a dispatch error into an HTTP response.
+///
+/// Install an implementation with `with_exception_handler` on the router, the
+/// server, or a middleware chain. Every error the framework produces while
+/// serving a request then flows through this method instead of the default
+/// `impl From<Error> for Response` conversion.
+///
+/// # Responsibility
+///
+/// Installing a handler transfers responsibility for the response body and
+/// headers to the handler. The default conversion never exposes internal
+/// details and sets `Content-Type: text/plain; charset=utf-8` together with
+/// `X-Content-Type-Options: nosniff`; a custom handler provides none of these
+/// unless it sets them itself. Interpolating `Display` output of the error into
+/// a response body can disclose internal paths and credentials.
+///
+/// # Panics
+///
+/// A panicking handler is not caught here. The request's connection task fails
+/// and the server process stays alive.
+///
+/// # Examples
+///
+/// ```
+/// use async_trait::async_trait;
+/// use hyper::StatusCode;
+/// use reinhardt_http::{Error, ExceptionHandler, Request, Response};
+///
+/// struct JsonErrors;
+///
+/// #[async_trait]
+/// impl ExceptionHandler for JsonErrors {
+///     async fn handle_exception(&self, _request: &Request, error: Error) -> Response {
+///         let status = StatusCode::from_u16(error.status_code())
+///             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+///         Response::new(status).with_body("error")
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait ExceptionHandler: Send + Sync + 'static {
+	/// Builds the response for `error`.
+	///
+	/// `request` carries the method, URI, version, headers, path parameters,
+	/// query parameters and extensions of the original request, which is
+	/// exactly what [`Request::clone_for_di`] preserves. Its body is empty
+	/// because the original request body has already been consumed by the
+	/// handler that produced the error.
+	async fn handle_exception(&self, request: &Request, error: Error) -> Response;
+}
+
+/// Applies an [`ExceptionHandler`] to the errors produced by an inner handler.
+///
+/// Wrap the innermost handler of a chain with this adapter to route its errors
+/// through the installed handler. The adapter always yields `Ok`, so an outer
+/// wrapper that converts errors cannot observe them.
+///
+/// This adapter sees only errors that reach it as `Err`. Errors raised by
+/// middleware inside a [`MiddlewareChain`](crate::MiddlewareChain) are converted
+/// by that chain, which applies its own installed handler instead.
+///
+/// # Examples
+///
+/// ```
+/// use async_trait::async_trait;
+/// use bytes::Bytes;
+/// use hyper::{HeaderMap, Method, StatusCode, Version};
+/// use reinhardt_http::{
+///     Error, ExceptionHandler, ExceptionHandlingHandler, Handler, Request, Response,
+/// };
+/// use std::sync::Arc;
+///
+/// struct FailingHandler;
+///
+/// #[async_trait]
+/// impl Handler for FailingHandler {
+///     async fn handle(&self, _request: Request) -> reinhardt_http::Result<Response> {
+///         Err(Error::NotFound("no route".to_string()))
+///     }
+/// }
+///
+/// struct TeapotErrors;
+///
+/// #[async_trait]
+/// impl ExceptionHandler for TeapotErrors {
+///     async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+///         Response::new(StatusCode::IM_A_TEAPOT)
+///     }
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let handler = ExceptionHandlingHandler::new(
+///     Arc::new(FailingHandler),
+///     Arc::new(TeapotErrors),
+/// );
+///
+/// let request = Request::builder()
+///     .method(Method::GET)
+///     .uri("/")
+///     .version(Version::HTTP_11)
+///     .headers(HeaderMap::new())
+///     .body(Bytes::new())
+///     .build()
+///     .unwrap();
+///
+/// let response = handler.handle(request).await.unwrap();
+/// assert_eq!(response.status, StatusCode::IM_A_TEAPOT);
+/// # }
+/// ```
+pub struct ExceptionHandlingHandler {
+	inner: Arc<dyn Handler>,
+	exception_handler: Arc<dyn ExceptionHandler>,
+}
+
+impl ExceptionHandlingHandler {
+	/// Creates an adapter that converts `inner`'s errors with `exception_handler`.
+	pub fn new(inner: Arc<dyn Handler>, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		Self {
+			inner,
+			exception_handler,
+		}
+	}
+}
+
+#[async_trait]
+impl Handler for ExceptionHandlingHandler {
+	async fn handle(&self, request: Request) -> Result<Response> {
+		// `Request` is not `Clone` because it owns parsed-body state. Capture the
+		// context with `clone_for_di`, which copies method, URI, version, headers,
+		// path parameters and query parameters, and shares the extensions store
+		// (auth state, DI context) through an internal `Arc`. This cost is paid
+		// only where a custom handler is installed, because this adapter is only
+		// constructed in that case.
+		let context = request.clone_for_di();
+		match self.inner.handle(request).await {
+			Ok(response) => Ok(response),
+			Err(error) => Ok(self.exception_handler.handle_exception(&context, error).await),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bytes::Bytes;
+	use hyper::{HeaderMap, Method, StatusCode, Version};
+	use rstest::rstest;
+	use std::sync::Mutex;
+
+	/// Marker type stored in the request's DI context.
+	#[derive(Debug, PartialEq, Eq)]
+	struct MarkerContext(&'static str);
+
+	/// What an exception handler observed about the request it was given.
+	#[derive(Debug, PartialEq, Eq)]
+	struct ObservedRequest {
+		method: Method,
+		path: String,
+		request_id: Option<String>,
+		item_id: Option<String>,
+		di_marker: Option<&'static str>,
+	}
+
+	/// Exception handler that records the request context it receives.
+	struct ObservingHandler {
+		observed: Arc<Mutex<Vec<ObservedRequest>>>,
+	}
+
+	#[async_trait]
+	impl ExceptionHandler for ObservingHandler {
+		async fn handle_exception(&self, request: &Request, error: Error) -> Response {
+			let di_marker = request
+				.get_di_context::<MarkerContext>()
+				.map(|marker| marker.0);
+			self.observed.lock().unwrap().push(ObservedRequest {
+				method: request.method.clone(),
+				path: request.uri.path().to_string(),
+				request_id: request.get_header("x-request-id"),
+				item_id: request.path_params.get("id").cloned(),
+				di_marker,
+			});
+
+			// Echo the error so the assertion can prove the error travelled through.
+			Response::new(StatusCode::IM_A_TEAPOT).with_body(error.to_string())
+		}
+	}
+
+	/// Handler that always fails with the error produced by `factory`.
+	///
+	/// `Error` is not `Clone`, so the factory builds a fresh value per call.
+	struct FailingHandler {
+		factory: fn() -> Error,
+	}
+
+	#[async_trait]
+	impl Handler for FailingHandler {
+		async fn handle(&self, _request: Request) -> Result<Response> {
+			Err((self.factory)())
+		}
+	}
+
+	/// Handler that always succeeds.
+	struct OkHandler;
+
+	#[async_trait]
+	impl Handler for OkHandler {
+		async fn handle(&self, _request: Request) -> Result<Response> {
+			Ok(Response::ok().with_body("ok"))
+		}
+	}
+
+	/// Handler that counts how many times it ran.
+	struct CountingHandler {
+		calls: Arc<Mutex<usize>>,
+	}
+
+	#[async_trait]
+	impl Handler for CountingHandler {
+		async fn handle(&self, _request: Request) -> Result<Response> {
+			*self.calls.lock().unwrap() += 1;
+			Err(Error::Internal("boom".to_string()))
+		}
+	}
+
+	fn build_request(method: Method, uri: &str) -> Request {
+		Request::builder()
+			.method(method)
+			.uri(uri)
+			.version(Version::HTTP_11)
+			.headers(HeaderMap::new())
+			.body(Bytes::new())
+			.build()
+			.unwrap()
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inner_error_is_converted_by_installed_handler() {
+		// Arrange
+		let observed = Arc::new(Mutex::new(Vec::new()));
+		let handler = ExceptionHandlingHandler::new(
+			Arc::new(FailingHandler {
+				factory: || Error::NotFound("no route".to_string()),
+			}),
+			Arc::new(ObservingHandler {
+				observed: Arc::clone(&observed),
+			}),
+		);
+		let request = build_request(Method::GET, "/missing");
+
+		// Act
+		let response = handler.handle(request).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::IM_A_TEAPOT);
+		assert_eq!(observed.lock().unwrap().len(), 1);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_handler_receives_original_request_context() {
+		// Arrange
+		let observed = Arc::new(Mutex::new(Vec::new()));
+		let handler = ExceptionHandlingHandler::new(
+			Arc::new(FailingHandler {
+				factory: || Error::Internal("boom".to_string()),
+			}),
+			Arc::new(ObservingHandler {
+				observed: Arc::clone(&observed),
+			}),
+		);
+
+		let mut headers = HeaderMap::new();
+		headers.insert("x-request-id", "req-42".parse().unwrap());
+		let mut request = Request::builder()
+			.method(Method::POST)
+			.uri("/api/items/7")
+			.version(Version::HTTP_11)
+			.headers(headers)
+			.body(Bytes::from_static(b"payload"))
+			.build()
+			.unwrap();
+		request.path_params.insert("id", "7");
+
+		// Act
+		handler.handle(request).await.unwrap();
+
+		// Assert
+		let observed = observed.lock().unwrap();
+		assert_eq!(observed.len(), 1);
+		assert_eq!(observed[0].method, Method::POST);
+		assert_eq!(observed[0].path, "/api/items/7");
+		assert_eq!(observed[0].request_id, Some("req-42".to_string()));
+		assert_eq!(observed[0].item_id, Some("7".to_string()));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_handler_shares_request_extensions() {
+		// Arrange
+		let observed = Arc::new(Mutex::new(Vec::new()));
+		let handler = ExceptionHandlingHandler::new(
+			Arc::new(FailingHandler {
+				factory: || Error::Internal("boom".to_string()),
+			}),
+			Arc::new(ObservingHandler {
+				observed: Arc::clone(&observed),
+			}),
+		);
+		let mut request = build_request(Method::GET, "/");
+		request.set_di_context(MarkerContext("di-visible"));
+
+		// Act
+		handler.handle(request).await.unwrap();
+
+		// Assert: the extensions store is shared with the context request
+		let observed = observed.lock().unwrap();
+		assert_eq!(observed.len(), 1);
+		assert_eq!(observed[0].di_marker, Some("di-visible"));
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_handler_is_not_invoked_for_successful_response() {
+		// Arrange
+		let observed = Arc::new(Mutex::new(Vec::new()));
+		let handler = ExceptionHandlingHandler::new(
+			Arc::new(OkHandler),
+			Arc::new(ObservingHandler {
+				observed: Arc::clone(&observed),
+			}),
+		);
+
+		// Act
+		let response = handler.handle(build_request(Method::GET, "/")).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, StatusCode::OK);
+		assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "ok");
+		assert!(observed.lock().unwrap().is_empty());
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_inner_handler_runs_exactly_once() {
+		// Arrange
+		let calls = Arc::new(Mutex::new(0_usize));
+		let observed = Arc::new(Mutex::new(Vec::new()));
+		let handler = ExceptionHandlingHandler::new(
+			Arc::new(CountingHandler {
+				calls: Arc::clone(&calls),
+			}),
+			Arc::new(ObservingHandler {
+				observed: Arc::clone(&observed),
+			}),
+		);
+
+		// Act
+		handler.handle(build_request(Method::GET, "/")).await.unwrap();
+
+		// Assert
+		assert_eq!(*calls.lock().unwrap(), 1);
+		assert_eq!(observed.lock().unwrap().len(), 1);
+	}
+}

--- a/crates/reinhardt-http/src/exception.rs
+++ b/crates/reinhardt-http/src/exception.rs
@@ -11,7 +11,7 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use crate::{Error, Handler, Request, Response};
+use crate::{Error, Handler, Request, Response, Result};
 
 /// A strategy for turning a dispatch error into an HTTP response.
 ///
@@ -150,7 +150,10 @@ impl Handler for ExceptionHandlingHandler {
 		let context = request.clone_for_di();
 		match self.inner.handle(request).await {
 			Ok(response) => Ok(response),
-			Err(error) => Ok(self.exception_handler.handle_exception(&context, error).await),
+			Err(error) => Ok(self
+				.exception_handler
+				.handle_exception(&context, error)
+				.await),
 		}
 	}
 }
@@ -348,7 +351,10 @@ mod tests {
 		);
 
 		// Act
-		let response = handler.handle(build_request(Method::GET, "/")).await.unwrap();
+		let response = handler
+			.handle(build_request(Method::GET, "/"))
+			.await
+			.unwrap();
 
 		// Assert
 		assert_eq!(response.status, StatusCode::OK);
@@ -372,7 +378,10 @@ mod tests {
 		);
 
 		// Act
-		handler.handle(build_request(Method::GET, "/")).await.unwrap();
+		handler
+			.handle(build_request(Method::GET, "/"))
+			.await
+			.unwrap();
 
 		// Assert
 		assert_eq!(*calls.lock().unwrap(), 1);

--- a/crates/reinhardt-http/src/lib.rs
+++ b/crates/reinhardt-http/src/lib.rs
@@ -33,6 +33,7 @@
 //! - [`request`]: Typed HTTP request wrapper with builder pattern and trusted proxy support
 //! - [`response`]: HTTP response with helpers for JSON, streaming, and error responses
 //! - [`middleware`]: Middleware trait and composition chain for request processing
+//! - [`exception`]: Exception handler hook for replacing the default error-to-response conversion
 //! - [`auth_state`]: Authentication state extensions stored in request context
 //! - [`upload`]: File upload handling (in-memory and temporary file backends)
 //! - [`chunked_upload`]: Resumable chunked upload session management
@@ -84,6 +85,8 @@
 pub mod auth_state;
 /// Chunked file upload handling with progress tracking.
 pub mod chunked_upload;
+/// Exception handler hook and adapter for replacing the default error conversion.
+pub mod exception;
 /// Request extension storage for passing data between middleware.
 pub mod extensions;
 /// Flash messages middleware for one-time notifications.
@@ -107,6 +110,7 @@ pub use auth_state::AuthState;
 pub use chunked_upload::{
 	ChunkedUploadError, ChunkedUploadManager, ChunkedUploadSession, UploadProgress,
 };
+pub use exception::{ExceptionHandler, ExceptionHandlingHandler};
 pub use extensions::{Extensions, IsActive, IsAdmin, IsAuthenticated};
 #[cfg(feature = "messages")]
 pub use messages_middleware::MessagesMiddleware;

--- a/crates/reinhardt-http/src/middleware.rs
+++ b/crates/reinhardt-http/src/middleware.rs
@@ -46,6 +46,7 @@ use reinhardt_core::exception::Result;
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
+use crate::exception::ExceptionHandler;
 use crate::{Request, Response};
 
 /// Type-erased DI singleton registration entry contributed by a middleware.
@@ -171,6 +172,9 @@ pub trait Middleware: Send + Sync {
 pub struct MiddlewareChain {
 	middlewares: Vec<Arc<dyn Middleware>>,
 	handler: Arc<dyn Handler>,
+	/// Applied instead of the default `Response::from` conversion when a request
+	/// fails anywhere in this chain, including inside middleware.
+	exception_handler: Option<Arc<dyn ExceptionHandler>>,
 }
 
 impl MiddlewareChain {
@@ -198,6 +202,7 @@ impl MiddlewareChain {
 		Self {
 			middlewares: Vec::new(),
 			handler,
+			exception_handler: None,
 		}
 	}
 
@@ -209,7 +214,48 @@ impl MiddlewareChain {
 		Self {
 			middlewares,
 			handler,
+			exception_handler: None,
 		}
+	}
+
+	/// Installs an exception handler for every failure in this chain.
+	///
+	/// Without one, `Err` values are converted by `impl From<Error> for Response`,
+	/// which omits internal details and returns a plain-text body. The installed
+	/// handler replaces that conversion for errors raised by the base handler and
+	/// for errors raised by middleware in this chain.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use async_trait::async_trait;
+	/// use reinhardt_http::{
+	///     Error, ExceptionHandler, Handler, MiddlewareChain, Request, Response,
+	/// };
+	/// use std::sync::Arc;
+	///
+	/// # struct MyHandler;
+	/// # #[async_trait]
+	/// # impl Handler for MyHandler {
+	/// #     async fn handle(&self, _request: Request) -> reinhardt_core::exception::Result<Response> {
+	/// #         Ok(Response::ok())
+	/// #     }
+	/// # }
+	/// struct TeapotErrors;
+	///
+	/// #[async_trait]
+	/// impl ExceptionHandler for TeapotErrors {
+	///     async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+	///         Response::new(hyper::StatusCode::IM_A_TEAPOT)
+	///     }
+	/// }
+	///
+	/// let chain = MiddlewareChain::new(Arc::new(MyHandler))
+	///     .with_exception_handler(Arc::new(TeapotErrors));
+	/// ```
+	pub fn with_exception_handler(mut self, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		self.exception_handler = Some(exception_handler);
+		self
 	}
 
 	/// Adds a middleware to the chain using builder pattern.
@@ -279,25 +325,46 @@ impl MiddlewareChain {
 #[async_trait]
 impl Handler for MiddlewareChain {
 	async fn handle(&self, request: Request) -> Result<Response> {
+		// A chain with no middleware neither converts nor swallows errors, so the
+		// installed handler is applied here to keep `with_exception_handler`
+		// meaningful for a bare chain. The error still propagates as `Err` when no
+		// handler is installed, which is the behaviour callers rely on today.
 		if self.middlewares.is_empty() {
-			return self.handler.handle(request).await;
+			let Some(exception_handler) = self.exception_handler.as_ref() else {
+				return self.handler.handle(request).await;
+			};
+			let context = request.clone_for_di();
+			return match self.handler.handle(request).await {
+				Ok(response) => Ok(response),
+				Err(e) => Ok(exception_handler.handle_exception(&context, e).await),
+			};
 		}
 
 		if self.middlewares.len() == 1 {
 			let middleware = &self.middlewares[0];
 			if !middleware.should_continue(&request) {
+				let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 				return match self.handler.handle(request).await {
 					Ok(response) => Ok(response),
-					Err(e) => Ok(Response::from(e)),
+					Err(e) => Ok(convert_error(
+						self.exception_handler.as_ref(),
+						context.as_ref(),
+						e,
+					)
+					.await),
 				};
 			}
 
+			let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 			let next: Arc<dyn Handler> = Arc::new(ErrorToResponseHandler {
 				inner: self.handler.clone(),
+				exception_handler: self.exception_handler.clone(),
 			});
 			let response = match middleware.process(request, next).await {
 				Ok(response) => response,
-				Err(e) => Response::from(e),
+				Err(e) => {
+					convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await
+				}
 			};
 			return Ok(response);
 		}
@@ -314,6 +381,7 @@ impl Handler for MiddlewareChain {
 		// all middleware post-processing runs even for error responses.
 		let mut current_handler: Arc<dyn Handler> = Arc::new(ErrorToResponseHandler {
 			inner: self.handler.clone(),
+			exception_handler: self.exception_handler.clone(),
 		});
 
 		for middleware in self
@@ -328,6 +396,7 @@ impl Handler for MiddlewareChain {
 			current_handler = Arc::new(ConditionalComposedHandler {
 				middleware: mw,
 				next: handler,
+				exception_handler: self.exception_handler.clone(),
 			});
 		}
 
@@ -431,6 +500,36 @@ impl Middleware for ExcludeMiddleware {
 	}
 }
 
+/// Captures the request context an installed exception handler needs.
+///
+/// Returns `None` when no handler is installed, so the default error path pays
+/// nothing. The context is produced by `Request::clone_for_di`, which copies
+/// method, URI, version, headers, path parameters and query parameters and
+/// shares the extensions store through an internal `Arc`.
+fn capture_exception_context(
+	exception_handler: Option<&Arc<dyn ExceptionHandler>>,
+	request: &Request,
+) -> Option<Request> {
+	if exception_handler.is_none() {
+		return None;
+	}
+	Some(request.clone_for_di())
+}
+
+/// Converts `error` into a response with the installed handler when both the
+/// handler and a captured context are present, and with the default
+/// `impl From<Error> for Response` otherwise.
+async fn convert_error(
+	exception_handler: Option<&Arc<dyn ExceptionHandler>>,
+	context: Option<&Request>,
+	error: Error,
+) -> Response {
+	match (exception_handler, context) {
+		(Some(handler), Some(context)) => handler.handle_exception(context, error).await,
+		_ => Response::from(error),
+	}
+}
+
 /// Internal handler wrapper that converts errors to HTTP responses.
 ///
 /// Wraps the base handler so that middleware always receives `Ok(Response)`
@@ -439,14 +538,21 @@ impl Middleware for ExcludeMiddleware {
 /// responses, matching Django's `process_response` semantics.
 struct ErrorToResponseHandler {
 	inner: Arc<dyn Handler>,
+	exception_handler: Option<Arc<dyn ExceptionHandler>>,
 }
 
 #[async_trait]
 impl Handler for ErrorToResponseHandler {
 	async fn handle(&self, request: Request) -> Result<Response> {
+		let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 		match self.inner.handle(request).await {
 			Ok(response) => Ok(response),
-			Err(e) => Ok(Response::from(e)),
+			Err(e) => Ok(convert_error(
+				self.exception_handler.as_ref(),
+				context.as_ref(),
+				e,
+			)
+			.await),
 		}
 	}
 }
@@ -458,6 +564,7 @@ impl Handler for ErrorToResponseHandler {
 struct ConditionalComposedHandler {
 	middleware: Arc<dyn Middleware>,
 	next: Arc<dyn Handler>,
+	exception_handler: Option<Arc<dyn ExceptionHandler>>,
 }
 
 #[async_trait]
@@ -467,9 +574,12 @@ impl Handler for ConditionalComposedHandler {
 		// Convert errors to responses so that outer middleware post-processing
 		// (e.g., security headers) always runs — matching Django's process_response
 		// semantics where the response hook executes for both success and error cases.
+		let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 		let response = match self.middleware.process(request, self.next.clone()).await {
 			Ok(response) => response,
-			Err(e) => Response::from(e),
+			Err(e) => {
+				convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await
+			}
 		};
 
 		Ok(response)
@@ -481,6 +591,7 @@ mod tests {
 	use super::*;
 	use bytes::Bytes;
 	use hyper::{HeaderMap, Method, Version};
+	use rstest::rstest;
 
 	// Mock handler for testing
 	struct MockHandler {
@@ -1079,5 +1190,122 @@ mod tests {
 
 		// Assert: status code correctly reflects the error
 		assert_eq!(response.status, hyper::StatusCode::UNAUTHORIZED);
+	}
+
+	// ==========================================================================
+	// Exception handler support (Issue #6294)
+	// ==========================================================================
+
+	/// Middleware that always fails.
+	struct FailingMiddleware;
+
+	#[async_trait]
+	impl Middleware for FailingMiddleware {
+		async fn process(&self, _request: Request, _next: Arc<dyn Handler>) -> Result<Response> {
+			Err(Error::Http("rejected by middleware".to_string()))
+		}
+	}
+
+	/// Base handler that always fails.
+	struct ErroringHandler;
+
+	#[async_trait]
+	impl Handler for ErroringHandler {
+		async fn handle(&self, _request: Request) -> Result<Response> {
+			Err(Error::NotFound("no route".to_string()))
+		}
+	}
+
+	/// Exception handler producing a body identifiable in assertions.
+	struct TeapotHandler;
+
+	#[async_trait]
+	impl ExceptionHandler for TeapotHandler {
+		async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+			Response::new(hyper::StatusCode::IM_A_TEAPOT).with_body("teapot")
+		}
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_chain_exception_handler_converts_middleware_error() {
+		// Arrange
+		let chain = MiddlewareChain::new(Arc::new(MockHandler {
+			response_body: "unused".to_string(),
+		}))
+		.with_middleware(Arc::new(FailingMiddleware))
+		.with_exception_handler(Arc::new(TeapotHandler));
+
+		// Act
+		let response = chain.handle(create_test_request()).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+		assert_eq!(
+			String::from_utf8(response.body.to_vec()).unwrap(),
+			"teapot"
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_chain_without_exception_handler_keeps_default_middleware_error() {
+		// Arrange
+		let chain = MiddlewareChain::new(Arc::new(MockHandler {
+			response_body: "unused".to_string(),
+		}))
+		.with_middleware(Arc::new(FailingMiddleware));
+
+		// Act
+		let response = chain.handle(create_test_request()).await.unwrap();
+
+		// Assert: the default conversion maps Error::Http to 400, not to the handler's status
+		assert_eq!(response.status, hyper::StatusCode::BAD_REQUEST);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_chain_exception_handler_converts_base_handler_error() {
+		// Arrange
+		let chain = MiddlewareChain::new(Arc::new(ErroringHandler))
+			.with_middleware(Arc::new(PassthroughMiddleware))
+			.with_exception_handler(Arc::new(TeapotHandler));
+
+		// Act
+		let response = chain.handle(create_test_request()).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_bare_chain_with_exception_handler_converts_base_handler_error() {
+		// Arrange: no middleware, so the chain takes its early-return path
+		let chain = MiddlewareChain::new(Arc::new(ErroringHandler))
+			.with_exception_handler(Arc::new(TeapotHandler));
+
+		// Act
+		let response = chain.handle(create_test_request()).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+		assert_eq!(
+			String::from_utf8(response.body.to_vec()).unwrap(),
+			"teapot"
+		);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_bare_chain_without_exception_handler_propagates_error() {
+		// Arrange
+		let chain = MiddlewareChain::new(Arc::new(ErroringHandler));
+
+		// Act
+		let result = chain.handle(create_test_request()).await;
+
+		// Assert: a chain with no middleware must not start swallowing errors
+		assert!(result.is_err());
 	}
 }

--- a/crates/reinhardt-http/src/middleware.rs
+++ b/crates/reinhardt-http/src/middleware.rs
@@ -42,7 +42,7 @@
 //! ```
 
 use async_trait::async_trait;
-use reinhardt_core::exception::Result;
+use reinhardt_core::exception::{Error, Result};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
@@ -346,12 +346,12 @@ impl Handler for MiddlewareChain {
 				let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 				return match self.handler.handle(request).await {
 					Ok(response) => Ok(response),
-					Err(e) => Ok(convert_error(
-						self.exception_handler.as_ref(),
-						context.as_ref(),
-						e,
-					)
-					.await),
+					Err(e) => {
+						Ok(
+							convert_error(self.exception_handler.as_ref(), context.as_ref(), e)
+								.await,
+						)
+					}
 				};
 			}
 
@@ -362,9 +362,7 @@ impl Handler for MiddlewareChain {
 			});
 			let response = match middleware.process(request, next).await {
 				Ok(response) => response,
-				Err(e) => {
-					convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await
-				}
+				Err(e) => convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await,
 			};
 			return Ok(response);
 		}
@@ -510,9 +508,8 @@ fn capture_exception_context(
 	exception_handler: Option<&Arc<dyn ExceptionHandler>>,
 	request: &Request,
 ) -> Option<Request> {
-	if exception_handler.is_none() {
-		return None;
-	}
+	// Bail out before cloning when no handler is installed.
+	exception_handler?;
 	Some(request.clone_for_di())
 }
 
@@ -547,12 +544,7 @@ impl Handler for ErrorToResponseHandler {
 		let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 		match self.inner.handle(request).await {
 			Ok(response) => Ok(response),
-			Err(e) => Ok(convert_error(
-				self.exception_handler.as_ref(),
-				context.as_ref(),
-				e,
-			)
-			.await),
+			Err(e) => Ok(convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await),
 		}
 	}
 }
@@ -577,9 +569,7 @@ impl Handler for ConditionalComposedHandler {
 		let context = capture_exception_context(self.exception_handler.as_ref(), &request);
 		let response = match self.middleware.process(request, self.next.clone()).await {
 			Ok(response) => response,
-			Err(e) => {
-				convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await
-			}
+			Err(e) => convert_error(self.exception_handler.as_ref(), context.as_ref(), e).await,
 		};
 
 		Ok(response)
@@ -1241,10 +1231,7 @@ mod tests {
 
 		// Assert
 		assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
-		assert_eq!(
-			String::from_utf8(response.body.to_vec()).unwrap(),
-			"teapot"
-		);
+		assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
 	}
 
 	#[rstest]
@@ -1290,10 +1277,7 @@ mod tests {
 
 		// Assert
 		assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
-		assert_eq!(
-			String::from_utf8(response.body.to_vec()).unwrap(),
-			"teapot"
-		);
+		assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
 	}
 
 	#[rstest]

--- a/crates/reinhardt-server/README.md
+++ b/crates/reinhardt-server/README.md
@@ -131,6 +131,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Custom Exception Responses
+
+Install an `ExceptionHandler` when the application needs a consistent error
+schema for handler or middleware failures:
+
+```rust
+use async_trait::async_trait;
+use hyper::StatusCode;
+use reinhardt::http::{Error, ExceptionHandler, Request, Response};
+use reinhardt::server::HttpServer;
+use std::sync::Arc;
+
+struct ApiErrors;
+
+#[async_trait]
+impl ExceptionHandler for ApiErrors {
+    async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+        Response::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_body("request failed")
+    }
+}
+
+let server = HttpServer::new(handler)
+    .with_exception_handler(Arc::new(ApiErrors));
+```
+
+The custom handler is responsible for safe response bodies and security
+headers. The default conversion omits internal details and supplies
+`Content-Type: text/plain; charset=utf-8` and
+`X-Content-Type-Options: nosniff`; do not expose an error's `Display` output
+without reviewing it for sensitive data.
+
 ### WebSocket Server
 
 ```rust

--- a/crates/reinhardt-server/src/server/http.rs
+++ b/crates/reinhardt-server/src/server/http.rs
@@ -6,7 +6,9 @@ use hyper::server::conn::http1;
 use hyper::service::Service;
 use hyper_util::rt::TokioIo;
 use reinhardt_di::InjectionContext;
-use reinhardt_http::{Handler, Middleware, MiddlewareChain};
+use reinhardt_http::{
+	ExceptionHandler, ExceptionHandlingHandler, Handler, Middleware, MiddlewareChain,
+};
 use reinhardt_http::{Request, Response};
 use std::future::Future;
 use std::net::SocketAddr;
@@ -21,6 +23,9 @@ pub struct HttpServer {
 	handler: Arc<dyn Handler>,
 	pub(crate) middlewares: Vec<Arc<dyn Middleware>>,
 	di_context: Option<Arc<InjectionContext>>,
+	/// Applied instead of the default `Response::from` conversion when a request
+	/// fails. Set through [`HttpServer::with_exception_handler`].
+	exception_handler: Option<Arc<dyn ExceptionHandler>>,
 }
 
 impl HttpServer {
@@ -49,7 +54,50 @@ impl HttpServer {
 			handler: Arc::new(handler),
 			middlewares: Vec::new(),
 			di_context: None,
+			exception_handler: None,
 		}
+	}
+
+	/// Installs an exception handler for every failure this server produces.
+	///
+	/// Covers errors from the wrapped handler and errors raised by middleware
+	/// registered with [`HttpServer::with_middleware`]. Without one, errors are
+	/// converted by `impl From<Error> for Response`.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use async_trait::async_trait;
+	/// use hyper::StatusCode;
+	/// use reinhardt_http::{Error, ExceptionHandler, Request, Response};
+	/// use reinhardt_server::server::HttpServer;
+	/// use std::sync::Arc;
+	///
+	/// struct TeapotErrors;
+	///
+	/// #[async_trait]
+	/// impl ExceptionHandler for TeapotErrors {
+	///     async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+	///         Response::new(StatusCode::IM_A_TEAPOT)
+	///     }
+	/// }
+	///
+	/// struct MyHandler;
+	///
+	/// #[async_trait]
+	/// impl reinhardt_http::Handler for MyHandler {
+	///     async fn handle(&self, _request: Request) -> reinhardt_core::exception::Result<Response> {
+	///         Ok(Response::ok())
+	///     }
+	/// }
+	///
+	/// let server = HttpServer::new(MyHandler)
+	///     .with_exception_handler(Arc::new(TeapotErrors));
+	/// # let _ = server;
+	/// ```
+	pub fn with_exception_handler(mut self, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		self.exception_handler = Some(exception_handler);
+		self
 	}
 
 	/// Add a middleware to the server using builder pattern
@@ -131,11 +179,26 @@ impl HttpServer {
 	///
 	/// This creates a MiddlewareChain that wraps the handler with all configured middlewares.
 	fn build_handler(&self) -> Arc<dyn Handler> {
+		// Route the wrapped handler's errors through an installed handler. This is
+		// what covers the no-middleware case, where no chain exists to convert them.
+		let handler: Arc<dyn Handler> = match self.exception_handler.as_ref() {
+			Some(exception_handler) => Arc::new(ExceptionHandlingHandler::new(
+				self.handler.clone(),
+				Arc::clone(exception_handler),
+			)),
+			None => self.handler.clone(),
+		};
+
 		if self.middlewares.is_empty() {
-			return self.handler.clone();
+			return handler;
 		}
 
-		let mut chain = MiddlewareChain::new(self.handler.clone());
+		// The chain converts errors raised by middleware itself, so it needs the
+		// handler independently of the adapter above.
+		let mut chain = MiddlewareChain::new(handler);
+		if let Some(exception_handler) = self.exception_handler.as_ref() {
+			chain = chain.with_exception_handler(Arc::clone(exception_handler));
+		}
 		for middleware in &self.middlewares {
 			chain.add_middleware(middleware.clone());
 		}
@@ -691,5 +754,113 @@ mod tests {
 			!body.contains(leaked_fragment),
 			"Response body must not contain internal details '{leaked_fragment}', but got: {body}"
 		);
+	}
+
+	// ==========================================================================
+	// Exception handler installation (Issue #6294)
+	// ==========================================================================
+
+	use reinhardt_http::Middleware;
+
+	/// Exception handler producing a body identifiable in assertions.
+	struct TeapotErrors;
+
+	#[async_trait::async_trait]
+	impl ExceptionHandler for TeapotErrors {
+		async fn handle_exception(
+			&self,
+			_request: &Request,
+			_error: reinhardt_core::exception::Error,
+		) -> Response {
+			Response::new(StatusCode::IM_A_TEAPOT).with_body("teapot")
+		}
+	}
+
+	/// Middleware that always fails before reaching the next handler.
+	struct FailingMiddleware;
+
+	#[async_trait::async_trait]
+	impl Middleware for FailingMiddleware {
+		async fn process(
+			&self,
+			_request: Request,
+			_next: Arc<dyn Handler>,
+		) -> reinhardt_core::exception::Result<Response> {
+			Err(reinhardt_core::exception::Error::Internal(
+				"middleware failed".to_string(),
+			))
+		}
+	}
+
+	fn build_request() -> Request {
+		Request::builder()
+			.method(hyper::Method::GET)
+			.uri("/")
+			.version(hyper::Version::HTTP_11)
+			.headers(hyper::HeaderMap::new())
+			.body(Bytes::new())
+			.build()
+			.unwrap()
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_server_exception_handler_converts_handler_error() {
+		// Arrange
+		let server = HttpServer::new(ErrorHandler {
+			error_message: "database unavailable".to_string(),
+		})
+		.with_exception_handler(Arc::new(TeapotErrors));
+		let handler = server.build_handler();
+
+		// Act
+		let response = handler
+			.handle(build_request())
+			.await
+			.unwrap_or_else(Response::from);
+
+		// Assert
+		assert_eq!(response.status, StatusCode::IM_A_TEAPOT);
+		assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_server_exception_handler_converts_middleware_error() {
+		// Arrange: a succeeding handler behind a failing middleware, so a 418 can
+		// only come from the chain converting the middleware's error
+		let server = HttpServer::new(TestHandler)
+			.with_middleware(FailingMiddleware)
+			.with_exception_handler(Arc::new(TeapotErrors));
+		let handler = server.build_handler();
+
+		// Act
+		let response = handler
+			.handle(build_request())
+			.await
+			.unwrap_or_else(Response::from);
+
+		// Assert
+		assert_eq!(response.status, StatusCode::IM_A_TEAPOT);
+		assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn test_server_without_exception_handler_keeps_default_conversion() {
+		// Arrange
+		let server = HttpServer::new(ErrorHandler {
+			error_message: "database unavailable".to_string(),
+		});
+		let handler = server.build_handler();
+
+		// Act
+		let response = handler
+			.handle(build_request())
+			.await
+			.unwrap_or_else(Response::from);
+
+		// Assert: the default conversion maps Error::Database to a bare 500
+		assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
 	}
 }

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -96,6 +96,28 @@ if let Some((handler, params)) = router.match_request(&request) {
 }
 ```
 
+### Router Exception Handling
+
+`ServerRouter::with_exception_handler` installs an application-defined
+response hook for unmatched routes (404), method mismatches (405), handler
+errors, and router middleware errors. `UnifiedRouter` exposes the same builder
+method for shared server/client route declarations:
+
+```rust
+use reinhardt::http::{ExceptionHandler, Error, Request, Response};
+use reinhardt::urls::routers::ServerRouter;
+use std::sync::Arc;
+
+let router = ServerRouter::new()
+    .with_exception_handler(Arc::new(MyExceptionHandler));
+```
+
+The hook runs only for errors that reach the configured router or middleware
+chain. Custom responses must set their own safe body and security headers;
+the default conversion hides internal details and sets
+`X-Content-Type-Options: nosniff`. Avoid copying an error's `Display` output
+into a public response without reviewing it for sensitive data.
+
 ### URL Reversal
 
 ```rust

--- a/crates/reinhardt-urls/src/routers/server_router.rs
+++ b/crates/reinhardt-urls/src/routers/server_router.rs
@@ -47,6 +47,7 @@
 use crate::routers::UrlReverser;
 use matchit::Router as MatchitRouter;
 use reinhardt_di::InjectionContext;
+use reinhardt_http::ExceptionHandler;
 use reinhardt_middleware::Middleware;
 #[cfg(feature = "viewsets")]
 use std::collections::HashMap;
@@ -211,4 +212,13 @@ pub struct ServerRouter {
 
 	/// Flag indicating if routes have been compiled (uses RwLock for thread-safety)
 	pub(crate) routes_compiled: RwLock<bool>,
+
+	/// Applied instead of the default `Response::from` conversion when a request
+	/// fails.
+	///
+	/// Set through [`ServerRouter::with_exception_handler`]. Errors raised by
+	/// this router's own middleware inherit the handler from the chain built in
+	/// the `Handler` impl. The setter is not propagated to child routers mounted
+	/// with `mount`; set the handler on the router that serves the request.
+	pub(crate) exception_handler: Option<Arc<dyn ExceptionHandler>>,
 }

--- a/crates/reinhardt-urls/src/routers/server_router/builder.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/builder.rs
@@ -8,7 +8,7 @@ use super::types::MiddlewareInfo;
 use crate::routers::UrlReverser;
 use matchit::Router as MatchitRouter;
 use reinhardt_di::InjectionContext;
-use reinhardt_http::ExcludeMiddleware;
+use reinhardt_http::{ExceptionHandler, ExcludeMiddleware};
 use reinhardt_middleware::Middleware;
 #[cfg(feature = "viewsets")]
 use std::collections::HashMap;
@@ -103,7 +103,50 @@ impl ServerRouter {
 			head_router: RwLock::new(MatchitRouter::new()),
 			options_router: RwLock::new(MatchitRouter::new()),
 			routes_compiled: RwLock::new(false),
+			exception_handler: None,
 		}
+	}
+
+	/// Installs an exception handler for every failure this router produces.
+	///
+	/// Covers unmatched routes (404), method mismatches (405), errors raised by
+	/// the view or handler of a matched route, and errors raised by this router's
+	/// own middleware. Without one, errors are converted by
+	/// `impl From<Error> for Response`.
+	///
+	/// The handler applies to this router only. A server that wraps the router
+	/// must be given the same handler separately; `runserver` reads it back with
+	/// [`ServerRouter::exception_handler`] and forwards it.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use async_trait::async_trait;
+	/// use hyper::StatusCode;
+	/// use reinhardt_http::{Error, ExceptionHandler, Request, Response};
+	/// use reinhardt_urls::routers::ServerRouter;
+	/// use std::sync::Arc;
+	///
+	/// struct TeapotErrors;
+	///
+	/// #[async_trait]
+	/// impl ExceptionHandler for TeapotErrors {
+	///     async fn handle_exception(&self, _request: &Request, _error: Error) -> Response {
+	///         Response::new(StatusCode::IM_A_TEAPOT)
+	///     }
+	/// }
+	///
+	/// let router = ServerRouter::new().with_exception_handler(Arc::new(TeapotErrors));
+	/// assert!(router.exception_handler().is_some());
+	/// ```
+	pub fn with_exception_handler(mut self, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		self.exception_handler = Some(exception_handler);
+		self
+	}
+
+	/// Returns the installed exception handler, if any.
+	pub fn exception_handler(&self) -> Option<&Arc<dyn ExceptionHandler>> {
+		self.exception_handler.as_ref()
 	}
 
 	/// Set the prefix for this router

--- a/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
@@ -99,6 +99,15 @@ impl Handler for ServerRouter {
 					.fold(MiddlewareChain::new(handler), |chain, mw| {
 						chain.with_middleware(mw.clone())
 					});
+				// A middleware in this chain can fail too (a CSRF or permission
+				// rejection on an unmatched path), and that error must use the same
+				// handler as the 404/405 body above.
+				let chain = match self.exception_handler.as_ref() {
+					Some(exception_handler) => {
+						chain.with_exception_handler(Arc::clone(exception_handler))
+					}
+					None => chain,
+				};
 				return chain.handle(req).await;
 			}
 		};

--- a/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
@@ -106,7 +106,7 @@ impl Handler for ServerRouter {
 					// An installed handler answers the request directly. Without
 					// one the error stays an `Err`, which is what callers of a
 					// middleware-free router rely on.
-					let error = routing_error(error_kind, &method.to_string(), &path);
+					let error = routing_error(error_kind, method.as_ref(), &path);
 					return match self.exception_handler.as_ref() {
 						Some(exception_handler) => {
 							Ok(exception_handler.handle_exception(&req, error).await)

--- a/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
@@ -37,16 +37,37 @@ impl Default for ServerRouter {
 	}
 }
 
-/// Handler that always returns a pre-built response.
+/// The kind of routing failure produced when no route matches a request.
+#[derive(Clone, Copy)]
+enum RoutingErrorKind {
+	NotFound,
+	MethodNotAllowed,
+}
+
+fn routing_error(kind: RoutingErrorKind, method: &str, path: &str) -> Error {
+	match kind {
+		RoutingErrorKind::MethodNotAllowed => {
+			Error::MethodNotAllowed(format!("Method {method} not allowed for {path}"))
+		}
+		RoutingErrorKind::NotFound => Error::NotFound(format!("No route for {method} {path}")),
+	}
+}
+
+/// Handler that returns the routing error for the current request.
 ///
-/// Used internally to route framework-level error responses (404/405)
-/// through the middleware chain for post-processing. (#3234)
-struct FixedResponseHandler(Response);
+/// Keeping the error as an `Err` until the middleware chain reaches this
+/// handler lets middleware short-circuit an unmatched request without first
+/// invoking the exception handler for a response that will be discarded.
+struct RoutingErrorHandler {
+	kind: RoutingErrorKind,
+	method: String,
+	path: String,
+}
 
 #[async_trait]
-impl Handler for FixedResponseHandler {
+impl Handler for RoutingErrorHandler {
 	async fn handle(&self, _request: Request) -> Result<Response> {
-		Ok(self.0.clone())
+		Err(routing_error(self.kind, &self.method, &self.path))
 	}
 }
 
@@ -54,20 +75,28 @@ impl Handler for FixedResponseHandler {
 #[async_trait]
 impl Handler for ServerRouter {
 	async fn handle(&self, mut req: Request) -> Result<Response> {
-		let path = req.uri.path();
-		let method = &req.method;
+		let path = req.uri.path().to_owned();
+		let method = req.method.clone();
 
 		// Resolve route with HTTP method for matchit routing
-		let route_match = match self.resolve(path, method) {
+		let route_match = match self.resolve(&path, &method) {
 			Some(m) => m,
 			None => {
 				// Route not found for this method
 				// Check if path exists for any other method to determine 404 vs 405
-				let error = if self.path_exists_for_any_method(path) {
-					Error::MethodNotAllowed(format!("Method {} not allowed for {}", method, path))
+				let error_kind = if self.path_exists_for_any_method(&path) {
+					RoutingErrorKind::MethodNotAllowed
 				} else {
-					Error::NotFound(format!("No route for {} {}", method, path))
+					RoutingErrorKind::NotFound
 				};
+
+				// The route match normally installs the route's DI context below.
+				// Unmatched requests have no `RouteMatch`, so install the router
+				// context before an exception handler or router middleware observes
+				// the request.
+				if let Some(di_ctx) = &self.di_context {
+					req.set_di_context(di_ctx.clone());
+				}
 
 				// If router has middleware, route the error response through the
 				// middleware chain so post-processing (e.g., security headers) is
@@ -77,6 +106,7 @@ impl Handler for ServerRouter {
 					// An installed handler answers the request directly. Without
 					// one the error stays an `Err`, which is what callers of a
 					// middleware-free router rely on.
+					let error = routing_error(error_kind, &method.to_string(), &path);
 					return match self.exception_handler.as_ref() {
 						Some(exception_handler) => {
 							Ok(exception_handler.handle_exception(&req, error).await)
@@ -85,15 +115,15 @@ impl Handler for ServerRouter {
 					};
 				}
 
-				// The handler builds the body and the router middleware below
-				// post-processes it, preserving the #3234 ordering.
-				let response = match self.exception_handler.as_ref() {
-					Some(exception_handler) => {
-						exception_handler.handle_exception(&req, error).await
-					}
-					None => Response::from(error),
-				};
-				let handler: Arc<dyn Handler> = Arc::new(FixedResponseHandler(response));
+				// Keep the routing error as an `Err` so the chain's exception
+				// handler runs only when middleware calls the inner handler. This
+				// preserves #3234 post-processing while avoiding duplicate custom
+				// responses when middleware rejects the request first.
+				let handler: Arc<dyn Handler> = Arc::new(RoutingErrorHandler {
+					kind: error_kind,
+					method: method.to_string(),
+					path,
+				});
 				let chain = own_middleware
 					.iter()
 					.fold(MiddlewareChain::new(handler), |chain, mw| {

--- a/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/router_impls.rs
@@ -8,7 +8,9 @@ use super::ServerRouter;
 #[cfg(feature = "viewsets")]
 use super::types::ViewRoute;
 use async_trait::async_trait;
-use reinhardt_http::{Error, Handler, MiddlewareChain, Request, Response, Result};
+use reinhardt_http::{
+	Error, ExceptionHandlingHandler, Handler, MiddlewareChain, Request, Response, Result,
+};
 use std::sync::Arc;
 
 impl std::fmt::Debug for ServerRouter {
@@ -72,10 +74,25 @@ impl Handler for ServerRouter {
 				// applied to framework-level 404/405 responses. (#3234)
 				let own_middleware = self.build_middleware_with_exclusions();
 				if own_middleware.is_empty() {
-					return Err(error);
+					// An installed handler answers the request directly. Without
+					// one the error stays an `Err`, which is what callers of a
+					// middleware-free router rely on.
+					return match self.exception_handler.as_ref() {
+						Some(exception_handler) => {
+							Ok(exception_handler.handle_exception(&req, error).await)
+						}
+						None => Err(error),
+					};
 				}
 
-				let response = Response::from(error);
+				// The handler builds the body and the router middleware below
+				// post-processes it, preserving the #3234 ordering.
+				let response = match self.exception_handler.as_ref() {
+					Some(exception_handler) => {
+						exception_handler.handle_exception(&req, error).await
+					}
+					None => Response::from(error),
+				};
 				let handler: Arc<dyn Handler> = Arc::new(FixedResponseHandler(response));
 				let chain = own_middleware
 					.iter()
@@ -93,15 +110,32 @@ impl Handler for ServerRouter {
 			req.set_di_context(di_ctx.clone());
 		}
 
+		// Route the matched handler's errors through an installed handler before
+		// the middleware chain wraps it. Without one the handler is used as-is, so
+		// the default conversion is unchanged.
+		let route_handler: Arc<dyn Handler> = match self.exception_handler.as_ref() {
+			Some(exception_handler) => Arc::new(ExceptionHandlingHandler::new(
+				route_match.handler.clone(),
+				Arc::clone(exception_handler),
+			)),
+			None => route_match.handler.clone(),
+		};
+
 		// Apply middleware stack using MiddlewareChain
 		if route_match.middleware_stack.is_empty() {
 			// No middleware, execute handler directly
-			route_match.handler.handle(req).await
+			route_handler.handle(req).await
 		} else {
-			let chain = MiddlewareChain::with_middlewares(
-				route_match.handler.clone(),
-				route_match.middleware_stack,
-			);
+			// The chain also converts errors raised by middleware itself, so it
+			// needs the handler independently of the adapter above.
+			let chain =
+				MiddlewareChain::with_middlewares(route_handler, route_match.middleware_stack);
+			let chain = match self.exception_handler.as_ref() {
+				Some(exception_handler) => {
+					chain.with_exception_handler(Arc::clone(exception_handler))
+				}
+				None => chain,
+			};
 
 			// Execute chain
 			chain.handle(req).await

--- a/crates/reinhardt-urls/src/routers/server_router/tests.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/tests.rs
@@ -5,7 +5,10 @@ use hyper::Method;
 use reinhardt_core::endpoint::EndpointInfo;
 use reinhardt_http::{Handler, Request, Response, Result};
 use rstest::rstest;
-use std::sync::Arc;
+use std::sync::{
+	Arc,
+	atomic::{AtomicUsize, Ordering},
+};
 
 struct TestEndpoint<const ID: u8>;
 
@@ -1301,6 +1304,23 @@ impl reinhardt_http::ExceptionHandler for TeapotErrors {
 	}
 }
 
+/// Exception handler that records every invocation.
+struct CountingErrors {
+	calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl reinhardt_http::ExceptionHandler for CountingErrors {
+	async fn handle_exception(
+		&self,
+		_request: &reinhardt_http::Request,
+		_error: reinhardt_http::Error,
+	) -> reinhardt_http::Response {
+		self.calls.fetch_add(1, Ordering::SeqCst);
+		reinhardt_http::Response::new(hyper::StatusCode::IM_A_TEAPOT).with_body("teapot")
+	}
+}
+
 /// Handler that always fails, used to produce a view error.
 struct FailingView;
 
@@ -1375,6 +1395,73 @@ async fn test_404_with_router_middleware_still_runs_post_processing() {
 			.get("x-security-test")
 			.map(|v| v.to_str().unwrap()),
 		Some("applied"),
+	);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unmatched_middleware_error_does_not_invoke_exception_handler_twice() {
+	// Arrange: middleware rejects before the synthetic unmatched-route handler
+	// can run, so only the middleware error should reach the exception handler.
+	let calls = Arc::new(AtomicUsize::new(0));
+	let router = ServerRouter::new()
+		.with_exception_handler(Arc::new(CountingErrors {
+			calls: Arc::clone(&calls),
+		}))
+		.with_middleware(FailingMiddleware);
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/nonexistent"))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+/// Exception handler that verifies the router's DI context is visible.
+struct DiContextErrors {
+	expected: Arc<InjectionContext>,
+}
+
+#[async_trait::async_trait]
+impl reinhardt_http::ExceptionHandler for DiContextErrors {
+	async fn handle_exception(
+		&self,
+		request: &reinhardt_http::Request,
+		_error: reinhardt_http::Error,
+	) -> reinhardt_http::Response {
+		let has_context = request
+			.get_di_context::<Arc<InjectionContext>>()
+			.is_some_and(|actual| Arc::ptr_eq(actual.as_ref(), &self.expected));
+		let body = if has_context { "context" } else { "missing" };
+		reinhardt_http::Response::new(hyper::StatusCode::IM_A_TEAPOT).with_body(body)
+	}
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unmatched_exception_handler_receives_router_di_context() {
+	// Arrange
+	let di_context =
+		Arc::new(InjectionContext::builder(Arc::new(reinhardt_di::SingletonScope::new())).build());
+	let router = ServerRouter::new()
+		.with_di_context(Arc::clone(&di_context))
+		.with_exception_handler(Arc::new(DiContextErrors {
+			expected: Arc::clone(&di_context),
+		}));
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/nonexistent"))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(
+		String::from_utf8(response.body.to_vec()).unwrap(),
+		"context"
 	);
 }
 

--- a/crates/reinhardt-urls/src/routers/server_router/tests.rs
+++ b/crates/reinhardt-urls/src/routers/server_router/tests.rs
@@ -1284,3 +1284,148 @@ fn test_validate_routes_includes_name_errors() {
 	let errors = result.unwrap_err();
 	assert!(errors.iter().any(|e| e.contains("Duplicate route name")));
 }
+
+// --- Exception handler installation (Issue #6294) ---
+
+/// Exception handler producing a body identifiable in assertions.
+struct TeapotErrors;
+
+#[async_trait::async_trait]
+impl reinhardt_http::ExceptionHandler for TeapotErrors {
+	async fn handle_exception(
+		&self,
+		_request: &reinhardt_http::Request,
+		_error: reinhardt_http::Error,
+	) -> reinhardt_http::Response {
+		reinhardt_http::Response::new(hyper::StatusCode::IM_A_TEAPOT).with_body("teapot")
+	}
+}
+
+/// Handler that always fails, used to produce a view error.
+struct FailingView;
+
+#[async_trait::async_trait]
+impl Handler for FailingView {
+	async fn handle(&self, _request: Request) -> Result<Response> {
+		Err(reinhardt_http::Error::Internal("view failed".to_string()))
+	}
+}
+
+/// Handler that always succeeds, used to prove middleware ran.
+struct OkView;
+
+#[async_trait::async_trait]
+impl Handler for OkView {
+	async fn handle(&self, _request: Request) -> Result<Response> {
+		Ok(Response::ok().with_body("ok"))
+	}
+}
+
+/// Middleware that always fails before reaching the next handler.
+struct FailingMiddleware;
+
+#[async_trait::async_trait]
+impl Middleware for FailingMiddleware {
+	async fn process(
+		&self,
+		_request: reinhardt_http::Request,
+		_next: Arc<dyn Handler>,
+	) -> reinhardt_http::Result<reinhardt_http::Response> {
+		Err(reinhardt_http::Error::Internal(
+			"middleware failed".to_string(),
+		))
+	}
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_404_uses_installed_exception_handler() {
+	// Arrange: handler installed, no router middleware
+	let router = ServerRouter::new().with_exception_handler(Arc::new(TeapotErrors));
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/nonexistent"))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_404_with_router_middleware_still_runs_post_processing() {
+	// Arrange: handler plus router middleware that adds a security header
+	let router = ServerRouter::new()
+		.with_exception_handler(Arc::new(TeapotErrors))
+		.with_middleware(SecurityHeaderTestMiddleware);
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/nonexistent"))
+		.await
+		.unwrap();
+
+	// Assert: the handler built the body and the middleware still post-processed
+	// it, preserving the #3234 ordering.
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(
+		response
+			.headers
+			.get("x-security-test")
+			.map(|v| v.to_str().unwrap()),
+		Some("applied"),
+	);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_view_error_uses_installed_exception_handler() {
+	// Arrange: a failing view on a router with no middleware, so the error can
+	// only be answered by the adapter around the route handler
+	let router = ServerRouter::new()
+		.with_exception_handler(Arc::new(TeapotErrors))
+		.handler_arc("/fail", Arc::new(FailingView));
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/fail"))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_middleware_error_uses_installed_exception_handler() {
+	// Arrange: a succeeding view behind a failing middleware, so a 418 can only
+	// come from the chain converting the middleware's error
+	let router = ServerRouter::new()
+		.with_exception_handler(Arc::new(TeapotErrors))
+		.with_middleware(FailingMiddleware)
+		.handler_arc("/ok", Arc::new(OkView));
+
+	// Act
+	let response = Handler::handle(&router, create_test_request("/ok"))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.status, hyper::StatusCode::IM_A_TEAPOT);
+	assert_eq!(String::from_utf8(response.body.to_vec()).unwrap(), "teapot");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_without_exception_handler_keeps_default_conversion() {
+	// Arrange: the same failing view route, but no handler installed
+	let router = ServerRouter::new().handler_arc("/fail", Arc::new(FailingView));
+
+	// Act
+	let result = Handler::handle(&router, create_test_request("/fail")).await;
+
+	// Assert: a middleware-free router still propagates the error unchanged
+	assert!(result.is_err());
+}

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -701,6 +701,11 @@ impl ServerRouter {
 		self
 	}
 
+	/// No-op for `ServerRouter::with_exception_handler`.
+	pub fn with_exception_handler<H>(self, _exception_handler: H) -> Self {
+		self
+	}
+
 	/// No-op for `ServerRouter::with_middleware`.
 	pub fn with_middleware<M>(self, _middleware: M) -> Self {
 		self
@@ -796,6 +801,7 @@ const _: fn() = || {
 			s.with_prefix("/api")
 				.with_namespace("api")
 				.with_di_context(())
+				.with_exception_handler(())
 				.with_middleware(())
 				.with_route_middleware(())
 				.exclude("/internal")

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -51,6 +51,10 @@ use crate::routers::client_router::ClientRouter;
 use reinhardt_core::exception::Result;
 #[cfg(native)]
 use reinhardt_di::InjectionContext;
+// Both `UnifiedRouter` variants install an exception handler, so this import is
+// gated on `native` alone rather than on the `client-router` feature.
+#[cfg(native)]
+use reinhardt_http::ExceptionHandler;
 #[cfg(all(native, not(feature = "client-router")))]
 use reinhardt_http::{Request, Response};
 #[cfg(native)]
@@ -334,6 +338,15 @@ impl UnifiedRouter {
 		self
 	}
 
+	/// Install an exception handler for errors raised while serving requests.
+	///
+	/// This is a convenience method that delegates to
+	/// [`ServerRouter::with_exception_handler`].
+	pub fn with_exception_handler(mut self, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		self.server = self.server.with_exception_handler(exception_handler);
+		self
+	}
+
 	/// Exclude a URL path from the most recently added server middleware.
 	///
 	/// This is a convenience method that delegates to [`ServerRouter::exclude`].
@@ -574,6 +587,15 @@ impl UnifiedRouter {
 			self.di_registrations.register_arc_any(type_id, value);
 		}
 		self.server = self.server.with_middleware(middleware);
+		self
+	}
+
+	/// Install an exception handler for errors raised while serving requests.
+	///
+	/// This is a convenience method that delegates to
+	/// [`ServerRouter::with_exception_handler`].
+	pub fn with_exception_handler(mut self, exception_handler: Arc<dyn ExceptionHandler>) -> Self {
+		self.server = self.server.with_exception_handler(exception_handler);
 		self
 	}
 

--- a/src/exports/core_types.rs
+++ b/src/exports/core_types.rs
@@ -7,7 +7,10 @@ pub use reinhardt_core::{
 };
 
 #[cfg(all(feature = "core", native))]
-pub use reinhardt_http::{Handler, Middleware, MiddlewareChain, Request, Response, ViewResult};
+pub use reinhardt_http::{
+	ExceptionHandler, ExceptionHandlingHandler, Handler, Middleware, MiddlewareChain, Request,
+	Response, ViewResult,
+};
 
 #[cfg(all(feature = "core", native))]
 pub use reinhardt_http::Extensions;

--- a/tests/bench/graphql_performance.rs
+++ b/tests/bench/graphql_performance.rs
@@ -92,7 +92,7 @@ fn bench_direct_graphql(c: &mut Criterion) {
 #[cfg(feature = "graphql-grpc")]
 fn bench_grpc_graphql(c: &mut Criterion) {
 	let runtime = tokio::runtime::Runtime::new().unwrap();
-	let schema = Schema::build(Query, Mutation, EmptySubscription).finish();
+	let schema = GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription).finish();
 	let service = GraphQLGrpcService::new(schema);
 
 	let mut group = c.benchmark_group("grpc_graphql");

--- a/tests/integration/src/graphql/fixtures/schema.rs
+++ b/tests/integration/src/graphql/fixtures/schema.rs
@@ -83,12 +83,12 @@ async fn grpc_fixture(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
 ) -> (
 	Schema<Query, Mutation, EmptySubscription>,
-	GraphQLGrpcService,
+	reinhardt_graphql::GraphQLGrpcService<Query, Mutation, EmptySubscription>,
 ) {
 	use reinhardt_graphql::grpc_service::GraphQLGrpcService;
 
 	let (_container, pool, _port, _url) = postgres_container.await;
-	let schema = create_schema();
+	let schema = reinhardt_graphql::create_schema(UserStorage::new());
 	let grpc_service = GraphQLGrpcService::new(schema.clone());
 
 	(schema, grpc_service)

--- a/tests/integration/tests/server.rs
+++ b/tests/integration/tests/server.rs
@@ -19,6 +19,9 @@ mod server_middleware_integration_tests;
 #[path = "server/server_test_helpers.rs"]
 mod server_test_helpers;
 
+#[path = "server/exception_handler_integration.rs"]
+mod exception_handler_integration;
+
 #[path = "server/server_tests.rs"]
 mod server_tests;
 

--- a/tests/integration/tests/server/exception_handler_integration.rs
+++ b/tests/integration/tests/server/exception_handler_integration.rs
@@ -1,0 +1,91 @@
+//! Exception handler installation end-to-end tests (Issue #6294).
+//!
+//! Exercises the reporter's scenario over a real HTTP connection: a router with
+//! an installed [`ExceptionHandler`] must answer errors with the application's
+//! fixed error shape rather than the framework default.
+
+use async_trait::async_trait;
+use reinhardt_core::exception::Error;
+use reinhardt_http::{ExceptionHandler, Handler, Middleware, Request, Response};
+use reinhardt_urls::routers::ServerRouter;
+use rstest::rstest;
+use std::sync::Arc;
+
+use super::server_test_helpers::{shutdown_test_server, spawn_test_server};
+
+/// Reproduces an application whose clients parse a fixed error body.
+struct ApiErrors;
+
+#[async_trait]
+impl ExceptionHandler for ApiErrors {
+	async fn handle_exception(&self, _request: &Request, error: Error) -> Response {
+		let status = hyper::StatusCode::from_u16(error.status_code())
+			.unwrap_or(hyper::StatusCode::INTERNAL_SERVER_ERROR);
+		Response::new(status).with_body(
+			serde_json::json!({
+				"errNo": status.as_u16(),
+				"errMsg": "The requested resource is not available.",
+			})
+			.to_string(),
+		)
+	}
+}
+
+/// Middleware that fails before reaching the next handler.
+struct RejectingMiddleware;
+
+#[async_trait]
+impl Middleware for RejectingMiddleware {
+	async fn process(
+		&self,
+		_request: Request,
+		_next: Arc<dyn Handler>,
+	) -> reinhardt_core::exception::Result<Response> {
+		Err(Error::PermissionDenied(
+			"token rejected by middleware".to_string(),
+		))
+	}
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_router_404_uses_installed_handler_over_http() {
+	// Arrange: the reporter's installation, on a real listener
+	let router = ServerRouter::new().with_exception_handler(Arc::new(ApiErrors));
+	let (url, handle) = spawn_test_server(Arc::new(router)).await;
+
+	// Act
+	let response = reqwest::get(format!("{}/missing", url)).await.unwrap();
+
+	// Assert: the framework default body is replaced by the application shape
+	assert_eq!(response.status().as_u16(), 404);
+	let body: serde_json::Value = response.json().await.unwrap();
+	assert_eq!(body["errNo"], 404);
+	assert_eq!(body["errMsg"], "The requested resource is not available.");
+
+	// Cleanup
+	shutdown_test_server(handle).await;
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_middleware_error_uses_installed_handler_over_http() {
+	// Arrange: a failing middleware on the router, so the error never reaches a
+	// view and can only be answered by the router's installed handler
+	let router = ServerRouter::new()
+		.with_exception_handler(Arc::new(ApiErrors))
+		.with_middleware(RejectingMiddleware);
+	let (url, handle) = spawn_test_server(Arc::new(router)).await;
+
+	// Act
+	let response = reqwest::get(format!("{}/anything", url)).await.unwrap();
+
+	// Assert
+	assert_eq!(response.status().as_u16(), 403);
+	let body: serde_json::Value = response.json().await.unwrap();
+	assert_eq!(body["errNo"], 403);
+	assert_eq!(body["errMsg"], "The requested resource is not available.");
+
+	// Cleanup
+	shutdown_test_server(handle).await;
+}

--- a/tests/integration/tests/server/exception_handler_integration.rs
+++ b/tests/integration/tests/server/exception_handler_integration.rs
@@ -5,8 +5,11 @@
 //! fixed error shape rather than the framework default.
 
 use async_trait::async_trait;
+// Imported through the facade prelude, mirroring what a generated project's
+// `src/config/urls.rs` sees with `use reinhardt::prelude::*`.
+use reinhardt::prelude::ExceptionHandler;
 use reinhardt_core::exception::Error;
-use reinhardt_http::{ExceptionHandler, Handler, Middleware, Request, Response};
+use reinhardt_http::{Handler, Middleware, Request, Response};
 use reinhardt_urls::routers::ServerRouter;
 use rstest::rstest;
 use std::sync::Arc;
@@ -41,7 +44,10 @@ impl Middleware for RejectingMiddleware {
 		_request: Request,
 		_next: Arc<dyn Handler>,
 	) -> reinhardt_core::exception::Result<Response> {
-		Err(Error::PermissionDenied(
+		// `Error::Authorization` maps to 403 and stands in for the kind of
+		// middleware rejection (CSRF, permission check) that must also reach the
+		// application's handler.
+		Err(Error::Authorization(
 			"token rejected by middleware".to_string(),
 		))
 	}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -92,7 +92,7 @@
 			<ul class="nav-links" id="nav-links" role="list">
 				<li><a href="/quickstart/">Quickstart</a></li>
 				<li><a href="/docs/">Docs</a></li>
-				<li><a href="/notes/">Notes</a></li>
+				<li><a href="https://press.reinhardt-web.dev/">Notes</a></li>
 				<li><a href="/changelog/">Changelog</a></li>
 				<li>
 					<a href="{{ config.extra.github_repo }}"


### PR DESCRIPTION
## Summary

This PR addresses:

- Adds the `ExceptionHandler` extension point to `reinhardt-http`, with `ExceptionHandlingHandler` as the adapter that applies it to a handler chain.
- Gives `MiddlewareChain` a `with_exception_handler` builder; its internal error-to-response sites consult the installed handler, so errors raised by middleware are covered in addition to errors from the base handler.
- Installs the hook on `ServerRouter` / `UnifiedRouter`, on `HttpServer`, and re-exports it from the facade prelude.
- Makes `runserver` forward the router's handler to `HttpServer`, so a single installation in `src/config/urls.rs` covers server-level middleware too.
- Adds an end-to-end integration test that serves the reporter's scenario over a real HTTP connection.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`reinhardt_dispatch::ExceptionHandler` is public API that could not be installed and that nothing
invoked. Investigation showed the report's proposed fix — `Dispatcher::with_exception_handler`
plus threading a handler through `convert_exception_to_response` — sits on code the framework never
runs: `Dispatcher` has no consumer, and `convert_exception_to_response` has no caller.

The live path funnels every error through one global
`impl From<reinhardt_core::exception::Error> for Response`, which cannot be swapped at runtime
because a trait impl is chosen at compile time. An extension point therefore has to be an object
inserted into the path.

Two structural facts drove the design:

1. **The trait has to live in `reinhardt-http`.** `reinhardt-dispatch` depends on that crate, so the
   reverse direction is impossible, and two of the conversion sites are in it.
2. **`MiddlewareChain` swallows errors internally** — with at least one middleware present it never
   returns `Err` — so wrapping only the innermost handler would leave middleware errors (CSRF
   rejection, authorization denial, rate limiting) on the default body. The chain consults the
   handler itself for that reason.

`reinhardt-dispatch` is deliberately untouched: its API is provably unreachable, so changing its
signature would buy a SemVer break and nothing else. Removing it is tracked separately.

When no handler is installed every site still falls back to `Response::from`, so behaviour is
unchanged and the information-disclosure guarantees covered by #439 are untouched.

Fixes #6294

## How Was This Tested?

Commands run in the branch's worktree:

- `cargo nextest run -p reinhardt-http --all-features` — 227 tests, all pass.
- `cargo test --doc -p reinhardt-http --all-features` — 131 doctests, all pass.
- `cargo nextest run -p reinhardt-urls --all-features` — 921 tests, all pass. Includes the router
  cases: 404 through the handler, a view error through the adapter, a router-middleware error
  through the chain, and the #3234 regression guard asserting router middleware still post-processes
  the handler's 404 body.
- `cargo nextest run -p reinhardt-server -p reinhardt-commands --all-features`.
- `cargo clippy` and `cargo fmt --check` over `reinhardt-http`, `reinhardt-urls`, `reinhardt-server`
  and `reinhardt-commands` — clean.

New tests assert the invariant that matters for a released line: with no handler installed, a
middleware-free router still propagates `Err` and every other path returns the default body.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have formatted the code with `cargo make fmt-fix`
- [x] I have checked the code with `cargo make clippy-check`

## Related Issues

Fixes #6294

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Additional Labels
- [x] `enhancement` - approved non-breaking addition under SP-6, hence `rc-addition`

### Scope Label
- [x] `http` - HTTP layer, handlers, middleware
- [x] `routing` - URL routing, path matching

---

**Additional Context:**

The extension point takes `reinhardt_core::exception::Error` unchanged, which is the type the live
path produces and which carries `status_code()`. Structured validation payloads (DRF's
`ValidationError` equivalent) are intentionally out of scope and belong in a separate issue; the
signature chosen here does not block them.

Installing a handler transfers responsibility for the response body and headers to the handler: the
default conversion's safety properties (no internal details, `Content-Type: text/plain; charset=utf-8`,
`X-Content-Type-Options: nosniff`) are not applied on its behalf. This is documented on the trait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
