### PR TITLE
fix(test): define the native cfg so generated model validators compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,6 +387,10 @@ reinhardt-query = { workspace = true, optional = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 
+[dev-dependencies]
+# The root integration test target reuses `tests/build.rs`, which invokes this macro.
+cfg_aliases = "0.2"
+
 [build-dependencies]
 cfg_aliases = "0.2"
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -96,6 +96,10 @@ async-stream = "0.3"
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
+# Declares the `wasm` / `native` cfg aliases consumed by generated model code.
+# Not a workspace dependency: `cfg_aliases` is declared directly in each package
+# that uses it.
+cfg_aliases = "0.2"
 
 [lib]
 path = "integration/src/lib.rs"

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,4 +1,19 @@
+//! Build script for the shared test-support package.
+//!
+//! This package's `[lib]` points at `integration/src/lib.rs`, the same sources
+//! `reinhardt-integration-tests` compiles. The model macro gates the `Validate`
+//! derive and the validator attributes it generates behind `cfg(native)`, so the
+//! alias has to be defined here too — otherwise the shared library would compile
+//! with the generated validators silently dropped in this package only.
+
+use cfg_aliases::cfg_aliases;
+
 fn main() {
 	println!("cargo::rustc-check-cfg=cfg(wasm)");
 	println!("cargo::rustc-check-cfg=cfg(native)");
+
+	cfg_aliases! {
+		wasm: { all(target_family = "wasm", target_os = "unknown") },
+		native: { not(all(target_family = "wasm", target_os = "unknown")) },
+	}
 }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -145,6 +145,11 @@ regex = { workspace = true }
 tracing = { workspace = true }
 trybuild = { workspace = true }
 
+[build-dependencies]
+# Declares the `wasm` / `native` cfg aliases consumed by generated model code and by test modules.
+# Not a workspace dependency: `cfg_aliases` is declared directly in each package that uses it.
+cfg_aliases = "0.2"
+
 [features]
 default = ["postgres", "sqlite", "caching", "hot-reload", "dynamic-redis"]
 testcontainers = []

--- a/tests/integration/build.rs
+++ b/tests/integration/build.rs
@@ -1,3 +1,12 @@
+//! Build script for the cross-crate integration test package.
+//!
+//! The model macro gates the `Validate` derive and the validator attributes it generates behind
+//! `cfg(native)`, and several test modules are themselves gated on `native`. `rustc-check-cfg`
+//! only silences the `unexpected_cfgs` lint; the aliases have to be emitted for those blocks to
+//! take effect.
+
+use cfg_aliases::cfg_aliases;
+
 fn main() {
 	// Declare custom cfg features to avoid "unexpected cfg" warnings
 	println!(
@@ -5,4 +14,9 @@ fn main() {
 	);
 	println!("cargo::rustc-check-cfg=cfg(wasm)");
 	println!("cargo::rustc-check-cfg=cfg(native)");
+
+	cfg_aliases! {
+		wasm: { all(target_family = "wasm", target_os = "unknown") },
+		native: { not(all(target_family = "wasm", target_os = "unknown")) },
+	}
 }

--- a/tests/integration/tests/macros/validator_integration.rs
+++ b/tests/integration/tests/macros/validator_integration.rs
@@ -1,7 +1,9 @@
 //! Integration tests for validator support in Model derive macro
 
+use reinhardt_core::validators::Validate;
 use reinhardt_db::orm::Model as ModelTrait;
 use reinhardt_macros::model;
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -156,4 +158,122 @@ fn test_no_validators() {
 	assert!(!name_field.attributes.contains_key("min_length"));
 	assert!(!name_field.attributes.contains_key("min_value"));
 	assert!(!name_field.attributes.contains_key("max_value"));
+}
+
+// ============================================================================
+// Generated validator execution
+//
+// `field_metadata()` only proves the validator attributes were recorded as
+// metadata. The tests below exercise the `Validate` impl `#[model]` generates
+// for `{Model}Info` — the code path that regressed in issue #6295, where a bound
+// carrying a type suffix pinned the validator's type parameter and failed to
+// compile.
+//
+// That impl only exists when `cfg(native)` is defined, which this package's
+// `build.rs` now does. These tests are deliberately NOT `#[cfg]`-gated: if the
+// alias stops being defined they must fail to compile rather than silently
+// disappear, which is exactly how #6295 stayed hidden.
+// ============================================================================
+
+/// `UserInfo` with values satisfying every validator except the field under test.
+fn valid_user_info() -> UserInfo {
+	UserInfo {
+		id: 1,
+		email: "user@example.com".to_string(),
+		website: "https://example.com".to_string(),
+		username: "user".to_string(),
+		age: 30,
+	}
+}
+
+#[rstest]
+fn generated_validators_accept_in_bounds_values() {
+	// Arrange
+	let info = valid_user_info();
+
+	// Act
+	let result = info.validate();
+
+	// Assert
+	assert!(
+		result.is_ok(),
+		"expected in-bounds info to validate: {result:?}"
+	);
+}
+
+#[rstest]
+#[case(0, true)]
+#[case(120, true)]
+#[case(-1, false)]
+#[case(121, false)]
+fn generated_range_validator_enforces_bounds(#[case] age: i32, #[case] expected_ok: bool) {
+	// Arrange
+	let mut info = valid_user_info();
+	info.age = age;
+
+	// Act
+	let result = info.validate();
+
+	// Assert
+	assert_eq!(result.is_ok(), expected_ok, "age {age} => {result:?}");
+}
+
+#[rstest]
+#[case("abc", true)]
+#[case("user", true)]
+#[case("ab", false)]
+fn generated_length_validator_enforces_min_bound(
+	#[case] username: &str,
+	#[case] expected_ok: bool,
+) {
+	// Arrange
+	let mut info = valid_user_info();
+	info.username = username.to_string();
+
+	// Act
+	let result = info.validate();
+
+	// Assert
+	assert_eq!(
+		result.is_ok(),
+		expected_ok,
+		"username {username:?} => {result:?}"
+	);
+}
+
+/// Regression test for issue #6295: a `min_value` / `max_value` bound applied to
+/// a 32-bit field. The pre-fix macro emitted `validate(range(min = 0i64, ...))`,
+/// which pinned `MinValueValidator<T>` to `i64` and failed to compile against an
+/// `Option<i32>` field with `E0308: expected &i64, found &i32`.
+#[rstest]
+#[case(Some(0), true)]
+#[case(Some(2147483647), true)]
+#[case(Some(-1), false)]
+#[case(None, true)]
+fn generated_range_validator_supports_32_bit_fields(
+	#[case] quantity: Option<i32>,
+	#[case] expected_ok: bool,
+) {
+	// Arrange
+	#[derive(Serialize, Deserialize)]
+	#[model(app_label = "test_app", table_name = "validator_range_bound_items")]
+	struct RangeBoundItem {
+		#[field(primary_key = true)]
+		id: i64,
+
+		#[field(null = true, min_value = 0, max_value = 2147483647)]
+		quantity: Option<i32>,
+	}
+
+	let info = RangeBoundItemInfo { id: 1, quantity };
+
+	// Act
+	let result = info.validate();
+
+	// Assert
+	assert_eq!(
+		result.is_ok(),
+		expected_ok,
+		"quantity {quantity:?} => {result:?}"
+	);
 }


### PR DESCRIPTION
## Summary

This PR addresses:

- `tests/integration/build.rs` and `tests/build.rs` now **define** the `native` / `wasm` cfg aliases with `cfg_aliases!` instead of only declaring them with `rustc-check-cfg`.
- `tests/integration/tests/macros/validator_integration.rs` gains runtime coverage for the `Validate` impl the `#[model]` macro generates; it previously only inspected `field_metadata()`.
- Adds the `cfg_aliases` build dependency to both test packages.

Closes #6298.

> **Stacked PR** — this branch is based on `fix/issue-6295-unsuffixed-validate-bounds` (PR #6297) rather than `main`. Defining `native` immediately exposes the #6295 defect (`E0308: expected &i64, found &i32` in `validator_integration.rs`), so this PR cannot compile without that fix. **Please retarget the base to `main` once #6297 merges.**

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible

## Motivation and Context

`rustc-check-cfg` only silences the `unexpected_cfgs` lint — it does not set the cfg. `tests/integration/build.rs` and `tests/build.rs` printed those declarations but never emitted the cfgs, so `cfg(native)` was **false** in both packages. Every `#[cfg_attr(native, ...)]` attribute generated by `#[model]` was therefore dropped:

- the `Validate` derive the macro puts on the generated `{Model}Info` struct,
- the `#[validate(...)]` attributes it puts on that struct's fields,

which means the generated validator code for the **46 test files** under `tests/integration/tests/` that use `#[model]` was never compiled. Four behavioural tests gated on `#[cfg(native)]` in `tests/integration/tests/pages/api_model_crud_integration.rs` were also compiled out and had never run.

Both aliases are now defined the same way the other packages do it (`reinhardt-core`, `reinhardt-apps`, `reinhardt-pages`, `reinhardt-urls`, `reinhardt-test`, `reinhardt-testkit`). `tests/` needs the definition as well because its `[lib]` points at the same `integration/src/lib.rs` sources — without it the shared library would compile with generated validators dropped in one package but not the other.

The new tests in `validator_integration.rs` are deliberately **not** `#[cfg]`-gated. If the alias ever stops being defined they must fail to compile rather than silently disappear, which is precisely how this hole stayed hidden. `reinhardt-integration-tests` is not part of the WASM matrix (`wasm-check.yml` covers `reinhardt-web`, `reinhardt-pages`, `reinhardt-query`, `reinhardt-core` only), so host-only assertions are safe here.

## How Was This Tested?

Blast radius was measured before landing, on a branch that did **not** yet have the #6297 fix:

| Check | Result |
|---|---|
| `cargo check -p reinhardt-integration-tests --all-features --tests` (without the #6297 fix) | **exactly 2 errors**, both `E0308: expected &i64, found &i32`, at `validator_integration.rs:8` and `:99` — the #6295 defect, surfaced by enabling `native` for the first time |
| same command, with the #6297 fix stacked | exit 0, 0 errors |
| `cargo nextest run -p reinhardt-integration-tests --all-features -E 'test(/validator_integration\|non_wasm_error/)'` | **22 passed, 0 failed** — 12 new cases plus the 4 previously-dead `cfg(native)` tests plus the 6 pre-existing metadata tests |
| `cargo check -p reinhardt-test-support --all-features --tests` | exit 0, 0 errors |
| `cargo fmt -p reinhardt-integration-tests -p reinhardt-test-support -- --check` | clean |
| `cargo clippy -p reinhardt-integration-tests -p reinhardt-test-support --all-features --tests` | **no lint targets any file this PR touches**; see the pre-existing failure noted below |

The four tests in `api_model_crud_integration.rs` that had never executed now run and pass, so enabling the alias surfaced no collateral breakage beyond #6295.

## Additional Context

- **Pre-existing clippy failure, not caused by this PR.** `cargo clippy -p reinhardt-integration-tests --all-features --all-targets -- -D warnings` exits non-zero on `clippy::approx_constant` at `tests/integration/tests/views/views_property_based_integration.rs:210` (`3.14`). This was verified to reproduce identically on unmodified `main` (exit 101, same file:line). Because `cargo make clippy-check` runs `--workspace --all --all-features -- -D warnings`, `clippy.yml` should be reporting this on `main` too. Tracked as #6300; this PR does not touch that file, changes no features, and `tests/integration/tests/views/` has no `native`/`wasm` gating.
- `instructions/MACRO_USAGE.md` is unaffected: no macro attribute syntax changed. `CHANGELOG` is generated by release-plz.
- The macro-level regression test for #6295 (`model_derive::tests::test_validate_range_bounds_are_unsuffixed`) stays as the fast guard; the tests added here are the compile-and-run guard that was missing.

## Checklist

- [x] I have followed the Contributing Guidelines
- [x] I have followed the Commit Guidelines
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have formatted the code

## Related Issues

- Fixes #6298
- Depends on #6295 / PR #6297 (stacked base)

## Labels to Apply

### Type Label
- [x] `bug` - Bug fix

### Scope Label
- [x] `ci-cd` - CI/CD workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
