### PR TITLE
feat(pages): render named ClientForms with owned mutations

### DIFF
--- a/crates/reinhardt-formatter/Cargo.toml
+++ b/crates/reinhardt-formatter/Cargo.toml
@@ -9,7 +9,11 @@ authors.workspace = true
 description = "Formatter for Reinhardt page!, form!, head!, and style! DSL macros"
 publish = true
 
+[features]
+testing = ["dep:reinhardt-manouche"]
+
 [dependencies]
+reinhardt-manouche = { workspace = true, optional = true }
 clap = { version = "4.5", features = ["derive"] }
 colored = { workspace = true }
 regex = "1.10"
@@ -25,6 +29,9 @@ walkdir = "2.5"
 zeroize = "1.8"
 
 [dev-dependencies]
+syn = { workspace = true, features = ["full", "visit"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 rstest = { workspace = true }
 tempfile = "3.8"
 

--- a/crates/reinhardt-formatter/src/format_engine.rs
+++ b/crates/reinhardt-formatter/src/format_engine.rs
@@ -2752,4 +2752,79 @@ static STYLES: Styles = style! { .card { color: red; } };\n";
 		assert_eq!(protected_source, source);
 		assert_eq!(restored, source);
 	}
+
+	#[cfg(feature = "testing")]
+	#[rstest]
+	#[case(include_str!("../tests/fixtures/form/client_form_view.input"))]
+	#[case(include_str!("../tests/fixtures/form/client_form_view_expressions.input"))]
+	fn named_client_form_preserves_parsed_expressions_and_is_idempotent(#[case] input: &str) {
+		use quote::ToTokens;
+		use reinhardt_manouche::core::{ClientFormViewClause, PresentationProperty};
+		use syn::visit::Visit;
+		struct Views(Vec<Vec<String>>);
+		impl<'ast> Visit<'ast> for Views {
+			fn visit_macro(&mut self, node: &'ast syn::Macro) {
+				if !node.path.is_ident("form") {
+					return;
+				}
+				let ast = reinhardt_manouche::parser::parse_client_form_view(node.tokens.clone())
+					.unwrap();
+				let mut expressions = vec![ast.companion.to_token_stream().to_string()];
+				fn properties(items: Vec<PresentationProperty>, out: &mut Vec<String>) {
+					for property in items {
+						out.push(property.name.to_string());
+						out.push(property.value.to_token_stream().to_string());
+					}
+				}
+				for clause in ast.clauses {
+					match clause {
+						ClientFormViewClause::Mutation(value) | ClientFormViewClause::Id(value) => {
+							expressions.push(value.to_token_stream().to_string())
+						}
+						ClientFormViewClause::Customize(fields) => {
+							for field in fields {
+								expressions.push(field.field.to_string());
+								properties(field.properties, &mut expressions);
+							}
+						}
+						ClientFormViewClause::Styling(items)
+						| ClientFormViewClause::Submit(items)
+						| ClientFormViewClause::Summary(items) => properties(items, &mut expressions),
+					}
+				}
+				self.0.push(expressions);
+			}
+		}
+		// Arrange
+		let formatter = FormatEngine::new();
+		let mut before = Views(Vec::new());
+		before.visit_file(&syn::parse_file(input).unwrap());
+		// Act
+		let formatted = formatter.format(input).unwrap().content;
+		let mut after = Views(Vec::new());
+		after.visit_file(&syn::parse_file(&formatted).unwrap());
+		// Assert
+		assert_eq!(before.0.len(), 1);
+		assert_eq!(before.0, after.0);
+		assert_eq!(formatter.format(&formatted).unwrap().content, formatted);
+		assert_eq!(
+			input.matches("// Reuse the configured mutation.").count(),
+			formatted
+				.matches("// Reuse the configured mutation.")
+				.count()
+		);
+	}
+
+	#[test]
+	fn named_client_form_matches_the_golden_layout() {
+		let result = FormatEngine::new()
+			.format(include_str!(
+				"../tests/fixtures/form/client_form_view.input"
+			))
+			.unwrap();
+		assert_eq!(
+			result.content,
+			include_str!("../tests/fixtures/form/client_form_view.expected.rs")
+		);
+	}
 }

--- a/crates/reinhardt-formatter/tests/fixtures/form/client_form_view.expected.rs
+++ b/crates/reinhardt-formatter/tests/fixtures/form/client_form_view.expected.rs
@@ -1,0 +1,26 @@
+fn login_page() {
+	let _page = form! {
+		client_form: auth::LoginClientForm,
+		mutation: &mutation,
+		id: "login",
+		customize: {
+			r#type: {
+				label: "Type"
+			},
+			password: {
+				widget: PasswordInput,
+				autocomplete: "current-password"
+			}
+		},
+		styling: {
+			class: styles::auth().as_str()
+		},
+		submit: {
+			label: "Sign in",
+			pending_label: "Signing in..."
+		},
+		summary: {
+			label: "Errors"
+		},
+	};
+}

--- a/crates/reinhardt-formatter/tests/fixtures/form/client_form_view.input
+++ b/crates/reinhardt-formatter/tests/fixtures/form/client_form_view.input
@@ -1,0 +1,3 @@
+fn login_page() {
+	let _page = form!{client_form: auth::LoginClientForm,mutation: &mutation,id: "login",customize:{r#type:{label: "Type"},password:{widget: PasswordInput,autocomplete: "current-password"}},styling:{class: styles::auth().as_str()},submit:{label: "Sign in",pending_label: "Signing in..."},summary:{label: "Errors"},};
+}

--- a/crates/reinhardt-formatter/tests/fixtures/form/client_form_view_expressions.input
+++ b/crates/reinhardt-formatter/tests/fixtures/form/client_form_view_expressions.input
@@ -1,0 +1,10 @@
+fn login_page() {
+    let _page = form! {
+        client_form: crate::auth::LoginClientForm,
+        // Reuse the configured mutation.
+        mutation: { let handle = get::<Request, Response>(); handle },
+        customize: {
+            username: { label: { let join = |a: &str, b: &str| format!("{a},{b}"); join("User", "name") }, aria_describedby: r#"external-help"# },
+        },
+    };
+}

--- a/crates/reinhardt-manouche/src/core.rs
+++ b/crates/reinhardt-manouche/src/core.rs
@@ -7,6 +7,7 @@
 //! - Common types and utilities
 
 pub mod attr_utils;
+pub mod client_form_view;
 pub mod form_node;
 pub mod form_typed;
 pub mod head_node;
@@ -17,6 +18,7 @@ pub mod style_typed;
 pub mod typed_node;
 pub mod types;
 
+pub use client_form_view::*;
 pub use form_node::*;
 pub use form_typed::*;
 pub use head_node::*;

--- a/crates/reinhardt-manouche/src/core/client_form_view.rs
+++ b/crates/reinhardt-manouche/src/core/client_form_view.rs
@@ -1,0 +1,72 @@
+//! Independent syntax for rendering a named ClientForm's existing mutation.
+
+use syn::{Expr, Ident, Path};
+
+/// A named ClientForm view, preserving presentation expression order.
+#[derive(Clone, Debug)]
+pub struct ClientFormViewMacro {
+	/// Path to the generated ClientForm companion.
+	pub companion: Path,
+	/// Configuration in source order, excluding the initial companion path.
+	pub clauses: Vec<ClientFormViewClause>,
+}
+
+impl ClientFormViewMacro {
+	/// Returns the mutation expression required by the parser.
+	pub fn mutation(&self) -> &Expr {
+		self.clauses
+			.iter()
+			.find_map(|clause| match clause {
+				ClientFormViewClause::Mutation(value) => Some(value),
+				_ => None,
+			})
+			.expect("a parsed ClientForm view has a mutation")
+	}
+
+	/// Returns customized Rust field names in source order.
+	pub fn field_names(&self) -> Vec<String> {
+		self.clauses
+			.iter()
+			.flat_map(|clause| match clause {
+				ClientFormViewClause::Customize(fields) => fields.as_slice(),
+				_ => &[],
+			})
+			.map(|field| field.field.to_string().trim_start_matches("r#").to_owned())
+			.collect()
+	}
+}
+
+/// One configuration clause in a named ClientForm view.
+#[derive(Clone, Debug)]
+pub enum ClientFormViewClause {
+	/// Reference to the application-owned mutation.
+	Mutation(Expr),
+	/// Explicit form instance ID.
+	Id(Expr),
+	/// Shared presentation classes.
+	Styling(Vec<PresentationProperty>),
+	/// Typed field presentation overrides.
+	Customize(Vec<FieldCustomization>),
+	/// Submit button labels and class.
+	Submit(Vec<PresentationProperty>),
+	/// Validation summary label.
+	Summary(Vec<PresentationProperty>),
+}
+
+/// A presentation property with its original expression and source span.
+#[derive(Clone, Debug)]
+pub struct PresentationProperty {
+	/// Property name.
+	pub name: Ident,
+	/// Expression evaluated once during view assembly.
+	pub value: Expr,
+}
+
+/// Partial presentation overrides for one exposed Rust DTO field.
+#[derive(Clone, Debug)]
+pub struct FieldCustomization {
+	/// Rust field identifier, which may be raw.
+	pub field: Ident,
+	/// Overrides in source order.
+	pub properties: Vec<PresentationProperty>,
+}

--- a/crates/reinhardt-manouche/src/parser.rs
+++ b/crates/reinhardt-manouche/src/parser.rs
@@ -6,11 +6,13 @@
 //! - `head!` macro → `HeadMacro`
 //! - `style!` macro → `StyleMacro`
 
+mod client_form_view;
 mod form;
 mod head;
 mod page;
 mod style;
 
+pub use client_form_view::*;
 pub use form::*;
 pub use head::*;
 pub use page::*;

--- a/crates/reinhardt-manouche/src/parser/client_form_view.rs
+++ b/crates/reinhardt-manouche/src/parser/client_form_view.rs
@@ -1,0 +1,198 @@
+//! Parser for the independent named ClientForm view mode.
+
+use crate::core::client_form_view::{
+	ClientFormViewClause, ClientFormViewMacro, FieldCustomization, PresentationProperty,
+};
+use proc_macro2::{Span, TokenStream, TokenTree};
+use std::collections::BTreeMap;
+use syn::{
+	Expr, Ident, Lit, Token, braced,
+	ext::IdentExt,
+	parse::{Parse, ParseStream},
+};
+
+/// Detects the explicit first-property discriminator without parsing standalone forms.
+pub fn is_client_form_view(input: &TokenStream) -> bool {
+	let mut tokens = input.clone().into_iter();
+	matches!(tokens.next(), Some(TokenTree::Ident(key)) if key == "client_form")
+		&& matches!(tokens.next(), Some(TokenTree::Punct(colon)) if colon.as_char() == ':')
+}
+
+/// Parses a complete named ClientForm view.
+pub fn parse_client_form_view(input: TokenStream) -> syn::Result<ClientFormViewMacro> {
+	syn::parse2(input)
+}
+
+impl Parse for ClientFormViewMacro {
+	fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+		let first = input.call(Ident::parse_any)?;
+		if first != "client_form" {
+			return Err(syn::Error::new(
+				first.span(),
+				"`client_form` must be the first property",
+			));
+		}
+		input.parse::<Token![:]>()?;
+		let companion = input.parse()?;
+		let mut seen = BTreeMap::from([(String::from("client_form"), first.span())]);
+		let mut clauses = Vec::new();
+		comma_or_end(input)?;
+		while !input.is_empty() {
+			let key = input.call(Ident::parse_any)?;
+			unique(&mut seen, &key, "property")?;
+			input.parse::<Token![:]>()?;
+			let clause = match key.to_string().as_str() {
+				"mutation" => ClientFormViewClause::Mutation(input.parse()?),
+				"id" => {
+					let value: Expr = input.parse()?;
+					if let Expr::Lit(literal) = &value
+						&& let Lit::Str(id) = &literal.lit
+						&& (id.value().is_empty()
+							|| id.value().chars().any(|ch| ch.is_ascii_whitespace()))
+					{
+						return Err(syn::Error::new(
+							id.span(),
+							"`id` must be nonempty and contain no ASCII whitespace",
+						));
+					}
+					ClientFormViewClause::Id(value)
+				}
+				"styling" => ClientFormViewClause::Styling(properties(
+					input,
+					"styling",
+					&[
+						"class",
+						"field_class",
+						"input_class",
+						"label_class",
+						"help_class",
+						"error_class",
+						"summary_class",
+					],
+				)?),
+				"customize" => ClientFormViewClause::Customize(customizations(input)?),
+				"submit" => ClientFormViewClause::Submit(properties(
+					input,
+					"submit",
+					&["label", "pending_label", "class"],
+				)?),
+				"summary" => {
+					ClientFormViewClause::Summary(properties(input, "summary", &["label"])?)
+				}
+				_ => {
+					return Err(syn::Error::new(
+						key.span(),
+						format!("`{key}` is not allowed in a named ClientForm view"),
+					));
+				}
+			};
+			clauses.push(clause);
+			comma_or_end(input)?;
+		}
+		if !seen.contains_key("mutation") {
+			return Err(syn::Error::new(first.span(), "missing `mutation` property"));
+		}
+		Ok(Self { companion, clauses })
+	}
+}
+
+fn comma_or_end(input: ParseStream<'_>) -> syn::Result<()> {
+	if !input.is_empty() {
+		input.parse::<Token![,]>()?;
+	}
+	Ok(())
+}
+
+fn unique(seen: &mut BTreeMap<String, Span>, key: &Ident, kind: &str) -> syn::Result<()> {
+	let name = key.to_string().trim_start_matches("r#").to_owned();
+	if seen.insert(name.clone(), key.span()).is_some() {
+		return Err(syn::Error::new(
+			key.span(),
+			format!("duplicate `{name}` {kind}"),
+		));
+	}
+	Ok(())
+}
+
+fn properties(
+	input: ParseStream<'_>,
+	context: &str,
+	allowed: &[&str],
+) -> syn::Result<Vec<PresentationProperty>> {
+	let content;
+	braced!(content in input);
+	let mut properties = Vec::new();
+	let mut seen = BTreeMap::new();
+	while !content.is_empty() {
+		let name = content.call(Ident::parse_any)?;
+		unique(&mut seen, &name, "property")?;
+		if !allowed.contains(&name.to_string().as_str()) {
+			return Err(syn::Error::new(
+				name.span(),
+				format!("unknown {context} presentation property `{name}`"),
+			));
+		}
+		content.parse::<Token![:]>()?;
+		let value: Expr = content.parse()?;
+		if name == "widget" {
+			let supported = [
+				"TextInput",
+				"Textarea",
+				"EmailInput",
+				"UrlInput",
+				"PasswordInput",
+				"NumberInput",
+				"CheckboxInput",
+				"Select",
+			];
+			let valid = matches!(&value, Expr::Path(path)
+                if path.qself.is_none() && path.path.leading_colon.is_none()
+                && path.path.get_ident().is_some_and(|widget| supported.contains(&widget.to_string().as_str())));
+			if !valid {
+				return Err(syn::Error::new_spanned(
+					value,
+					"expected a supported widget identifier",
+				));
+			}
+		}
+		properties.push(PresentationProperty { name, value });
+		comma_or_end(&content)?;
+	}
+	Ok(properties)
+}
+
+fn customizations(input: ParseStream<'_>) -> syn::Result<Vec<FieldCustomization>> {
+	let content;
+	braced!(content in input);
+	let mut fields = Vec::new();
+	let mut seen = BTreeMap::new();
+	while !content.is_empty() {
+		let field = content.call(Ident::parse_any)?;
+		unique(&mut seen, &field, "field customization")?;
+		content.parse::<Token![:]>()?;
+		let properties = properties(
+			&content,
+			"field",
+			&[
+				"widget",
+				"label",
+				"aria_label",
+				"aria_describedby",
+				"help_text",
+				"placeholder",
+				"autocomplete",
+				"class",
+				"wrapper_class",
+				"label_class",
+				"help_class",
+				"error_class",
+				"empty_label",
+				"true_label",
+				"false_label",
+			],
+		)?;
+		fields.push(FieldCustomization { field, properties });
+		comma_or_end(&content)?;
+	}
+	Ok(fields)
+}

--- a/crates/reinhardt-manouche/tests/client_form_view.rs
+++ b/crates/reinhardt-manouche/tests/client_form_view.rs
@@ -1,0 +1,173 @@
+//! Contract tests for the independent named ClientForm view syntax.
+
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+use reinhardt_manouche::parser::{is_client_form_view, parse_client_form_view};
+
+#[test]
+fn accepts_external_paths_raw_fields_and_ordered_expression_islands() {
+	// Arrange
+	let tokens = quote! {
+		client_form: crate::auth::LoginClientForm,
+		summary: { label: "Errors" },
+		customize: {
+			r#type: { label: String::from("Type"), widget: TextInput },
+			password: { placeholder: { let join = |a, b| format!("{a},{b}"); join("a", "b") } },
+		},
+		mutation: get::<Request, Response>(&login),
+	};
+	// Act
+	let ast = parse_client_form_view(tokens.clone()).unwrap();
+	// Assert
+	assert!(is_client_form_view(&tokens));
+	assert_eq!(ast.field_names(), vec!["type", "password"]);
+	assert_eq!(ast.clauses.len(), 3);
+	assert_eq!(
+		ast.companion.to_token_stream().to_string(),
+		"crate :: auth :: LoginClientForm"
+	);
+	assert_eq!(
+		ast.mutation().to_token_stream().to_string(),
+		quote!(get::<Request, Response>(&login)).to_string()
+	);
+}
+
+#[test]
+fn mode_detection_requires_the_first_property() {
+	assert!(is_client_form_view(
+		&quote!(client_form: Login, mutation: &m)
+	));
+	assert!(!is_client_form_view(&quote!(name: Login, fields: {})));
+	assert!(!is_client_form_view(
+		&quote!(mutation: &m, client_form: Login)
+	));
+	assert!(!is_client_form_view(&quote!(client_form())));
+}
+
+#[test]
+fn rejects_duplicate_entries_at_every_level() {
+	let cases = [
+		(
+			quote!(client_form: Login, mutation: &m, mutation: &m),
+			"duplicate `mutation` property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, client_form: Login),
+			"duplicate `client_form` property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, customize: { name: {}, r#name: {} }),
+			"duplicate `name` field customization",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, customize: { name: { label: "a", label: "b" } }),
+			"duplicate `label` property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, styling: { class: "a", class: "b" }),
+			"duplicate `class` property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, submit: { label: "a", label: "b" }),
+			"duplicate `label` property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, summary: { label: "a", label: "b" }),
+			"duplicate `label` property",
+		),
+	];
+	for (tokens, message) in cases {
+		assert_eq!(
+			parse_client_form_view(tokens).unwrap_err().to_string(),
+			message
+		);
+	}
+}
+
+#[test]
+fn rejects_standalone_configuration_and_unknown_properties() {
+	for key in [
+		"fields",
+		"action",
+		"method",
+		"server_fn",
+		"state",
+		"validation",
+		"on_submit",
+		"on_success",
+		"on_error",
+		"name",
+	] {
+		let tokens: TokenStream = format!("client_form: Login, mutation: &m, {key}: {{}}")
+			.parse()
+			.unwrap();
+		assert_eq!(
+			parse_client_form_view(tokens).unwrap_err().to_string(),
+			format!("`{key}` is not allowed in a named ClientForm view")
+		);
+	}
+	for key in [
+		"min",
+		"max",
+		"minlength",
+		"maxlength",
+		"pattern",
+		"required",
+		"unknown",
+	] {
+		let tokens: TokenStream =
+			format!("client_form: Login, mutation: &m, customize: {{ name: {{ {key}: 1 }} }}")
+				.parse()
+				.unwrap();
+		assert_eq!(
+			parse_client_form_view(tokens).unwrap_err().to_string(),
+			format!("unknown field presentation property `{key}`")
+		);
+	}
+}
+
+#[test]
+fn validates_widget_tokens_ids_and_required_entries() {
+	let cases = [
+		(quote!(client_form: Login), "missing `mutation` property"),
+		(
+			quote!(mutation: &m, client_form: Login),
+			"`client_form` must be the first property",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, id: ""),
+			"`id` must be nonempty and contain no ASCII whitespace",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, id: "has space"),
+			"`id` must be nonempty and contain no ASCII whitespace",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, customize: { name: { widget: widgets::TextInput } }),
+			"expected a supported widget identifier",
+		),
+		(
+			quote!(client_form: Login, mutation: &m, customize: { name: { widget: CustomInput } }),
+			"expected a supported widget identifier",
+		),
+	];
+	for (tokens, message) in cases {
+		assert_eq!(
+			parse_client_form_view(tokens).unwrap_err().to_string(),
+			message
+		);
+	}
+	assert!(
+		parse_client_form_view(quote!(client_form: Login, mutation: &m, id: make_id())).is_ok()
+	);
+	assert!(
+		parse_client_form_view(quote!(client_form: Login, mutation: &m, id: "valid:表" )).is_ok()
+	);
+	assert!(parse_client_form_view(quote!(client_form: Login, mutation: &m trailing)).is_err());
+	assert!(
+		parse_client_form_view(
+			quote!(client_form: Login, mutation: &m, submit: { label: "Submit" trailing })
+		)
+		.is_err()
+	);
+}

--- a/crates/reinhardt-pages/Cargo.toml
+++ b/crates/reinhardt-pages/Cargo.toml
@@ -285,7 +285,8 @@ web-sys = { version = "0.3.83", features = [
 ] }
 
 # Async support for WASM
-reinhardt-core = {workspace = true, default-features = false, features = ["reactive", "page", "parsers", "security", "validators"]}
+# Shared named DTOs retain the same validation derive on native and browser targets.
+reinhardt-core = {workspace = true, default-features = false, features = ["reactive", "page", "parsers", "security", "validators", "macros"]}
 smallvec = { workspace = true }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = "0.4.56"
@@ -391,6 +392,11 @@ required-features = ["testing"]
 [[test]]
 name = "server_mutation_wasm_test"
 path = "tests/wasm/server_mutation_wasm_test.rs"
+required-features = ["testing"]
+
+[[test]]
+name = "client_form_view_wasm_test"
+path = "tests/wasm/client_form_view_wasm_test.rs"
 required-features = ["testing"]
 
 [[test]]

--- a/crates/reinhardt-pages/README.md
+++ b/crates/reinhardt-pages/README.md
@@ -501,7 +501,12 @@ the catalog.
 
 ### Forms: Static Definition and Dynamic Behavior
 
-`form!` defines static form structure: field names, widgets, labels,
+`form!` can render a named ClientForm's existing mutation with
+`client_form: LoginRequestClientForm, mutation: &mutation`. The DTO owns the
+field set and validation, and the view shares the mutation's runtime. See the
+[named ClientForm guide](docs/client_forms.md) for complete examples.
+
+The standalone `form!` mode defines static form structure: field names, widgets, labels,
 validation metadata, server function binding, and rendering. `use_form` owns
 typed runtime behavior: values, field signals, dirty/touched state, validation
 errors, loading, success, reset, and submit orchestration.
@@ -606,6 +611,11 @@ The supported value/control matrix is:
 | `bool` | checkbox |
 | `Vec<String>` | select-many |
 
+Named `ClientForm` fields additionally support optional primitive numbers with
+number inputs, optional booleans with three-state selects, and required/optional
+`ClientFormChoiceSource` enums with select-one controls. Selects use opaque DOM
+tokens while the runtime and submitted DTO retain their typed values.
+
 `RangeInput` and `input[type=range]` are not currently compatible with a typed
 runtime field binding; use an unbound or application-specific path for range
 controls.
@@ -616,7 +626,7 @@ touched/dirty/submitting/success state, and returns `use_form_action` handles
 to idle. It is not automatic after a successful submit and is not connected to
 a native `<button type="reset">` or reset event. Use
 `runtime.sync_after_native_reset()` for application-owned controls after the
-browser resets them. Generated `form!` controls synchronize browser defaults
+browser resets them. Generated `form!` and `ClientForm` controls synchronize browser defaults
 automatically without invoking `runtime.reset()`. Pending network work continues;
 stale form-action completions cannot repopulate form-owned submit state, while
 standalone `use_action` handles are outside this reset boundary. Reset skips

--- a/crates/reinhardt-pages/docs/client_forms.md
+++ b/crates/reinhardt-pages/docs/client_forms.md
@@ -1,0 +1,180 @@
+# Named ClientForm views
+
+Use `form!` to render a named DTO's existing `FormServerMutation`. The DTO defines
+the editable fields, declaration order, serialized names, and validation. The
+view supplies presentation settings and shares the mutation's runtime.
+
+```rust
+use reinhardt_pages::{client_form, form, use_form};
+use reinhardt_pages::reactive::ReactiveScope;
+use reinhardt_pages::server_fn::{server_fn, ServerFnError};
+use reinhardt_core::validators::Validate;
+use serde::{Deserialize, Serialize};
+
+#[client_form(server_fn = login, validate)]
+#[derive(Clone, Serialize, Deserialize, Validate)]
+pub struct LoginRequest {
+    #[validate(length(min = 1, max = 150))]
+    pub username: String,
+    #[validate(length(min = 1, max = 128))]
+    pub password: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AuthResponse {
+    pub token: String,
+}
+
+#[server_fn]
+pub async fn login(request: crate::LoginRequest) -> Result<AuthResponse, ServerFnError> {
+    let token = request.username;
+    Ok(AuthResponse { token })
+}
+
+fn main() {
+    ReactiveScope::run(|| {
+        let definition = LoginRequestClientForm::new();
+        let runtime = use_form(&definition).build();
+        let mutation = definition.server_mutation(&runtime).build();
+
+        let page = form! {
+            client_form: LoginRequestClientForm,
+            mutation: &mutation,
+            id: "login",
+            styling: { class: "auth-form" },
+            customize: {
+                username: { label: "Username", autocomplete: "username" },
+                password: {
+                    widget: PasswordInput,
+                    label: "Password",
+                    autocomplete: "current-password",
+                    help_text: "Enter your account password.",
+                },
+            },
+            submit: { label: "Sign in", pending_label: "Signing in..." },
+            summary: { label: "Please correct the following errors" },
+        }.into_page();
+
+        assert_eq!(runtime.get_values().username, "");
+        assert_eq!(page.render_to_string().matches("name=\"username\"").count(), 1);
+    });
+}
+```
+
+The server function above is a transport example; implement authentication in
+the existing application endpoint. Configure success/error callbacks, query
+invalidation, redirects, and optional reset on the runtime or mutation before
+constructing the view. A submit event prevents native navigation and calls that
+mutation's `dispatch()` once. Native rendering never executes a request.
+
+## Syntax
+
+`client_form` must be first and `mutation` is required. Remaining entries may
+appear in any order. Every presentation expression is evaluated once in source
+order. The descriptor has an inherent `into_page()` method and implements
+`IntoPage`.
+
+| Entry | Meaning |
+| --- | --- |
+| `client_form` | Path to a generated companion, including one from another crate. |
+| `mutation` | Reference to a mutation whose form and input match that companion and DTO. |
+| `id` | Optional nonempty ID with no ASCII whitespace. |
+| `styling` | Form and shared field classes. |
+| `customize` | Partial map keyed by exposed Rust field identifiers. |
+| `submit` | `label`, `pending_label`, and `class`. |
+| `summary` | Validation summary `label`. |
+
+All exposed fields appear in DTO declaration order. Serde names are used for
+control `name` attributes and server error resolution. Raw identifiers are
+accepted in customization; default labels omit the `r#` prefix. Skipped fields
+keep their existing request/default behavior and cannot be customized.
+
+Unknown fields, duplicate properties, incompatible mutations/widgets, and
+unsupported presentation properties fail compilation. This mode rejects
+`fields`, `action`, `method`, server function declarations, validation rules,
+state declarations, and lifecycle callback declarations.
+
+## Fields and widgets
+
+| DTO field | Default | Other supported widgets |
+| --- | --- | --- |
+| `String`, `Option<String>` | `TextInput` | `Textarea`, `EmailInput`, `UrlInput`, `PasswordInput` |
+| Primitive number, optional primitive number | `NumberInput` | None |
+| `bool` | `CheckboxInput` | None |
+| `Option<bool>` | `Select` | None |
+| Enum or optional enum implementing `ClientFormChoiceSource` | `Select` | None |
+
+Optional boolean choices distinguish unset, false, and true. Optional enum
+choices distinguish unset from every enum value, including a variant serialized
+as an empty string. DOM tokens are `none` and `choice:N`; the transmitted DTO
+retains its ordinary serde representation. Invalid DOM choice tokens are ignored.
+
+Optional numeric empty input writes `None`. Invalid numeric edits retain the
+last typed value and expose the existing parse error through form validation.
+All numeric controls use `step="any"`, leaving integer/range rules to the typed
+runtime. Optional strings retain ClientForm's existing trim-and-empty-to-None
+request conversion.
+
+Field overrides include `widget`, `label`, `aria_label`, `aria_describedby`,
+`help_text`, `autocomplete`, `class`, `wrapper_class`, `label_class`,
+`help_class`, and `error_class`. `placeholder` is available for text and numeric
+fields. `empty_label` is available only for optional choices; `true_label` and
+`false_label` are available only for optional booleans.
+
+Nested fields, collections, uploads, radio layouts, custom widgets, and
+ModelForm rendering are outside this mode.
+
+## Styling and validation
+
+| Setting | Default |
+| --- | --- |
+| `styling.class` | `reinhardt-form` |
+| `styling.field_class` | `reinhardt-field` |
+| `styling.input_class` | `reinhardt-input` |
+| `styling.label_class` | `reinhardt-label` |
+| `styling.help_class` | `reinhardt-help` |
+| `styling.error_class` | `reinhardt-error` |
+| `styling.summary_class` | `reinhardt-validation-summary` |
+| `submit.class` | `reinhardt-submit` |
+
+A field override replaces its corresponding shared class, including an explicit
+empty string. Submit labels default to `Submit` / `Submitting...`; the summary
+label defaults to `Please correct the following errors`. Boolean labels default
+to `False` / `True`, and the unset choice label is empty.
+
+DTO validation remains opt-in through `#[client_form(validate)]`. A positive
+literal string length minimum on a nonoptional `String` produces `required`
+and `aria-required`. Other types and manual validators do not imply a required
+checkbox or other constraint.
+
+Forms use `novalidate` and do not project or accept `min`, `max`, `minlength`,
+`maxlength`, or `pattern` overrides. DTO string validation counts Unicode scalar
+values, while HTML length limits count UTF-16 code units. Runtime validation
+therefore remains authoritative, including for supplementary-plane characters.
+
+## Accessibility, hydration, and reset
+
+Labels, controls, help/error containers, the summary region, and the submit
+button retain their nodes while values, validation, or pending state change.
+Only the button is disabled while submitting. Controls keep focus and selection.
+
+The summary contains field errors in declaration order followed by nonempty
+form/submit errors. Only equal global messages are deduplicated. Unmatched
+server field names remain the runtime's existing form-level message. Summary
+links focus their retained controls; ordinary updates never move focus.
+
+Generated help/error IDs are combined with external `aria_describedby` IDs
+without duplicates. One summary live region announces errors. Explicit
+`aria_label` overrides the accessible name while retaining the visible label.
+
+Without an explicit ID, the view calls `use_id_with_prefix("client-form")` once.
+SSR and hydration must use the same ID scope and construction order. Explicit
+IDs are useful for independently rendered roots. IDs for fields, help, and
+errors use declaration ordinals, so serde aliases do not create collisions.
+
+Hydration reuses the existing typed bindings, preserves browser edits made
+before hydration, and omits password values from SSR. Explicit runtime field
+writes and resets take precedence over stale browser state. Native form reset
+uses the shared generated-control reset coordinator and performs runtime
+bookkeeping once per batch. Disposed scopes do not receive late reset or
+submission callbacks.

--- a/crates/reinhardt-pages/macros/src/client_form.rs
+++ b/crates/reinhardt-pages/macros/src/client_form.rs
@@ -11,6 +11,9 @@ use syn::{
 
 use crate::crate_paths::get_reinhardt_pages_crate;
 
+mod binding;
+mod view;
+
 const CLIENT_FORM_ATTRIBUTE_MARKER: &str = "__reinhardt_client_form_attribute";
 
 /// Derives a `use_form` compatible companion form for a DTO request type.
@@ -157,6 +160,7 @@ fn expand_client_form(input: DeriveInput) -> syn::Result<proc_macro2::TokenStrea
 			field.ty,
 			kind,
 			serialized_name,
+			view::positive_length_min(&field.attrs),
 		));
 	}
 
@@ -232,6 +236,7 @@ struct FormItemContext<'a> {
 }
 
 fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream {
+	let view_items = view::generate(&context);
 	let FormItemContext {
 		dto_vis,
 		dto_ident,
@@ -250,7 +255,7 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 	let numeric_field_tokens = field_token_fields
 		.iter()
 		.copied()
-		.filter(|field| matches!(&field.kind, FieldKind::Scalar))
+		.filter(|field| matches!(&field.kind, FieldKind::Scalar | FieldKind::OptionScalar))
 		.collect::<Vec<_>>();
 
 	let value_field_defs = fields.iter().map(|field| {
@@ -352,15 +357,17 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 		let name = &field.name;
 		let variant = &field.variant;
 		let value_ty = field.value_ty();
-		let clear_number_error = matches!(&field.kind, FieldKind::Scalar).then(|| {
-			let error = field.number_error_ident();
-			quote! { self.#error.set(::core::option::Option::None); }
-		});
+		let clear_number_error = matches!(&field.kind, FieldKind::Scalar | FieldKind::OptionScalar)
+			.then(|| {
+				let error = field.number_error_ident();
+				quote! { self.#error.set(::core::option::Option::None); }
+			});
 		quote! {
 			#field_ident::#variant => {
 				let value = ::std::boxed::Box::new(value) as ::std::boxed::Box<dyn ::core::any::Any>;
 				match value.downcast::<#value_ty>() {
 					::core::result::Result::Ok(value) => #pages_crate::reactive::batch(|| {
+						self.__source_preferred_fields.borrow_mut().insert(field);
 						self.#name.set(*value);
 						#clear_number_error
 					}),
@@ -430,7 +437,7 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 					::core::option::Option::Some(#pages_crate::component::ControlBinding::checkbox(self.#name))
 				},
 			}),
-			_ => None,
+			_ => binding::additional_arm(field, field_ident, pages_crate),
 		}
 	});
 	let custom_widget_error_arms = numeric_field_tokens.iter().map(|field| {
@@ -511,10 +518,13 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 	};
 
 	quote! {
+		#view_items
 		#[derive(Clone)]
 		#dto_vis struct #form_ident {
 			__initial_values: ::std::rc::Rc<::std::cell::RefCell<#values_ident>>,
 			__explicitly_reset: ::std::rc::Rc<::std::cell::Cell<bool>>,
+			__source_preferred_fields: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashSet<#field_ident>>>,
+			__native_reset_epoch: #pages_crate::reactive::Signal<u64>,
 			#(#form_field_defs,)*
 			#(#number_error_field_defs,)*
 		}
@@ -545,6 +555,8 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 				Self {
 					__initial_values: ::std::rc::Rc::new(::std::cell::RefCell::new(__initial_values.clone())),
 					__explicitly_reset: ::std::rc::Rc::new(::std::cell::Cell::new(false)),
+					__source_preferred_fields: ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::HashSet::new())),
+					__native_reset_epoch: #pages_crate::reactive::Signal::new(0),
 					#(#signal_initializers,)*
 					#(#number_error_initializers,)*
 				}
@@ -557,6 +569,7 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 				};
 				<#form_ident as #pages_crate::FormRuntimeSource>::runtime_apply_values(&self, &values);
 				*self.__initial_values.borrow_mut() = values;
+				self.__source_preferred_fields.borrow_mut().clear();
 				self
 			}
 
@@ -599,15 +612,24 @@ fn generate_form_items(context: FormItemContext<'_>) -> proc_macro2::TokenStream
 					_ => ::core::option::Option::None,
 				};
 				binding.map(|binding| {
+					let target = binding.target();
 					binding.prefer_source_on_hydration({
 						let explicitly_reset = self.__explicitly_reset.clone();
-						move || explicitly_reset.get()
+						let preferred_fields = self.__source_preferred_fields.clone();
+						move || explicitly_reset.get() || preferred_fields.borrow().contains(&field)
+					}).with_lifetime_target(target).on_native_reset({
+						let epoch = self.__native_reset_epoch;
+						move || epoch.set(epoch.get_untracked().wrapping_add(1))
 					})
 				})
 			}
 
 			fn runtime_reset_state(&self) {
 				self.__explicitly_reset.set(true);
+			}
+
+			fn runtime_native_reset_epoch(&self) -> u64 {
+				self.__native_reset_epoch.get()
 			}
 
 			fn runtime_field_by_name(&self, name: &str) -> ::core::option::Option<Self::Field> {
@@ -1056,6 +1078,7 @@ struct EditableField {
 	vis: Visibility,
 	ty: Type,
 	kind: FieldKind,
+	positive_length_min: bool,
 }
 
 impl EditableField {
@@ -1065,6 +1088,7 @@ impl EditableField {
 		ty: Type,
 		kind: FieldKind,
 		serialized_name: String,
+		positive_length_min: bool,
 	) -> Self {
 		let variant = format_ident!(
 			"{}",
@@ -1077,6 +1101,7 @@ impl EditableField {
 			vis,
 			ty,
 			kind,
+			positive_length_min,
 		}
 	}
 

--- a/crates/reinhardt-pages/macros/src/client_form/binding.rs
+++ b/crates/reinhardt-pages/macros/src/client_form/binding.rs
@@ -1,0 +1,45 @@
+//! Generates typed bindings absent from the primitive ControlBinding constructors.
+
+use super::{EditableField, FieldKind};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+pub(super) fn additional_arm(
+	field: &EditableField,
+	field_ident: &Ident,
+	pages: &TokenStream,
+) -> Option<TokenStream> {
+	let name = &field.name;
+	let variant = &field.variant;
+	let support = quote!(#pages::__private::client_form);
+	let (kind, binding) = match field.kind {
+		FieldKind::OptionScalar => {
+			let error = field.number_error_ident();
+			(
+				quote!(Number),
+				quote!(#support::optional_number_binding(self.#name, self.#error)),
+			)
+		}
+		FieldKind::OptionBool => (
+			quote!(SelectOne),
+			quote!(#support::optional_choice_binding(self.#name, &#support::BOOLEAN_CHOICES)),
+		),
+		FieldKind::Enum | FieldKind::OptionEnum => {
+			let ty = field.choice_ty()?;
+			let choices = quote!(<#ty as #pages::ClientFormChoiceSource>::client_form_choices());
+			let function = if matches!(field.kind, FieldKind::Enum) {
+				quote!(#support::choice_binding)
+			} else {
+				quote!(#support::optional_choice_binding)
+			};
+			(quote!(SelectOne), quote!(#function(self.#name, #choices)))
+		}
+		_ => return None,
+	};
+	Some(quote! {
+		(#field_ident::#variant, #pages::component::ControlKind::#kind) => {
+			::core::option::Option::Some(#binding)
+		},
+	})
+}

--- a/crates/reinhardt-pages/macros/src/client_form/view.rs
+++ b/crates/reinhardt-pages/macros/src/client_form/view.rs
@@ -1,0 +1,143 @@
+//! Generates DTO-specific metadata and typed presentation adapters.
+
+use super::{FieldKind, FormItemContext, ident_name_without_raw_prefix};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, quote_spanned};
+use syn::{Attribute, Expr, Lit, Meta, Token, punctuated::Punctuated};
+
+/// Inspect only the literal length minimum used for a safe required hint.
+pub(super) fn positive_length_min(attrs: &[Attribute]) -> bool {
+	attrs.iter().filter(|attr| attr.path().is_ident("validate")).any(|attr| {
+        let Ok(rules) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) else { return false };
+        rules.iter().any(|rule| {
+            let Meta::List(length) = rule else { return false };
+            if !length.path.is_ident("length") { return false; }
+            let Ok(bounds) = length.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) else { return false };
+            bounds.iter().any(|bound| {
+                matches!(bound, Meta::NameValue(min)
+                    if min.path.is_ident("min") && matches!(&min.value, Expr::Lit(value)
+                        if matches!(&value.lit, Lit::Int(value) if value.base10_parse::<usize>().is_ok_and(|value| value > 0))))
+            })
+        })
+    })
+}
+
+pub(super) fn generate(context: &FormItemContext<'_>) -> TokenStream {
+	let pages = context.pages_crate;
+	let dto = context.dto_ident;
+	let form = context.form_ident;
+	let vis = context.dto_vis;
+	let field_token = context.field_ident;
+	let wrapper = format_ident!("__{}View", form);
+	let support = quote!(#pages::__private::client_form);
+	let fields: Vec<_> = context
+		.fields
+		.iter()
+		.filter(|field| field.exposes_field_token(vis))
+		.collect();
+	let descriptors = fields.iter().enumerate().map(|(ordinal, field)| {
+        let variant = &field.variant;
+        let rust_name = ident_name_without_raw_prefix(&field.name);
+        let wire_name = &field.serialized_name;
+        let required = context.validate && matches!(field.kind, FieldKind::String) && field.positive_length_min;
+        let (widget, control) = match field.kind {
+            FieldKind::String | FieldKind::OptionString => (quote!(TextInput), quote!(Text)),
+            FieldKind::Scalar | FieldKind::OptionScalar => (quote!(NumberInput), quote!(Number)),
+            FieldKind::Bool => (quote!(CheckboxInput), quote!(Checkbox)),
+            _ => (quote!(Select), quote!(SelectOne)),
+        };
+        let optional_choice = matches!(field.kind, FieldKind::OptionBool | FieldKind::OptionEnum);
+        let boolean_choice = matches!(field.kind, FieldKind::OptionBool);
+        let choices = if let Some(ty) = field.choice_ty() {
+            quote! {
+                <#ty as #pages::ClientFormChoiceSource>::client_form_choices()
+                    .iter().enumerate().map(|(index, choice)| (
+                        ::std::format!("choice:{index}"), ::std::string::String::from(choice.label)
+                    )).collect()
+            }
+        } else if boolean_choice {
+            quote! {
+                #support::BOOLEAN_CHOICES.iter().enumerate().map(|(index, choice)| (
+                    ::std::format!("choice:{index}"), ::std::string::String::from(choice.label)
+                )).collect()
+            }
+        } else { quote!(::std::vec::Vec::new()) };
+        quote! {
+            #support::ViewField {
+                key: #field_token::#variant, ordinal: #ordinal, rust_name: #rust_name,
+                serialized_name: #wire_name, required: #required,
+                presentation: #support::FieldDisplay::new(
+                    #rust_name, #support::WidgetKind::#widget, #choices, #optional_choice, #boolean_choice,
+                ),
+                binding: #support::view_binding(runtime, #field_token::#variant, #pages::component::ControlKind::#control),
+            }
+        }
+    });
+	let customization_methods = fields.iter().enumerate().map(|(ordinal, field)| {
+        let method_vis = if matches!(field.vis, syn::Visibility::Inherited) { vis } else { &field.vis };
+        let method = format_ident!("__reinhardt_field_{}", ident_name_without_raw_prefix(&field.name));
+        let kind = match field.kind {
+            FieldKind::String | FieldKind::OptionString => quote!(#support::TextKind),
+            FieldKind::Scalar | FieldKind::OptionScalar => quote!(#support::NumberKind),
+            FieldKind::Bool => quote!(#support::BoolKind),
+            FieldKind::OptionBool => quote!(#support::OptionalBoolKind),
+            FieldKind::Enum => {
+                let ty = field.choice_ty();
+                quote!(#support::EnumKind<#ty>)
+            }
+            FieldKind::OptionEnum => {
+                let ty = field.choice_ty();
+                quote!(#support::OptionalEnumKind<#ty>)
+            }
+        };
+        quote_spanned! {field.name.span()=>
+            #[doc(hidden)]
+            #method_vis fn #method(mut self, configure: impl ::core::ops::FnOnce(#support::FieldPresentation<#kind>)
+                -> #support::FieldPresentation<#kind>) -> Self {
+                self.inner = self.inner.customize(#ordinal, configure);
+                self
+            }
+        }
+    });
+	quote! {
+		#[doc(hidden)]
+		#vis struct #wrapper<Deps, Output>
+		where Deps: ::core::clone::Clone + ::core::cmp::PartialEq + 'static,
+			Output: ::core::clone::Clone + 'static {
+			inner: #support::ClientFormView<#form, Deps, #dto, Output>,
+		}
+		impl<Deps, Output> #wrapper<Deps, Output>
+		where Deps: ::core::clone::Clone + ::core::cmp::PartialEq + 'static,
+			Output: ::core::clone::Clone + 'static {
+			#(#customization_methods)*
+			/// Converts the named form view into a retained Page.
+			pub fn into_page(self) -> #pages::component::Page { self.inner.into_page() }
+		}
+		impl<Deps, Output> #pages::component::IntoPage for #wrapper<Deps, Output>
+		where Deps: ::core::clone::Clone + ::core::cmp::PartialEq + 'static,
+			Output: ::core::clone::Clone + 'static {
+			fn into_page(self) -> #pages::component::Page { self.into_page() }
+		}
+		impl #form {
+			#[doc(hidden)]
+			pub fn __reinhardt_view_fields<Deps>(runtime: &#pages::UseFormReturn<Self, Deps>)
+				-> ::std::vec::Vec<#support::ViewField<#field_token>>
+			where Deps: ::core::clone::Clone + ::core::cmp::PartialEq + 'static {
+				::std::vec![#(#descriptors),*]
+			}
+
+			#[doc(hidden)]
+			pub fn __reinhardt_view<Deps, Output>(
+				mutation: &#pages::FormServerMutation<Self, Deps, #dto, Output>,
+				options: #support::ViewOptions,
+			) -> #wrapper<Deps, Output>
+			where Deps: ::core::clone::Clone + ::core::cmp::PartialEq + 'static,
+				Output: ::core::clone::Clone + 'static {
+				let id = options.resolve_id();
+				let runtime = mutation.form();
+				let fields = Self::__reinhardt_view_fields(&runtime);
+				#wrapper { inner: #support::ClientFormView::new(mutation.clone(), runtime, fields, options, id) }
+			}
+		}
+	}
+}

--- a/crates/reinhardt-pages/macros/src/crate_paths.rs
+++ b/crates/reinhardt-pages/macros/src/crate_paths.rs
@@ -32,73 +32,38 @@ pub(crate) struct CratePathInfo {
 /// 4. Only `reinhardt`: Use `::reinhardt::pages`
 /// 5. Fallback: Use `::reinhardt_pages`
 pub(crate) fn get_reinhardt_pages_crate_info() -> CratePathInfo {
-	use proc_macro_crate::{FoundCrate, crate_name};
-
-	// Check for internal crate usage first.
-	// Use absolute path `::reinhardt_pages` instead of `crate` for doc test compatibility.
-	// In doc tests, `crate` refers to the test binary, not `reinhardt_pages`.
-	// The target crate must have `extern crate self as reinhardt_pages;` for this to work.
-	if let Ok(FoundCrate::Itself) = crate_name("reinhardt-pages") {
-		return CratePathInfo {
-			needs_conditional: false,
-			use_statement: quote!(),
-			ident: quote!(::reinhardt_pages),
-		};
-	}
-
-	// Check what crates are available as dependencies
-	let has_reinhardt_pages = matches!(crate_name("reinhardt-pages"), Ok(FoundCrate::Name(_)));
-	let has_reinhardt = matches!(crate_name("reinhardt"), Ok(FoundCrate::Name(_)));
-	let has_reinhardt_web = matches!(crate_name("reinhardt-web"), Ok(FoundCrate::Name(_)));
-
-	// If both reinhardt-pages and reinhardt are available, use conditional compilation
-	// This handles the case where the project has both as dependencies for dual-target builds
-	if has_reinhardt_pages && (has_reinhardt || has_reinhardt_web) {
-		return CratePathInfo {
+	let direct = named_dependency("reinhardt-pages", "reinhardt_pages");
+	let facade = named_dependency("reinhardt", "reinhardt")
+		.or_else(|| named_dependency("reinhardt-web", "reinhardt"));
+	match (direct, facade) {
+		(Some(direct), Some(facade)) => CratePathInfo {
 			needs_conditional: true,
 			use_statement: quote! {
 				#[cfg(all(target_family = "wasm", target_os = "unknown"))]
-				use ::reinhardt_pages as __reinhardt_pages;
+				use #direct as __reinhardt_pages;
 				#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
-				use ::reinhardt::pages as __reinhardt_pages;
+				use #facade::pages as __reinhardt_pages;
 			},
 			ident: quote!(__reinhardt_pages),
-		};
-	}
-
-	// Only reinhardt-pages is available
-	if has_reinhardt_pages {
-		return CratePathInfo {
+		},
+		(direct, facade) => CratePathInfo {
 			needs_conditional: false,
 			use_statement: quote!(),
-			ident: quote!(::reinhardt_pages),
-		};
+			ident: direct
+				.or_else(|| facade.map(|facade| quote!(#facade::pages)))
+				.unwrap_or_else(|| quote!(::reinhardt_pages)),
+		},
 	}
+}
 
-	// Only reinhardt is available (via facade crate)
-	if has_reinhardt {
-		return CratePathInfo {
-			needs_conditional: false,
-			use_statement: quote!(),
-			ident: quote!(::reinhardt::pages),
-		};
-	}
-
-	// Only reinhardt-web is available (published package name)
-	if has_reinhardt_web {
-		return CratePathInfo {
-			needs_conditional: false,
-			use_statement: quote!(),
-			ident: quote!(::reinhardt::pages),
-		};
-	}
-
-	// Fallback - assume reinhardt_pages is available
-	CratePathInfo {
-		needs_conditional: false,
-		use_statement: quote!(),
-		ident: quote!(::reinhardt_pages),
-	}
+fn named_dependency(package: &str, internal_name: &str) -> Option<TokenStream> {
+	use proc_macro_crate::{FoundCrate, crate_name};
+	let name = match crate_name(package).ok()? {
+		FoundCrate::Itself => internal_name.to_owned(),
+		FoundCrate::Name(name) => name,
+	};
+	let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+	Some(quote!(::#ident))
 }
 
 /// Legacy function for backwards compatibility.
@@ -108,7 +73,10 @@ pub(crate) fn get_reinhardt_pages_crate() -> TokenStream {
 	if info.needs_conditional {
 		// For legacy callers that can't handle conditional compilation,
 		// prefer the server path (most common case for non-page! macro usage)
-		quote!(::reinhardt::pages)
+		let facade = named_dependency("reinhardt", "reinhardt")
+			.or_else(|| named_dependency("reinhardt-web", "reinhardt"))
+			.expect("conditional Pages resolution has a facade dependency");
+		quote!(#facade::pages)
 	} else {
 		info.ident
 	}
@@ -160,40 +128,10 @@ pub(crate) fn get_reinhardt_di_crate() -> TokenStream {
 /// Uses the same strategy order as [`get_reinhardt_pages_crate`] to avoid
 /// conditional dependency resolution issues.
 pub(crate) fn get_reinhardt_http_crate() -> TokenStream {
-	use proc_macro_crate::{FoundCrate, crate_name};
-
-	// Try via reinhardt crate first (prioritized to avoid conditional dependency issues)
-	match crate_name("reinhardt") {
-		Ok(FoundCrate::Itself) => return quote!(::reinhardt::reinhardt_http),
-		Ok(FoundCrate::Name(name)) => {
-			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-			return quote!(::#ident::reinhardt_http);
-		}
-		Err(_) => {}
-	}
-
-	// Try via reinhardt-web (published package name)
-	match crate_name("reinhardt-web") {
-		Ok(FoundCrate::Itself) => return quote!(::reinhardt::reinhardt_http),
-		Ok(FoundCrate::Name(name)) => {
-			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-			return quote!(::#ident::reinhardt_http);
-		}
-		Err(_) => {}
-	}
-
-	// Try direct crate (for internal usage within reinhardt-http crate)
-	match crate_name("reinhardt-http") {
-		Ok(FoundCrate::Itself) => return quote!(::reinhardt_http),
-		Ok(FoundCrate::Name(name)) => {
-			let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
-			return quote!(::#ident);
-		}
-		Err(_) => {}
-	}
-
-	// Final fallback - use reinhardt facade crate (re-exported module)
-	quote!(::reinhardt::reinhardt_http)
+	// Native server-function handlers use the HTTP types already owned by Pages.
+	// This also works when the consumer enables only the facade's pages feature.
+	let pages = get_reinhardt_pages_crate();
+	quote!(#pages::__private::reinhardt_http)
 }
 
 /// Resolves the path to the reinhardt_core crate dynamically.

--- a/crates/reinhardt-pages/macros/src/form.rs
+++ b/crates/reinhardt-pages/macros/src/form.rs
@@ -50,6 +50,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 
+mod client_form_view;
 mod codegen;
 mod validator;
 
@@ -61,6 +62,12 @@ mod validator;
 /// 3. Generate: TypedFormMacro → TokenStream (Rust code)
 pub(crate) fn form_impl(input: TokenStream) -> TokenStream {
 	let input2 = TokenStream2::from(input);
+	if reinhardt_manouche::parser::is_client_form_view(&input2) {
+		return match reinhardt_manouche::parser::parse_client_form_view(input2) {
+			Ok(ast) => client_form_view::generate(ast).into(),
+			Err(error) => error.to_compile_error().into(),
+		};
+	}
 	let ambient_arguments_source =
 		reinhardt_manouche::parser::detect_ambient_arguments_source(&input2);
 

--- a/crates/reinhardt-pages/macros/src/form/client_form_view.rs
+++ b/crates/reinhardt-pages/macros/src/form/client_form_view.rs
@@ -1,0 +1,100 @@
+//! Expands named-view syntax through the companion's typed presentation adapter.
+
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+use reinhardt_manouche::core::{ClientFormViewClause, ClientFormViewMacro, PresentationProperty};
+
+pub(super) fn generate(ast: ClientFormViewMacro) -> TokenStream {
+	let pages = crate::crate_paths::get_reinhardt_pages_crate();
+	let support = quote!(#pages::__private::client_form);
+	let companion = ast.companion;
+	let options = format_ident!("__reinhardt_view_options", span = Span::mixed_site());
+	let view = format_ident!("__reinhardt_view", span = Span::mixed_site());
+	let field = format_ident!("__reinhardt_field", span = Span::mixed_site());
+	let mut evaluations = Vec::new();
+	let mut settings = Vec::new();
+	let mut customizations = Vec::new();
+	let mut mutation = TokenStream::new();
+
+	for clause in ast.clauses {
+		let context = match &clause {
+			ClientFormViewClause::Submit(_) => "submit",
+			ClientFormViewClause::Summary(_) => "summary",
+			_ => "styling",
+		};
+		match clause {
+			ClientFormViewClause::Mutation(expression) => {
+				let temporary =
+					format_ident!("__reinhardt_view_mutation", span = Span::mixed_site());
+				evaluations.push(quote!(let #temporary = #expression;));
+				mutation = quote!(#temporary);
+			}
+			ClientFormViewClause::Id(expression) => {
+				let temporary = evaluate_string(&expression, &mut evaluations);
+				settings.push(quote!(let #options = #options.id(#temporary);));
+			}
+			ClientFormViewClause::Styling(properties)
+			| ClientFormViewClause::Submit(properties)
+			| ClientFormViewClause::Summary(properties) => {
+				for property in properties {
+					let property_name = property.name.to_string();
+					let mapped = match (context, property_name.as_str()) {
+						("submit", "label") => "submit_label",
+						("submit", "class") => "submit_class",
+						("summary", "label") => "summary_label",
+						_ => property_name.as_str(),
+					};
+					let name = syn::Ident::new(mapped, property.name.span());
+					let temporary = evaluate_string(&property.value, &mut evaluations);
+					settings.push(
+						quote_spanned!(name.span()=> let #options = #options.#name(#temporary);),
+					);
+				}
+			}
+			ClientFormViewClause::Customize(fields) => {
+				for customization in fields {
+					let name = customization.field.to_string();
+					let method = format_ident!(
+						"__reinhardt_field_{}",
+						name.trim_start_matches("r#"),
+						span = customization.field.span()
+					);
+					let setters = customization
+						.properties
+						.into_iter()
+						.map(|PresentationProperty { name, value }| {
+							if name == "widget" {
+								quote_spanned!(name.span()=> .widget(#support::#value))
+							} else {
+								let temporary = evaluate_string(&value, &mut evaluations);
+								quote_spanned!(name.span()=> .#name(#temporary))
+							}
+						})
+						.collect::<Vec<_>>();
+					customizations
+						.push(quote!(let #view = #view.#method(|#field| #field #(#setters)*);));
+				}
+			}
+		}
+	}
+	quote! {{
+		#(#evaluations)*
+		let #options = #support::ViewOptions::default();
+		#(#settings)*
+		let #view = #companion::__reinhardt_view(#mutation, #options);
+		#(#customizations)*
+		#view
+	}}
+}
+
+fn evaluate_string(expression: &syn::Expr, evaluations: &mut Vec<TokenStream>) -> syn::Ident {
+	let temporary = format_ident!(
+		"__reinhardt_view_value_{}",
+		evaluations.len(),
+		span = Span::mixed_site()
+	);
+	evaluations.push(quote! {
+		let #temporary: ::std::string::String = ::core::convert::Into::into(#expression);
+	});
+	temporary
+}

--- a/crates/reinhardt-pages/macros/src/lib.rs
+++ b/crates/reinhardt-pages/macros/src/lib.rs
@@ -187,6 +187,10 @@ pub fn derive_client_form(input: TokenStream) -> TokenStream {
 }
 
 /// Generates a `use_form` compatible companion form for a DTO request type.
+///
+/// Render its existing mutation through `form! { client_form: Companion,
+/// mutation: &mutation }`. Presentation adapters preserve the DTO's field
+/// order, serde names, and opted-in validation.
 #[proc_macro_attribute]
 pub fn client_form(args: TokenStream, input: TokenStream) -> TokenStream {
 	client_form::client_form_impl(args, input)
@@ -2337,6 +2341,14 @@ pub fn head(input: TokenStream) -> TokenStream {
 /// };
 /// # }
 /// ```
+/// # Named ClientForm views
+///
+/// Start with `client_form: SomeRequestClientForm` and supply `mutation:
+/// &mutation` to render an application-owned runtime. Optional `customize`,
+/// `styling`, `submit`, `summary`, and `id` entries configure presentation.
+/// The resulting descriptor implements `IntoPage` and has `into_page()`.
+/// Fields and validation come from the named DTO; incompatible field/widget
+/// combinations are rejected at compile time.
 #[proc_macro]
 pub fn form(input: TokenStream) -> TokenStream {
 	form::form_impl(input)

--- a/crates/reinhardt-pages/src/client_form.rs
+++ b/crates/reinhardt-pages/src/client_form.rs
@@ -2,6 +2,9 @@
 
 use std::hash::Hash;
 
+mod binding;
+mod view;
+
 /// One selectable option exposed by a DTO enum choice source.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClientFormChoice<T> {
@@ -25,6 +28,10 @@ pub trait ClientFormChoiceSource: Sized + Clone + PartialEq + 'static {
 /// Private helpers used by generated client-form code.
 #[doc(hidden)]
 pub mod __private {
+	pub use super::binding::{
+		BOOLEAN_CHOICES, choice_binding, optional_choice_binding, optional_number_binding,
+	};
+	pub use super::view::*;
 	use super::*;
 	use crate::form_state::FormValidationError;
 	use reinhardt_core::validators::{Validate, ValidationErrors};

--- a/crates/reinhardt-pages/src/client_form/binding.rs
+++ b/crates/reinhardt-pages/src/client_form/binding.rs
@@ -1,0 +1,170 @@
+//! Typed adapters for optional numbers and DTO choices.
+
+use super::ClientFormChoice;
+use reinhardt_core::reactive::{Signal, batch};
+use reinhardt_core::types::page::{
+	ControlBinding, ControlBindingError, ControlKind, ControlValue, ControlWriteOutcome,
+	NumberParseError, NumberValue,
+};
+
+/// Binds an optional primitive without a separate string value store.
+pub fn optional_number_binding<T: NumberValue>(
+	value: Signal<Option<T>>,
+	error: Signal<Option<NumberParseError>>,
+) -> ControlBinding {
+	ControlBinding::from_parts(
+		ControlKind::Number,
+		None,
+		value.id(),
+		move || {
+			ControlValue::Text(
+				value
+					.get()
+					.as_ref()
+					.map(NumberValue::format_control_value)
+					.unwrap_or_default(),
+			)
+		},
+		move |input| {
+			let ControlValue::Text(raw) = input else {
+				return Err(kind_mismatch(ControlKind::Number, &input));
+			};
+			let parsed = if raw.is_empty() {
+				Ok(None)
+			} else {
+				T::parse_control_value(&raw).map(Some)
+			};
+			match parsed {
+				Ok(next) => {
+					batch(|| {
+						value.set(next);
+						error.set(None);
+					});
+					Ok(ControlWriteOutcome::Committed)
+				}
+				Err(rejected) => {
+					error.set(Some(rejected.clone()));
+					Ok(ControlWriteOutcome::Rejected(rejected))
+				}
+			}
+		},
+		move || {
+			let previous = value.get_untracked();
+			let previous_error = error.get_untracked();
+			Box::new(move || {
+				batch(|| {
+					value.set(previous);
+					error.set(previous_error);
+				})
+			})
+		},
+	)
+	.with_lifetime_target(value.id())
+}
+
+/// Binds a required choice using an opaque ordinal DOM token.
+pub fn choice_binding<T: Clone + PartialEq + 'static>(
+	value: Signal<T>,
+	choices: &'static [ClientFormChoice<T>],
+) -> ControlBinding {
+	choice_binding_impl(
+		value,
+		move |value| {
+			choices
+				.iter()
+				.position(|choice| choice.value == *value)
+				.map(|index| format!("choice:{index}"))
+				.unwrap_or_default()
+		},
+		move |token| choice_index(token, choices.len()).map(|index| choices[index].value.clone()),
+	)
+}
+
+/// Binds optional choices, keeping an unset value distinct from every serialized value.
+pub fn optional_choice_binding<T: Clone + PartialEq + 'static>(
+	value: Signal<Option<T>>,
+	choices: &'static [ClientFormChoice<T>],
+) -> ControlBinding {
+	choice_binding_impl(
+		value,
+		move |value| match value {
+			None => String::from("none"),
+			Some(value) => choices
+				.iter()
+				.position(|choice| choice.value == *value)
+				.map(|index| format!("choice:{index}"))
+				.unwrap_or_default(),
+		},
+		move |token| {
+			if token == "none" {
+				Some(None)
+			} else {
+				choice_index(token, choices.len()).map(|index| Some(choices[index].value.clone()))
+			}
+		},
+	)
+}
+
+/// Fixed typed options for an optional boolean.
+pub static BOOLEAN_CHOICES: [ClientFormChoice<bool>; 2] = [
+	ClientFormChoice {
+		value: false,
+		serialized_value: "false",
+		label: "False",
+	},
+	ClientFormChoice {
+		value: true,
+		serialized_value: "true",
+		label: "True",
+	},
+];
+
+fn choice_index(token: &str, count: usize) -> Option<usize> {
+	let ordinal = token.strip_prefix("choice:")?;
+	let index: usize = ordinal.parse().ok()?;
+	(index < count && ordinal == index.to_string()).then_some(index)
+}
+
+fn choice_binding_impl<T: Clone + 'static>(
+	value: Signal<T>,
+	encode: impl Fn(&T) -> String + 'static,
+	decode: impl Fn(&str) -> Option<T> + 'static,
+) -> ControlBinding {
+	ControlBinding::from_parts(
+		ControlKind::SelectOne,
+		None,
+		value.id(),
+		move || ControlValue::Text(encode(&value.get())),
+		move |input| {
+			let ControlValue::Text(token) = input else {
+				return Err(kind_mismatch(ControlKind::SelectOne, &input));
+			};
+			match decode(&token) {
+				Some(next) => {
+					value.set(next);
+					Ok(ControlWriteOutcome::Committed)
+				}
+				None => Ok(ControlWriteOutcome::Ignored),
+			}
+		},
+		move || {
+			let previous = value.get_untracked();
+			Box::new(move || value.set(previous))
+		},
+	)
+	.with_lifetime_target(value.id())
+}
+
+fn kind_mismatch(control: ControlKind, value: &ControlValue) -> ControlBindingError {
+	ControlBindingError::ValueKindMismatch {
+		control,
+		actual: match value {
+			ControlValue::Text(_) => "text",
+			ControlValue::Checked(_) => "checked",
+			ControlValue::SelectedValues(_) => "selected-values",
+			ControlValue::Files(_) => "files",
+			#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+			ControlValue::File(_) => "file",
+		},
+	}
+}

--- a/crates/reinhardt-pages/src/client_form/view.rs
+++ b/crates/reinhardt-pages/src/client_form/view.rs
@@ -1,0 +1,403 @@
+//! Presentation descriptors borrowing a named form's application-owned runtime.
+
+use crate::component::{ControlBinding, ControlKind, IntoPage, Page, PageElement};
+use crate::reactive::Signal;
+use crate::{FormRuntimeSource, FormServerMutation, RuntimeControlBindingRequest, UseFormReturn};
+use reinhardt_core::types::page::EventType;
+
+mod errors;
+mod presentation;
+pub use errors::{SummaryEntry, collect_summary, describedby};
+pub use presentation::*;
+
+/// One exposed DTO field and its binding to the existing runtime.
+pub struct ViewField<Field> {
+	/// Generated form field token.
+	pub key: Field,
+	/// Stable declaration ordinal.
+	pub ordinal: usize,
+	/// Rust identifier without a raw prefix.
+	pub rust_name: &'static str,
+	/// Serde serialization name.
+	pub serialized_name: &'static str,
+	/// Safe required hint derived from opted-in string validation.
+	pub required: bool,
+	/// Once-evaluated display settings.
+	pub presentation: FieldDisplay,
+	/// Typed control source, without a duplicate editor signal.
+	pub binding: ControlBinding,
+}
+
+/// Resolves a generated field's binding using the runtime's existing adapter.
+pub fn view_binding<Form, Deps>(
+	runtime: &UseFormReturn<Form, Deps>,
+	field: Form::Field,
+	kind: ControlKind,
+) -> ControlBinding
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+{
+	runtime
+		.runtime_control_binding(
+			field,
+			RuntimeControlBindingRequest {
+				kind,
+				radio_value: None,
+			},
+		)
+		.unwrap_or_else(|| panic!("ClientForm view field {field:?} has no {kind} binding"))
+}
+
+/// Shared retained-view descriptor behind each generated, DTO-specific wrapper.
+pub struct ClientFormView<Form, Deps, Input, Output>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	Input: 'static,
+	Output: Clone + 'static,
+{
+	mutation: FormServerMutation<Form, Deps, Input, Output>,
+	runtime: UseFormReturn<Form, Deps>,
+	fields: Vec<ViewField<Form::Field>>,
+	options: ViewOptions,
+	id: String,
+}
+
+impl<Form, Deps, Input, Output> ClientFormView<Form, Deps, Input, Output>
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+	Input: 'static,
+	Output: Clone + 'static,
+{
+	/// Assembles metadata and a shared mutation handle without creating a runtime.
+	pub fn new(
+		mutation: FormServerMutation<Form, Deps, Input, Output>,
+		runtime: UseFormReturn<Form, Deps>,
+		fields: Vec<ViewField<Form::Field>>,
+		options: ViewOptions,
+		id: String,
+	) -> Self {
+		Self {
+			mutation,
+			runtime,
+			fields,
+			options,
+			id,
+		}
+	}
+	/// Applies one typed field customization exactly once.
+	pub fn customize<Kind>(
+		mut self,
+		ordinal: usize,
+		configure: impl FnOnce(FieldPresentation<Kind>) -> FieldPresentation<Kind>,
+	) -> Self {
+		let display = self.fields[ordinal].presentation.clone();
+		self.fields[ordinal].presentation =
+			configure(FieldPresentation::from_display(display)).into_display();
+		self
+	}
+
+	/// Builds retained controls and delegates submission to the existing mutation.
+	pub fn into_page(self) -> Page {
+		let Self {
+			mutation,
+			runtime,
+			fields,
+			options,
+			id,
+		} = self;
+		let state = runtime.form_state();
+		let ordered_fields: Vec<_> = fields
+			.iter()
+			.map(|field| (field.key, format!("{id}-field-{}", field.ordinal)))
+			.collect();
+		let summary_label = options.summary_label.clone();
+		let summary = PageElement::new("div")
+			.attr("id", format!("{id}-summary"))
+			.attr("class", options.summary_class.clone())
+			.attr("aria-live", "polite")
+			.attr("aria-atomic", "true")
+			.child(Page::reactive(move || {
+				let entries = collect_summary(
+					&ordered_fields,
+					&tracked_or_default(state.field_errors),
+					tracked_or_default(state.form_error).as_deref(),
+					tracked_or_default(state.submit_error).as_deref(),
+				);
+				if entries.is_empty() {
+					return Page::empty();
+				}
+				Page::fragment([
+					PageElement::new("p")
+						.child(Page::text(summary_label.clone()))
+						.into_page(),
+					PageElement::new("ul")
+						.children(entries.into_iter().map(summary_item))
+						.into_page(),
+				])
+			}));
+		let pending_button = mutation.clone();
+		let pending_label = mutation.clone();
+		let pending_form = mutation.clone();
+		let button = PageElement::new("button")
+			.attr("type", "submit")
+			.attr("class", options.submit_class.clone())
+			.reactive_attr("disabled", move || {
+				pending_button.is_pending().then(|| "disabled".into())
+			})
+			.child(Page::reactive({
+				let normal = options.submit_label.clone();
+				let pending = options.pending_label.clone();
+				move || {
+					Page::text(if pending_label.is_pending() {
+						pending.clone()
+					} else {
+						normal.clone()
+					})
+				}
+			}));
+		PageElement::new("form")
+			.attr("id", id.clone())
+			.attr("class", options.class.clone())
+			.bool_attr("novalidate", true)
+			.reactive_attr("aria-busy", move || {
+				Some(
+					if pending_form.is_pending() {
+						"true"
+					} else {
+						"false"
+					}
+					.into(),
+				)
+			})
+			.on(
+				EventType::Submit,
+				crate::raw_event_handler(move |event| {
+					event.prevent_default();
+					mutation.dispatch();
+				}),
+			)
+			.child(summary)
+			.children(
+				fields
+					.into_iter()
+					.map(|field| render_field(field, &runtime, &options, &id)),
+			)
+			.child(button)
+			.into_page()
+	}
+}
+
+fn tracked_or_default<T: Clone + Default + 'static>(signal: Signal<T>) -> T {
+	if signal.try_get_untracked().is_ok() {
+		signal.get()
+	} else {
+		T::default()
+	}
+}
+
+fn summary_item(entry: SummaryEntry) -> Page {
+	let content = if let Some(id) = entry.control_id {
+		PageElement::new("a")
+			.attr("href", format!("#{id}"))
+			.on(
+				EventType::Click,
+				crate::raw_event_handler(move |event| {
+					event.prevent_default();
+					focus_control(&id);
+				}),
+			)
+			.child(Page::text(entry.message))
+			.into_page()
+	} else {
+		Page::text(entry.message)
+	};
+	PageElement::new("li").child(content).into_page()
+}
+
+fn focus_control(id: &str) {
+	#[cfg(wasm)]
+	{
+		use wasm_bindgen::JsCast;
+		if let Some(control) = web_sys::window()
+			.and_then(|window| window.document())
+			.and_then(|document| document.get_element_by_id(id))
+			.and_then(|element| element.dyn_into::<web_sys::HtmlElement>().ok())
+		{
+			let _ = control.focus();
+		}
+	}
+	#[cfg(not(wasm))]
+	let _ = id;
+}
+
+fn render_field<Form, Deps>(
+	field: ViewField<Form::Field>,
+	runtime: &UseFormReturn<Form, Deps>,
+	options: &ViewOptions,
+	form_id: &str,
+) -> Page
+where
+	Form: FormRuntimeSource,
+	Deps: Clone + PartialEq + 'static,
+{
+	let ViewField {
+		key,
+		ordinal,
+		serialized_name,
+		required,
+		presentation: display,
+		binding,
+		..
+	} = field;
+	let id = format!("{form_id}-field-{ordinal}");
+	let help_id = format!("{form_id}-help-{ordinal}");
+	let error_id = format!("{form_id}-error-{ordinal}");
+	let errors = runtime.form_state().field_errors;
+	let mut control =
+		match display.widget {
+			WidgetKind::Textarea => PageElement::new("textarea"),
+			WidgetKind::Select => {
+				let mut select = PageElement::new("select");
+				if display.optional_choice {
+					select = select.child(
+						PageElement::new("option")
+							.attr("value", "none")
+							.child(Page::text(display.empty_label.clone())),
+					);
+				}
+				select.children(display.choices.iter().enumerate().map(
+					|(index, (token, label))| {
+						let label = if display.boolean_choice {
+							if index == 0 {
+								&display.false_label
+							} else {
+								&display.true_label
+							}
+						} else {
+							label
+						};
+						PageElement::new("option")
+							.attr("value", token.clone())
+							.child(Page::text(label.clone()))
+					},
+				))
+			}
+			widget => {
+				let input_type = match widget {
+					WidgetKind::TextInput => "text",
+					WidgetKind::EmailInput => "email",
+					WidgetKind::UrlInput => "url",
+					WidgetKind::PasswordInput => "password",
+					WidgetKind::NumberInput => "number",
+					WidgetKind::CheckboxInput => "checkbox",
+					WidgetKind::Textarea | WidgetKind::Select => unreachable!("handled above"),
+				};
+				PageElement::new("input").attr("type", input_type)
+			}
+		}
+		.attr("id", id.clone())
+		.attr("name", serialized_name)
+		.attr(
+			"class",
+			display
+				.class
+				.as_ref()
+				.unwrap_or(&options.input_class)
+				.clone(),
+		)
+		.attr(
+			"aria-describedby",
+			describedby(
+				display.help_text.as_ref().map(|_| help_id.as_str()),
+				&error_id,
+				display.aria_describedby.as_deref(),
+			),
+		)
+		.reactive_attr("aria-invalid", move || {
+			tracked_or_default(errors)
+				.contains_key(&key)
+				.then(|| "true".into())
+		})
+		.control_binding(binding);
+	if required {
+		control = control
+			.bool_attr("required", true)
+			.attr("aria-required", "true");
+	}
+	if display.widget == WidgetKind::NumberInput {
+		control = control.attr("step", "any");
+	}
+	for (name, value) in [
+		("aria-label", display.aria_label.as_ref()),
+		("placeholder", display.placeholder.as_ref()),
+		("autocomplete", display.autocomplete.as_ref()),
+	] {
+		if let Some(value) = value {
+			control = control.attr(name, value.clone());
+		}
+	}
+	let mut wrapper = PageElement::new("div")
+		.attr(
+			"class",
+			display
+				.wrapper_class
+				.as_ref()
+				.unwrap_or(&options.field_class)
+				.clone(),
+		)
+		.child(
+			PageElement::new("label")
+				.attr("for", id)
+				.attr(
+					"class",
+					display
+						.label_class
+						.as_ref()
+						.unwrap_or(&options.label_class)
+						.clone(),
+				)
+				.child(Page::text(display.label)),
+		)
+		.child(control);
+	if let Some(help) = display.help_text {
+		wrapper = wrapper.child(
+			PageElement::new("div")
+				.attr("id", help_id)
+				.attr(
+					"class",
+					display
+						.help_class
+						.as_ref()
+						.unwrap_or(&options.help_class)
+						.clone(),
+				)
+				.child(Page::text(help)),
+		);
+	}
+	wrapper
+		.child(
+			PageElement::new("div")
+				.attr("id", error_id)
+				.attr(
+					"class",
+					display
+						.error_class
+						.as_ref()
+						.unwrap_or(&options.error_class)
+						.clone(),
+				)
+				.reactive_attr("hidden", move || {
+					(!tracked_or_default(errors).contains_key(&key)).then(|| "hidden".into())
+				})
+				.child(Page::reactive(move || {
+					tracked_or_default(errors)
+						.get(&key)
+						.map(|error| Page::text(error.message().to_owned()))
+						.unwrap_or_else(Page::empty)
+				})),
+		)
+		.into_page()
+}

--- a/crates/reinhardt-pages/src/client_form/view/errors.rs
+++ b/crates/reinhardt-pages/src/client_form/view/errors.rs
@@ -1,0 +1,62 @@
+//! Stable ordering and accessible relationships for retained validation regions.
+
+use crate::FieldError;
+use std::{collections::HashMap, hash::Hash};
+
+/// One summary message and, for field errors, the retained control it describes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SummaryEntry {
+	/// Associated control ID for a field error.
+	pub control_id: Option<String>,
+	/// Existing runtime message, without rewriting or parsing it.
+	pub message: String,
+}
+
+/// Orders field messages by declaration and deduplicates equal global messages.
+pub fn collect_summary<Field: Copy + Eq + Hash>(
+	ordered_fields: &[(Field, String)],
+	errors: &HashMap<Field, FieldError>,
+	form_error: Option<&str>,
+	submit_error: Option<&str>,
+) -> Vec<SummaryEntry> {
+	let mut entries: Vec<_> = ordered_fields
+		.iter()
+		.filter_map(|(field, id)| {
+			errors.get(field).map(|error| SummaryEntry {
+				control_id: Some(id.clone()),
+				message: error.message().into(),
+			})
+		})
+		.collect();
+	for message in [form_error, submit_error]
+		.into_iter()
+		.flatten()
+		.filter(|message| !message.is_empty())
+	{
+		if !entries
+			.iter()
+			.any(|entry| entry.control_id.is_none() && entry.message == message)
+		{
+			entries.push(SummaryEntry {
+				control_id: None,
+				message: message.into(),
+			});
+		}
+	}
+	entries
+}
+
+/// Combines generated and external IDs, retaining each ID's first occurrence.
+pub fn describedby(help_id: Option<&str>, error_id: &str, external: Option<&str>) -> String {
+	let mut ids = Vec::new();
+	for id in help_id
+		.into_iter()
+		.chain(Some(error_id))
+		.chain(external.into_iter().flat_map(str::split_ascii_whitespace))
+	{
+		if !ids.contains(&id) {
+			ids.push(id);
+		}
+	}
+	ids.join(" ")
+}

--- a/crates/reinhardt-pages/src/client_form/view/presentation.rs
+++ b/crates/reinhardt-pages/src/client_form/view/presentation.rs
@@ -1,0 +1,311 @@
+//! Owned presentation settings and sealed field/widget capabilities.
+
+use std::marker::PhantomData;
+
+/// Rendering primitive selected by a typed presentation adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WidgetKind {
+	/// Single-line text.
+	TextInput,
+	/// Multiline text.
+	Textarea,
+	/// Email input.
+	EmailInput,
+	/// URL input.
+	UrlInput,
+	/// Password input, omitted from SSR values.
+	PasswordInput,
+	/// Typed primitive number.
+	NumberInput,
+	/// Boolean checkbox.
+	CheckboxInput,
+	/// Typed single choice.
+	Select,
+}
+
+macro_rules! kinds {
+    ($($kind:ident),* $(,)?) => {$(
+        #[doc = concat!("Capability marker for ", stringify!($kind), " fields.")]
+        pub struct $kind;
+    )*};
+}
+kinds!(TextKind, NumberKind, BoolKind, OptionalBoolKind);
+/// Capability marker for a required enum.
+pub struct EnumKind<T>(PhantomData<T>);
+/// Capability marker for an optional enum.
+pub struct OptionalEnumKind<T>(PhantomData<T>);
+
+mod sealed {
+	pub trait Widget<Kind> {}
+	pub trait Placeholder {}
+	pub trait OptionalChoice {}
+}
+
+/// Closed compatibility table used by generated field adapters.
+pub trait AllowedWidget<Kind>: sealed::Widget<Kind> {
+	/// Corresponding rendering primitive.
+	const KIND: WidgetKind;
+}
+
+macro_rules! widgets {
+    ($($widget:ident => $kind:ty),* $(,)?) => {$(
+        #[doc = concat!("Presentation marker for ", stringify!($widget), ".")]
+        pub struct $widget;
+        impl sealed::Widget<$kind> for $widget {}
+        impl AllowedWidget<$kind> for $widget {
+            const KIND: WidgetKind = WidgetKind::$widget;
+        }
+    )*};
+}
+widgets!(
+	TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+	UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+	CheckboxInput => BoolKind, Select => OptionalBoolKind,
+);
+impl<T> sealed::Widget<EnumKind<T>> for Select {}
+impl<T> AllowedWidget<EnumKind<T>> for Select {
+	const KIND: WidgetKind = WidgetKind::Select;
+}
+impl<T> sealed::Widget<OptionalEnumKind<T>> for Select {}
+impl<T> AllowedWidget<OptionalEnumKind<T>> for Select {
+	const KIND: WidgetKind = WidgetKind::Select;
+}
+impl sealed::Placeholder for TextKind {}
+impl sealed::Placeholder for NumberKind {}
+impl sealed::OptionalChoice for OptionalBoolKind {}
+impl<T> sealed::OptionalChoice for OptionalEnumKind<T> {}
+
+/// Owned display metadata; optional strings distinguish inheritance from an empty override.
+#[derive(Clone, Debug)]
+pub struct FieldDisplay {
+	/// Control primitive.
+	pub widget: WidgetKind,
+	/// Visible label.
+	pub label: String,
+	/// Stable ordinal tokens and labels.
+	pub choices: Vec<(String, String)>,
+	/// Whether choices include an unset option.
+	pub optional_choice: bool,
+	/// Whether the two options are boolean values.
+	pub boolean_choice: bool,
+	/// Explicit accessible name.
+	pub aria_label: Option<String>,
+	/// Additional described-by IDs.
+	pub aria_describedby: Option<String>,
+	/// Optional explanatory text.
+	pub help_text: Option<String>,
+	/// Editor placeholder.
+	pub placeholder: Option<String>,
+	/// Browser autocomplete hint.
+	pub autocomplete: Option<String>,
+	/// Control class override.
+	pub class: Option<String>,
+	/// Wrapper class override.
+	pub wrapper_class: Option<String>,
+	/// Label class override.
+	pub label_class: Option<String>,
+	/// Help class override.
+	pub help_class: Option<String>,
+	/// Error class override.
+	pub error_class: Option<String>,
+	/// Unset choice label.
+	pub empty_label: String,
+	/// True choice label.
+	pub true_label: String,
+	/// False choice label.
+	pub false_label: String,
+}
+
+impl FieldDisplay {
+	/// Creates declaration-derived defaults without reading field values.
+	pub fn new(
+		label: &str,
+		widget: WidgetKind,
+		choices: Vec<(String, String)>,
+		optional_choice: bool,
+		boolean_choice: bool,
+	) -> Self {
+		Self {
+			widget,
+			label: label.into(),
+			choices,
+			optional_choice,
+			boolean_choice,
+			aria_label: None,
+			aria_describedby: None,
+			help_text: None,
+			placeholder: None,
+			autocomplete: None,
+			class: None,
+			wrapper_class: None,
+			label_class: None,
+			help_class: None,
+			error_class: None,
+			empty_label: String::new(),
+			true_label: String::from("True"),
+			false_label: String::from("False"),
+		}
+	}
+}
+
+/// Typed configuration boundary used only by generated companion methods.
+pub struct FieldPresentation<Kind> {
+	display: FieldDisplay,
+	kind: PhantomData<fn() -> Kind>,
+}
+
+macro_rules! optional_setters {
+    ($($name:ident),* $(,)?) => {$(
+        #[doc = concat!("Overrides ", stringify!($name), " for this field.")]
+        pub fn $name(mut self, value: impl Into<String>) -> Self {
+            self.display.$name = Some(value.into());
+            self
+        }
+    )*};
+}
+impl<Kind> FieldPresentation<Kind> {
+	/// Wraps the existing display settings for one typed customization.
+	pub fn from_display(display: FieldDisplay) -> Self {
+		Self {
+			display,
+			kind: PhantomData,
+		}
+	}
+	/// Returns the customized owned settings.
+	pub fn into_display(self) -> FieldDisplay {
+		self.display
+	}
+	/// Selects a widget accepted by this field's capability table.
+	pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+		self.display.widget = W::KIND;
+		self
+	}
+	/// Overrides the visible label.
+	pub fn label(mut self, value: impl Into<String>) -> Self {
+		self.display.label = value.into();
+		self
+	}
+	optional_setters!(
+		aria_label,
+		aria_describedby,
+		help_text,
+		autocomplete,
+		class,
+		wrapper_class,
+		label_class,
+		help_class,
+		error_class
+	);
+}
+impl<Kind: sealed::Placeholder> FieldPresentation<Kind> {
+	optional_setters!(placeholder);
+}
+impl<Kind: sealed::OptionalChoice> FieldPresentation<Kind> {
+	/// Overrides the unset option label.
+	pub fn empty_label(mut self, value: impl Into<String>) -> Self {
+		self.display.empty_label = value.into();
+		self
+	}
+}
+impl FieldPresentation<OptionalBoolKind> {
+	/// Overrides the true option label.
+	pub fn true_label(mut self, value: impl Into<String>) -> Self {
+		self.display.true_label = value.into();
+		self
+	}
+	/// Overrides the false option label.
+	pub fn false_label(mut self, value: impl Into<String>) -> Self {
+		self.display.false_label = value.into();
+		self
+	}
+}
+
+/// Once-evaluated form-wide settings, separate from the resolved instance ID.
+#[derive(Clone, Debug)]
+pub struct ViewOptions {
+	/// Explicit ID, if supplied.
+	pub id: Option<String>,
+	/// Form class.
+	pub class: String,
+	/// Field wrapper class.
+	pub field_class: String,
+	/// Control class.
+	pub input_class: String,
+	/// Label class.
+	pub label_class: String,
+	/// Help class.
+	pub help_class: String,
+	/// Error class.
+	pub error_class: String,
+	/// Summary class.
+	pub summary_class: String,
+	/// Submit button label.
+	pub submit_label: String,
+	/// Pending submit button label.
+	pub pending_label: String,
+	/// Submit button class.
+	pub submit_class: String,
+	/// Validation summary label.
+	pub summary_label: String,
+}
+impl Default for ViewOptions {
+	fn default() -> Self {
+		Self {
+			id: None,
+			class: "reinhardt-form".into(),
+			field_class: "reinhardt-field".into(),
+			input_class: "reinhardt-input".into(),
+			label_class: "reinhardt-label".into(),
+			help_class: "reinhardt-help".into(),
+			error_class: "reinhardt-error".into(),
+			summary_class: "reinhardt-validation-summary".into(),
+			submit_label: "Submit".into(),
+			pending_label: "Submitting...".into(),
+			submit_class: "reinhardt-submit".into(),
+			summary_label: "Please correct the following errors".into(),
+		}
+	}
+}
+macro_rules! option_setters {
+    ($($name:ident),* $(,)?) => {$(
+        #[doc = concat!("Sets the form-wide ", stringify!($name), ".")]
+        pub fn $name(mut self, value: impl Into<String>) -> Self { self.$name = value.into(); self }
+    )*};
+}
+impl ViewOptions {
+	/// Sets and validates the explicit form ID before constructing bindings.
+	pub fn id(mut self, value: impl Into<String>) -> Self {
+		let id = value.into();
+		assert!(
+			!id.is_empty() && !id.chars().any(|ch| ch.is_ascii_whitespace()),
+			"ClientForm view id must be nonempty and contain no ASCII whitespace"
+		);
+		self.id = Some(id);
+		self
+	}
+	option_setters!(
+		class,
+		field_class,
+		input_class,
+		label_class,
+		help_class,
+		error_class,
+		summary_class,
+		submit_label,
+		pending_label,
+		submit_class,
+		summary_label
+	);
+	/// Resolves one instance ID using the existing request-scoped ID hook.
+	pub fn resolve_id(&self) -> String {
+		if let Some(id) = &self.id {
+			assert!(
+				!id.is_empty() && !id.chars().any(|ch| ch.is_ascii_whitespace()),
+				"ClientForm view id must be nonempty and contain no ASCII whitespace"
+			);
+			id.clone()
+		} else {
+			crate::reactive::hooks::id::use_id_with_prefix("client-form")
+		}
+	}
+}

--- a/crates/reinhardt-pages/src/hydration/reconcile.rs
+++ b/crates/reinhardt-pages/src/hydration/reconcile.rs
@@ -2,6 +2,8 @@
 //!
 //! This module verifies that SSR-rendered DOM matches the expected
 //! component structure during hydration.
+//! Empty presentation text follows the browser's child-node filtering; textarea
+//! snapshots retain their raw whitespace and line feeds.
 
 use crate::component::Page;
 
@@ -548,6 +550,10 @@ fn reconcile_children_at_path(
 		}
 		return Ok(());
 	}
+	// Match the DOM traversal without discarding raw textarea snapshot content.
+	expected_children.retain(
+		|(_, child)| !matches!(child, Page::Text(text) if normalize_whitespace(text).is_empty()),
+	);
 	let actual_nodes = relevant_child_nodes(element);
 
 	for (index, (child_path, child_view)) in expected_children.iter().enumerate() {
@@ -905,6 +911,9 @@ fn reconcile_options_children_at_path(
 	let children_inside_controlled_select = inside_controlled_select
 		|| matches!(view, Page::Element(element) if is_controlled_select(element));
 	collect_expected_children(child_views, &parent_path, &mut expected_children);
+	expected_children.retain(
+		|(_, child)| !matches!(child, Page::Text(text) if normalize_whitespace(text).is_empty()),
+	);
 
 	for (index, (child_path, child_view)) in expected_children.iter().enumerate() {
 		let Some(actual_node) = actual_nodes.get(index) else {

--- a/crates/reinhardt-pages/src/hydration/reconcile.rs
+++ b/crates/reinhardt-pages/src/hydration/reconcile.rs
@@ -2,8 +2,8 @@
 //!
 //! This module verifies that SSR-rendered DOM matches the expected
 //! component structure during hydration.
-//! Empty presentation text follows the browser's child-node filtering; textarea
-//! snapshots retain their raw whitespace and line feeds.
+//! Empty presentation text follows the browser's child-node filtering; raw-text
+//! snapshots such as `textarea` and `pre` retain their whitespace and line feeds.
 
 use crate::component::Page;
 
@@ -523,12 +523,13 @@ fn reconcile_children_at_path(
 ) -> Result<(), ReconcileError> {
 	let mut expected_children = Vec::new();
 	collect_expected_children(child_views, &path, &mut expected_children);
-	if element.tag_name().eq_ignore_ascii_case("textarea")
+	if (element.tag_name().eq_ignore_ascii_case("textarea")
+		|| element.tag_name().eq_ignore_ascii_case("pre"))
 		&& expected_children
 			.iter()
 			.all(|(_, view)| matches!(view, Page::Text(_)))
 	{
-		// Textarea snapshots retain whitespace, including an absent empty text node.
+		// Raw-text snapshots retain whitespace, including an absent empty text node.
 		let expected: String = expected_children
 			.iter()
 			.filter_map(|(_, view)| {

--- a/crates/reinhardt-pages/src/lib.rs
+++ b/crates/reinhardt-pages/src/lib.rs
@@ -1169,6 +1169,7 @@ pub mod form_generated;
 // Typed form runtime state (WASM-compatible)
 pub mod form_state;
 // Runtime support for DTO-derived client forms.
+#[doc = include_str!("../docs/client_forms.md")]
 pub mod client_form;
 // Model-backed form state is target-neutral. Legacy FormComponent support is
 // gated inside the module because it still depends on reinhardt-forms.
@@ -1364,6 +1365,8 @@ pub mod __private {
 	#[cfg(native)]
 	pub use hyper;
 	pub use inventory;
+	#[cfg(native)]
+	pub use reinhardt_http;
 	pub use reinhardt_urls;
 	pub use serde;
 	pub use serde_json;

--- a/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
+++ b/crates/reinhardt-pages/src/reactive/hooks/async_action.rs
@@ -242,8 +242,12 @@ impl<T: Clone + 'static, E: Clone + 'static> Action<T, E> {
 	}
 
 	/// Returns `true` if the action is pending.
+	///
+	/// Tracks phase changes without cloning the success value or error.
 	pub fn is_pending(&self) -> bool {
-		self.phase().is_pending()
+		let state = self.state();
+		reinhardt_core::reactive::with_runtime(|runtime| runtime.track_dependency(state.id()));
+		state.with_untracked(ActionPhase::is_pending)
 	}
 
 	pub(crate) fn try_is_pending_untracked(&self) -> Option<bool> {
@@ -1036,6 +1040,45 @@ mod tests {
 		action.force_success_for_test(());
 		reinhardt_core::reactive::with_runtime(|runtime| runtime.flush_updates());
 		assert_eq!(runs.get(), 1);
+	}
+
+	#[rstest]
+	#[serial_test::serial(reactive_runtime)]
+	fn pending_observation_tracks_transitions_without_cloning_outputs() {
+		struct Counted(Rc<Cell<usize>>);
+		impl Clone for Counted {
+			fn clone(&self) -> Self {
+				self.0.set(self.0.get() + 1);
+				Self(Rc::clone(&self.0))
+			}
+		}
+
+		// Arrange
+		let scope = reinhardt_core::reactive::ReactiveScope::new();
+		let clones = Rc::new(Cell::new(0));
+		let observations = Rc::new(RefCell::new(Vec::new()));
+		let action = scope.enter(|| use_action(|value: Counted| async { Ok::<_, Counted>(value) }));
+		let _effect = scope.enter(|| {
+			let observations = Rc::clone(&observations);
+			reinhardt_core::reactive::Effect::new(move || {
+				observations.borrow_mut().push(action.is_pending());
+			})
+		});
+
+		// Act
+		for phase in [
+			ActionPhase::Pending,
+			ActionPhase::Success(Counted(Rc::clone(&clones))),
+			ActionPhase::Error(Counted(Rc::clone(&clones))),
+			ActionPhase::Idle,
+		] {
+			action.state().set(phase);
+			reinhardt_core::reactive::with_runtime(|runtime| runtime.flush_updates());
+		}
+
+		// Assert
+		assert_eq!(*observations.borrow(), [false, true, false, false, false]);
+		assert_eq!(clones.get(), 0);
 	}
 
 	#[rstest]

--- a/crates/reinhardt-pages/tests/client_form_binding.rs
+++ b/crates/reinhardt-pages/tests/client_form_binding.rs
@@ -1,0 +1,204 @@
+//! Typed binding contracts shared by handwritten and generated ClientForm views.
+#![cfg(not(target_arch = "wasm32"))]
+
+use reinhardt_pages::component::{ControlValue, ControlWriteOutcome};
+use reinhardt_pages::control_binding::__private::{
+	NumberBinding, SelectOneBinding, into_control_binding,
+};
+use reinhardt_pages::reactive::ReactiveScope;
+use reinhardt_pages::{
+	ClientForm, ClientFormChoices, FormRuntimeSource, NumberParseErrorKind, use_form,
+};
+use serde::Serialize;
+
+#[test]
+fn optional_number_clears_parse_error_and_updates_value_as_one_observation() {
+	ReactiveScope::run(|| {
+		use reinhardt_pages::reactive::{Effect, EffectTiming};
+		use std::{cell::RefCell, rc::Rc};
+		// Arrange
+		let definition = TypedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let field = definition.count_field();
+		let binding = into_control_binding::<NumberBinding, _>(runtime.field(field), ());
+		binding.write(ControlValue::Text("invalid".into())).unwrap();
+		let observations = Rc::new(RefCell::new(Vec::new()));
+		let _effect = Effect::new_with_timing(
+			{
+				let observations = observations.clone();
+				let definition = definition.clone();
+				let value = runtime.watch_field::<Option<i32>>(field);
+				move || {
+					observations.borrow_mut().push((
+						value.get(),
+						definition.runtime_custom_widget_error(field).is_some(),
+					))
+				}
+			},
+			EffectTiming::Layout,
+		);
+		observations.borrow_mut().clear();
+		// Act
+		binding.write(ControlValue::Text("8".into())).unwrap();
+		// Assert
+		assert_eq!(*observations.borrow(), vec![(Some(8), false)]);
+	});
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, ClientFormChoices)]
+enum Mode {
+	#[default]
+	#[serde(rename = "")]
+	Empty,
+	Active,
+}
+
+#[derive(Clone, Serialize, ClientForm)]
+struct TypedRequest {
+	active: bool,
+	count: Option<i32>,
+	enabled: Option<bool>,
+	mode: Mode,
+	optional_mode: Option<Mode>,
+}
+
+#[test]
+fn optional_number_keeps_typed_state_when_an_edit_is_rejected() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = TypedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let field = definition.count_field();
+		let binding = into_control_binding::<NumberBinding, _>(runtime.field(field), ());
+		assert_eq!(binding.read(), ControlValue::Text(String::new()));
+		// Act
+		assert_eq!(
+			binding
+				.write(ControlValue::Text(String::from("7")))
+				.unwrap(),
+			ControlWriteOutcome::Committed
+		);
+		let snapshot = binding.snapshot();
+		let outcome = binding
+			.write(ControlValue::Text(String::from("1.5")))
+			.unwrap();
+		// Assert
+		let ControlWriteOutcome::Rejected(error) = outcome else {
+			panic!("fractional i32 input must be rejected")
+		};
+		assert_eq!(error.kind(), NumberParseErrorKind::Invalid);
+		assert_eq!(runtime.get_values().count, Some(7));
+		assert!(definition.runtime_custom_widget_error(field).is_some());
+		drop(snapshot);
+		assert_eq!(definition.runtime_custom_widget_error(field), None);
+		assert_eq!(
+			binding.write(ControlValue::Text(String::new())).unwrap(),
+			ControlWriteOutcome::Committed
+		);
+		assert_eq!(runtime.get_values().count, None);
+		assert_eq!(binding.read(), ControlValue::Text(String::new()));
+	});
+}
+
+#[test]
+fn optional_boolean_retains_all_three_states() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = TypedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let binding = into_control_binding::<SelectOneBinding, _>(
+			runtime.field(definition.enabled_field()),
+			(),
+		);
+		assert_eq!(binding.read(), ControlValue::Text(String::from("none")));
+		// Act / Assert
+		for (token, expected) in [
+			("choice:0", Some(false)),
+			("choice:1", Some(true)),
+			("none", None),
+		] {
+			assert_eq!(
+				binding.write(ControlValue::Text(token.into())).unwrap(),
+				ControlWriteOutcome::Committed
+			);
+			assert_eq!(runtime.get_values().enabled, expected);
+			assert_eq!(binding.read(), ControlValue::Text(token.into()));
+		}
+	});
+}
+
+#[test]
+fn choices_distinguish_empty_serialization_and_ignore_invalid_tokens() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = TypedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let binding = into_control_binding::<SelectOneBinding, _>(
+			runtime.field(definition.optional_mode_field()),
+			(),
+		);
+		// Act / Assert
+		binding
+			.write(ControlValue::Text(String::from("choice:0")))
+			.unwrap();
+		assert_eq!(runtime.get_values().optional_mode, Some(Mode::Empty));
+		assert_eq!(
+			serde_json::to_string(&runtime.get_values().optional_mode).unwrap(),
+			"\"\""
+		);
+		for invalid in [
+			"",
+			"choice:00",
+			"choice:+1",
+			"choice:99",
+			"Active",
+			"other:0",
+		] {
+			assert_eq!(
+				binding.write(ControlValue::Text(invalid.into())).unwrap(),
+				ControlWriteOutcome::Ignored
+			);
+			assert_eq!(runtime.get_values().optional_mode, Some(Mode::Empty));
+		}
+		let snapshot = binding.snapshot();
+		binding
+			.write(ControlValue::Text(String::from("none")))
+			.unwrap();
+		assert_eq!(runtime.get_values().optional_mode, None);
+		drop(snapshot);
+		assert_eq!(runtime.get_values().optional_mode, Some(Mode::Empty));
+		let required =
+			into_control_binding::<SelectOneBinding, _>(runtime.field(definition.mode_field()), ());
+		assert_eq!(
+			required
+				.write(ControlValue::Text(String::from("none")))
+				.unwrap(),
+			ControlWriteOutcome::Ignored
+		);
+		assert_eq!(runtime.get_values().mode, Mode::Empty);
+		assert_eq!(
+			serde_json::to_value(TypedRequestClientForm::to_request(&runtime)).unwrap(),
+			serde_json::json!({"active":false,"count":null,"enabled":null,"mode":"","optional_mode":""})
+		);
+	});
+}
+
+#[test]
+fn explicit_field_writes_win_hydration_and_reset_callbacks_share_an_epoch() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = TypedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let binding =
+			into_control_binding::<NumberBinding, _>(runtime.field(definition.count_field()), ());
+		assert!(!binding.source_preferred_on_hydration());
+		assert!(binding.has_native_reset());
+		// Act
+		runtime.reset_field(definition.count_field());
+		// Assert
+		assert!(binding.source_preferred_on_hydration());
+		let previous = definition.runtime_native_reset_epoch();
+		binding.notify_native_reset();
+		assert_eq!(definition.runtime_native_reset_epoch(), previous + 1);
+	});
+}

--- a/crates/reinhardt-pages/tests/client_form_view.rs
+++ b/crates/reinhardt-pages/tests/client_form_view.rs
@@ -1,0 +1,341 @@
+//! Named ClientForm metadata and retained native Page contracts.
+#![cfg(not(target_arch = "wasm32"))]
+
+#[path = "support/client_form_view_shared.rs"]
+pub mod support;
+
+use reinhardt_pages::__private::client_form::{
+	PasswordInput, SummaryEntry, ViewOptions, collect_summary, describedby,
+};
+use reinhardt_pages::FieldError;
+use reinhardt_pages::component::ControlValue;
+use reinhardt_pages::component::{Page, PageElement};
+use reinhardt_pages::reactive::ReactiveScope;
+use reinhardt_pages::{ClientForm, client_form, use_form};
+use std::collections::HashMap;
+use support::{LoginRequest, LoginRequestClientForm};
+
+#[test]
+fn form_macro_evaluates_presentation_once_in_source_order() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = LoginRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let order = std::cell::RefCell::new(Vec::new());
+		let record = |key, value: &str| {
+			order.borrow_mut().push(key);
+			String::from(value)
+		};
+		// Act
+		let page = reinhardt_pages::form! {
+			client_form: support::LoginRequestClientForm,
+			summary: { label: record(0, "Errors") },
+			customize: {
+				password: { widget: PasswordInput, label: record(1, "Password") },
+				username: { label: record(2, "Username") },
+			},
+			mutation: { order.borrow_mut().push(3); &mutation },
+			styling: { class: record(4, "auth-form") },
+			id: record(5, "login-macro"),
+			submit: { label: record(6, "Sign in"), pending_label: record(7, "Signing in...") },
+		}
+		.into_page();
+		// Assert
+		assert_eq!(*order.borrow(), (0..8).collect::<Vec<_>>());
+		assert_eq!(attr(elements(&page, "form")[0], "class"), Some("auth-form"));
+		runtime.set_value(definition.username_field(), String::from("changed"));
+		runtime.set_error(definition.password_field(), FieldError::new("Required"));
+		let _html = page.render_to_string();
+		assert_eq!(*order.borrow(), (0..8).collect::<Vec<_>>());
+		assert_eq!(
+			elements(&page, "input")[0].bound_control().unwrap().read(),
+			ControlValue::Text(String::from("changed"))
+		);
+	});
+}
+
+fn elements<'a>(page: &'a Page, tag: &str) -> Vec<&'a PageElement> {
+	let mut result = Vec::new();
+	if let Page::Element(element) = page {
+		if element.tag_name() == tag {
+			result.push(element);
+		}
+		for child in element.child_views() {
+			result.extend(elements(child, tag));
+		}
+	}
+	result
+}
+
+fn attr<'a>(element: &'a PageElement, name: &str) -> Option<&'a str> {
+	element
+		.attrs()
+		.iter()
+		.find(|(key, _)| key == name)
+		.map(|(_, value)| value.as_ref())
+}
+
+#[test]
+fn summary_preserves_field_order_and_deduplicates_only_equal_global_messages() {
+	// Arrange
+	let fields = vec![
+		(0_u8, String::from("login-field-0")),
+		(1_u8, String::from("login-field-1")),
+	];
+	let errors = HashMap::from([
+		(1_u8, FieldError::new("same")),
+		(0_u8, FieldError::new("same")),
+	]);
+	// Act / Assert
+	assert_eq!(
+		collect_summary(
+			&fields,
+			&errors,
+			Some("unmatched: rejected"),
+			Some("navigation failed")
+		),
+		vec![
+			SummaryEntry {
+				control_id: Some("login-field-0".into()),
+				message: "same".into()
+			},
+			SummaryEntry {
+				control_id: Some("login-field-1".into()),
+				message: "same".into()
+			},
+			SummaryEntry {
+				control_id: None,
+				message: "unmatched: rejected".into()
+			},
+			SummaryEntry {
+				control_id: None,
+				message: "navigation failed".into()
+			},
+		]
+	);
+	assert_eq!(
+		collect_summary::<u8>(&[], &HashMap::new(), Some("same"), Some("same")),
+		vec![SummaryEntry {
+			control_id: None,
+			message: "same".into()
+		}]
+	);
+	assert_eq!(
+		collect_summary::<u8>(&[], &HashMap::new(), Some(""), None),
+		vec![]
+	);
+	assert_eq!(
+		describedby(Some("help"), "error", Some("external help\texternal error")),
+		"help error external"
+	);
+}
+
+#[test]
+fn retained_controls_share_bindings_and_project_only_safe_constraints() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+			username: "alice".into(),
+			password: "secret".into(),
+		});
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let view =
+			LoginRequestClientForm::__reinhardt_view(&mutation, ViewOptions::default().id("login"))
+				.__reinhardt_field_username(|field| {
+					field
+						.help_text("A <name>")
+						.aria_describedby("external login-help-0")
+				})
+				.__reinhardt_field_password(|field| {
+					field.widget(PasswordInput).autocomplete("current-password")
+				});
+		// Act
+		let page = view.into_page();
+		// Assert
+		let form = elements(&page, "form")[0];
+		assert_eq!(attr(form, "novalidate"), Some("novalidate"));
+		let inputs = elements(&page, "input");
+		assert_eq!(inputs.len(), 2);
+		assert_eq!(
+			inputs
+				.iter()
+				.map(|input| (attr(input, "id"), attr(input, "name"), attr(input, "type")))
+				.collect::<Vec<_>>(),
+			vec![
+				(Some("login-field-0"), Some("username"), Some("text")),
+				(Some("login-field-1"), Some("password"), Some("password"))
+			]
+		);
+		assert_eq!(
+			attr(inputs[0], "aria-describedby"),
+			Some("login-help-0 login-error-0 external")
+		);
+		for input in &inputs {
+			assert_eq!(attr(input, "required"), Some("required"));
+			assert_eq!(attr(input, "aria-required"), Some("true"));
+			for forbidden in ["min", "max", "minlength", "maxlength", "pattern"] {
+				assert_eq!(attr(input, forbidden), None);
+			}
+		}
+		assert_eq!(
+			inputs[0].bound_control().unwrap().target(),
+			runtime
+				.watch_field::<String>(definition.username_field())
+				.id()
+		);
+		assert_eq!(elements(&page, "button").len(), 1);
+		runtime.set_error(definition.username_field(), FieldError::new("<invalid>"));
+		let invalid = inputs[0]
+			.reactive_attrs()
+			.iter()
+			.find(|attribute| attribute.name() == "aria-invalid")
+			.unwrap();
+		assert_eq!(invalid.value().as_deref(), Some("true"));
+		runtime.clear_errors();
+		assert_eq!(invalid.value(), None);
+		let html = page.render_to_string();
+		assert_eq!(html.matches("secret").count(), 0);
+		assert_eq!(html.matches("A &lt;name&gt;").count(), 1);
+		assert_eq!(html.matches("aria-live=").count(), 1);
+	});
+}
+
+#[test]
+#[should_panic(expected = "ClientForm view id must be nonempty")]
+fn runtime_id_expression_is_validated_before_a_view_is_assembled() {
+	let _options = ViewOptions::default().id(String::from("bad id"));
+}
+
+#[test]
+fn metadata_uses_the_owned_runtime_and_dto_declaration_order() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+			username: String::from("alice"),
+			password: String::from("secret"),
+		});
+		let runtime = use_form(&definition).build();
+		// Act
+		let fields = LoginRequestClientForm::__reinhardt_view_fields(&runtime);
+		// Assert
+		assert_eq!(
+			fields
+				.iter()
+				.map(|field| (
+					field.ordinal,
+					field.rust_name,
+					field.serialized_name,
+					field.required
+				))
+				.collect::<Vec<_>>(),
+			vec![
+				(0, "username", "username", true),
+				(1, "password", "password", true)
+			]
+		);
+		assert_eq!(
+			fields[0].binding.read(),
+			ControlValue::Text(String::from("alice"))
+		);
+		assert_eq!(
+			fields[1].binding.read(),
+			ControlValue::Text(String::from("secret"))
+		);
+		assert!(!runtime.form_state().is_touched.get());
+		fields[0]
+			.binding
+			.write(ControlValue::Text(String::from("bob")))
+			.unwrap();
+		assert_eq!(LoginRequestClientForm::to_request(&runtime).username, "bob");
+	});
+}
+
+#[client_form(name = RenamedForm)]
+#[derive(Clone)]
+#[serde(rename_all = "camelCase")]
+struct Renamed {
+	first_name: String,
+	#[serde(rename(serialize = "wireType", deserialize = "otherType"))]
+	r#type: String,
+	#[client_form(skip)]
+	internal: u32,
+}
+
+#[derive(Clone, ClientForm)]
+struct Unvalidated {
+	text: String,
+	optional: Option<String>,
+	flag: bool,
+	count: u32,
+}
+
+#[test]
+fn metadata_preserves_renames_raw_names_and_skipped_fields() {
+	ReactiveScope::run(|| {
+		// Arrange
+		let definition = RenamedForm::new();
+		let runtime = use_form(&definition).build();
+		// Act
+		let fields = RenamedForm::__reinhardt_view_fields(&runtime);
+		// Assert
+		assert_eq!(
+			fields
+				.iter()
+				.map(|field| (field.rust_name, field.serialized_name, field.required))
+				.collect::<Vec<_>>(),
+			vec![
+				("first_name", "firstName", false),
+				("type", "wireType", false)
+			]
+		);
+		let request = RenamedForm::to_request(&runtime);
+		assert_eq!(
+			(request.first_name, request.r#type, request.internal),
+			(String::new(), String::new(), 0)
+		);
+	});
+}
+
+#[test]
+fn derive_entry_does_not_infer_required_without_validation() {
+	ReactiveScope::run(|| {
+		let definition = UnvalidatedClientForm::new();
+		let runtime = use_form(&definition).build();
+		let fields = UnvalidatedClientForm::__reinhardt_view_fields(&runtime);
+		assert_eq!(
+			fields
+				.iter()
+				.map(|field| field.required)
+				.collect::<Vec<_>>(),
+			vec![false; 4]
+		);
+		let request = UnvalidatedClientForm::to_request(&runtime);
+		assert_eq!(
+			(request.text, request.optional, request.flag, request.count),
+			(String::new(), None, false, 0)
+		);
+	});
+}
+
+#[tokio::test]
+async fn request_id_scopes_are_independent_and_default_ids_are_unique_within_a_request() {
+	async fn ids() -> Vec<String> {
+		reinhardt_pages::reactive::hooks::id::scope_id_counter(async {
+            tokio::task::yield_now().await;
+            ReactiveScope::run(|| {
+                let definition = LoginRequestClientForm::new();
+                let runtime = use_form(&definition).build();
+                let mutation = definition.server_mutation(&runtime).build();
+                (0..2).map(|_| {
+                    let page = reinhardt_pages::form! { client_form: LoginRequestClientForm, mutation: &mutation }.into_page();
+                    attr(elements(&page, "form")[0], "id").unwrap().to_owned()
+                }).collect()
+            })
+        }).await
+	}
+	let (first, second) = tokio::join!(ids(), ids());
+	assert_eq!(first, vec!["client-form-0", "client-form-1"]);
+	assert_eq!(first, second);
+}

--- a/crates/reinhardt-pages/tests/client_form_view_facade_compile.rs
+++ b/crates/reinhardt-pages/tests/client_form_view_facade_compile.rs
@@ -1,0 +1,171 @@
+//! Downstream compilation with renamed dependencies and a separate DTO producer crate.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::{fs, path::Path, process::Command};
+use tempfile::TempDir;
+
+#[test]
+fn renamed_pages_and_facade_support_external_dtos_on_native_and_wasm() {
+	run_fixture_checks(false);
+}
+
+#[test]
+#[ignore = "Requires Chrome and a configured wasm-bindgen-test-runner"]
+fn renamed_facade_auth_pages_submit_in_browser() {
+	run_fixture_checks(true);
+}
+
+fn run_fixture_checks(browser: bool) {
+	let pages_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let root = pages_dir
+		.parent()
+		.unwrap()
+		.parent()
+		.unwrap()
+		.canonicalize()
+		.unwrap();
+	let fixture = pages_dir.join("tests/fixtures/named_client_form_auth/src");
+	let workspace = TempDir::new().unwrap();
+	let target = TempDir::new().unwrap();
+	fs::create_dir_all(workspace.path().join("dto/src")).unwrap();
+	fs::create_dir_all(workspace.path().join("app/src")).unwrap();
+	fs::write(
+		workspace.path().join("Cargo.toml"),
+		"[workspace]\nmembers = [\"dto\", \"app\"]\nresolver = \"3\"\n",
+	)
+	.unwrap();
+	fs::copy(
+		fixture.join("dto.rs"),
+		workspace.path().join("dto/src/dto.rs"),
+	)
+	.unwrap();
+	fs::copy(
+		fixture.join("pages.rs"),
+		workspace.path().join("app/src/pages.rs"),
+	)
+	.unwrap();
+	fs::copy(
+		fixture.join("browser.rs"),
+		workspace.path().join("app/src/browser.rs"),
+	)
+	.unwrap();
+	for (source, destination) in [
+		("support/client_form_view_browser.rs", "browser_support.rs"),
+		("fixtures/form_scope.rs", "form_scope.rs"),
+	] {
+		let support = fs::read_to_string(pages_dir.join("tests").join(source))
+			.unwrap()
+			.replace("reinhardt_pages::", "crate::pages_api::");
+		fs::write(workspace.path().join("app/src").join(destination), support).unwrap();
+	}
+	for facade in [false, true] {
+		if browser && !facade {
+			continue;
+		}
+		let (dependency, alias) = if facade {
+			(
+				format!(
+					"rh = {{ package = \"reinhardt-web\", path = {:?}, default-features = false, features = [\"pages\"] }}",
+					root
+				),
+				"rh::pages",
+			)
+		} else {
+			(
+				format!(
+					"pages_dep = {{ package = \"reinhardt-pages\", path = {:?} }}\nreinhardt-core = {{ path = {:?}, default-features = false, features = [\"validators\"] }}",
+					pages_dir,
+					root.join("crates/reinhardt-core")
+				),
+				"pages_dep",
+			)
+		};
+		for (directory, name, extra, module) in [
+			("dto", "auth-dto", String::new(), "dto"),
+			(
+				"app",
+				"auth-app",
+				format!("auth-dto = {{ path = {:?} }}", workspace.path().join("dto")),
+				"pages",
+			),
+		] {
+			let browser_dependencies = if directory == "app" && browser {
+				"\n[target.'cfg(target_arch = \"wasm32\")'.dev-dependencies]\nwasm-bindgen = \"0.2\"\nwasm-bindgen-test = \"0.3\"\njs-sys = \"0.3\"\ngloo-timers = { version = \"0.3\", features = [\"futures\"] }\nweb-sys = { version = \"0.3\", features = [\"Window\", \"Document\", \"Element\", \"HtmlInputElement\", \"HtmlFormElement\", \"HtmlSelectElement\", \"EventInit\"] }\n"
+			} else {
+				""
+			};
+			let manifest = format!(
+				"[package]\nname = \"{name}\"\nversion = \"0.0.0\"\nedition = \"2024\"\npublish = false\n[features]\ntesting = []\n[dependencies]\n{dependency}\nserde = {{ version = \"1\", features = [\"derive\"] }}\nserde_json = \"1\"\n{extra}\n{browser_dependencies}"
+			);
+			if facade {
+				assert!(!manifest.contains("reinhardt-pages"));
+				assert!(!manifest.contains("reinhardt-core"));
+			}
+			fs::write(
+				workspace.path().join(directory).join("Cargo.toml"),
+				manifest,
+			)
+			.unwrap();
+			let browser_module = if directory == "app" && browser {
+				"\n#[cfg(all(test, target_arch = \"wasm32\"))]\nmod browser;\n"
+			} else {
+				""
+			};
+			fs::write(
+				workspace.path().join(directory).join("src/lib.rs"),
+				format!("pub use {alias} as pages_api;\npub mod {module};\n{browser_module}"),
+			)
+			.unwrap();
+		}
+		for wasm in [false, true] {
+			if browser && !wasm {
+				continue;
+			}
+			let mut command =
+				Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+			command
+				.arg(if wasm && !browser { "check" } else { "test" })
+				.args(["--manifest-path"])
+				.arg(workspace.path().join("Cargo.toml"))
+				.args(["-p", "auth-app", "--target-dir"])
+				.arg(target.path())
+				.env_remove("CARGO_TARGET_DIR")
+				// Keep intermediate artifacts under the same RAII directory even
+				// when global Cargo configuration redirects build output or wrappers.
+				.env("CARGO_BUILD_BUILD_DIR", target.path().join("build"))
+				.env("RUSTC_WRAPPER", "");
+			if wasm {
+				command.args(["--target", "wasm32-unknown-unknown"]);
+			}
+			let output = command.arg("--offline").output().unwrap();
+			let output = if output.status.success() || !offline_resolution_failed(&output) {
+				output
+			} else {
+				let mut online = Command::new(command.get_program());
+				online.args(command.get_args().filter(|arg| *arg != "--offline"));
+				for (key, value) in command.get_envs() {
+					if let Some(value) = value {
+						online.env(key, value);
+					} else {
+						online.env_remove(key);
+					}
+				}
+				online.output().unwrap()
+			};
+			assert!(
+				output.status.success(),
+				"facade={facade}, wasm={wasm}, browser={browser}\ncommand: {command:?}\n{}\n{}",
+				String::from_utf8_lossy(&output.stdout),
+				String::from_utf8_lossy(&output.stderr)
+			);
+		}
+	}
+}
+
+fn offline_resolution_failed(output: &std::process::Output) -> bool {
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	stderr.contains("no matching package named")
+		|| stderr.contains("failed to download")
+		|| stderr.contains("attempting to make an HTTP request, but --offline was specified")
+		|| stderr.contains("candidate versions found which didn't match")
+}

--- a/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/browser.rs
+++ b/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/browser.rs
@@ -1,0 +1,73 @@
+//! Browser replacement of handwritten auth controls using external named DTOs.
+
+#[path = "form_scope.rs"]
+mod form_scope;
+#[path = "browser_support.rs"]
+// The shared browser fixture includes helpers for additional in-crate acceptance cases.
+#[allow(dead_code)]
+mod support;
+
+use crate::pages_api::{form, use_form};
+use auth_dto::dto::LoginRequestClientForm;
+use std::{cell::Cell, rc::Rc};
+use support::{BrowserRoot, FetchGuard, wait_for};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn external_auth_views_keep_payloads_callbacks_and_navigation_errors() {
+	form_scope::run(async {
+		// Arrange
+		let fetch = FetchGuard::install();
+		let successes = Rc::new(Cell::new(0));
+		let redirects = Rc::new(Cell::new(0));
+		let definition = LoginRequestClientForm::new();
+		let runtime = use_form(&definition).on_submit_success({
+			let successes = successes.clone();
+			move |_| successes.set(successes.get() + 1)
+		}).build();
+		let mutation = definition.server_mutation(&runtime)
+			.redirect("http://[")
+			.on_redirect_error({
+				let redirects = redirects.clone();
+				move |_| redirects.set(redirects.get() + 1)
+			}).build();
+		let login = BrowserRoot::mount(&form! {
+			client_form: LoginRequestClientForm,
+			mutation: &mutation,
+			customize: {
+				password: { widget: PasswordInput }
+			},
+		}.into_page());
+		let registrations = Rc::new(Cell::new(0));
+		let register = BrowserRoot::mount(&crate::pages::register({
+			let registrations = registrations.clone();
+			move || registrations.set(registrations.get() + 1)
+		}));
+		// Act / Assert
+		login.input("username", "alice");
+		login.input("password", "secret");
+		login.submit();
+		login.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		assert_eq!(fetch.requests()[0]["body"], serde_json::json!({"request":{"username":"alice","password":"secret"}}));
+		fetch.resolve(0, 200, serde_json::json!({"token":"session"}));
+		wait_for(|| redirects.get() == 1).await;
+		assert_eq!(successes.get(), 1);
+		assert_eq!(redirects.get(), 1);
+		assert!(!mutation.is_pending());
+		assert_eq!(registrations.get(), 0);
+		register.input("username", "alice");
+		register.input("email", "alice@example.com");
+		register.input("password", "long-enough-password");
+		register.submit();
+		wait_for(|| fetch.requests().len() == 2).await;
+		assert_eq!(fetch.requests()[1]["body"], serde_json::json!({"request":{"username":"alice","email":"alice@example.com","password":"long-enough-password"}}));
+		fetch.resolve(1, 200, serde_json::json!({"token":"registered"}));
+		wait_for(|| registrations.get() == 1).await;
+		assert_eq!(registrations.get(), 1);
+		assert_eq!(successes.get(), 1);
+		assert_eq!(fetch.requests().len(), 2);
+	}).await;
+}

--- a/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/dto.rs
+++ b/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/dto.rs
@@ -1,0 +1,40 @@
+use crate::pages_api::{
+	client_form,
+	server_fn::{ServerFnError, server_fn},
+};
+use serde::{Deserialize, Serialize};
+
+#[client_form(server_fn = login, validate)]
+#[derive(Clone, Serialize, Deserialize, crate::pages_api::__private::client_form::DtoValidate)]
+pub struct LoginRequest {
+	#[validate(length(min = 1, max = 150))]
+	pub username: String,
+	#[validate(length(min = 1, max = 128))]
+	pub password: String,
+}
+#[client_form(server_fn = register, validate)]
+#[derive(Clone, Serialize, Deserialize, crate::pages_api::__private::client_form::DtoValidate)]
+pub struct RegisterRequest {
+	#[validate(length(min = 3, max = 32))]
+	pub username: String,
+	#[validate(email, length(max = 254))]
+	pub email: String,
+	#[validate(length(min = 8, max = 128))]
+	pub password: String,
+}
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AuthResponse {
+	pub token: String,
+}
+#[server_fn]
+pub async fn login(request: crate::dto::LoginRequest) -> Result<AuthResponse, ServerFnError> {
+	Ok(AuthResponse {
+		token: request.username,
+	})
+}
+#[server_fn]
+pub async fn register(request: crate::dto::RegisterRequest) -> Result<AuthResponse, ServerFnError> {
+	Ok(AuthResponse {
+		token: request.username,
+	})
+}

--- a/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/pages.rs
+++ b/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/pages.rs
@@ -1,0 +1,118 @@
+use crate::pages_api::{component::Page, form, page, use_form};
+use auth_dto::dto::{LoginRequestClientForm, RegisterRequestClientForm};
+
+pub fn handwritten_login(on_success: impl Fn() + 'static) -> Page {
+	let definition = LoginRequestClientForm::new();
+	let runtime = use_form(&definition)
+		.on_submit_success(move |_| on_success())
+		.build();
+	let mutation = definition.server_mutation(&runtime).build();
+	page!({
+		form {
+			novalidate: true,
+			@submit: move |event| {
+				event.prevent_default();
+				mutation.dispatch();
+			},
+			label {
+				r#for: "login-username",
+				"Username"
+			}
+			input {
+				id: "login-username",
+				name: "username",
+				autocomplete: "username",
+				bind: runtime.field(definition.username_field())
+			}
+			label {
+				r#for: "login-password",
+				"Password"
+			}
+			input {
+				id: "login-password",
+				name: "password",
+				type: "password",
+				autocomplete: "current-password",
+				bind: runtime.field(definition.password_field())
+			}
+			button {
+				type: "submit",
+				"Sign in"
+			}
+		}
+	})
+}
+
+pub fn login(on_success: impl Fn() + 'static) -> Page {
+	let definition = LoginRequestClientForm::new();
+	let runtime = use_form(&definition)
+		.on_submit_success(move |_| on_success())
+		.build();
+	let mutation = definition.server_mutation(&runtime).build();
+	form! {
+		client_form: LoginRequestClientForm,
+		mutation: &mutation,
+		id: "login",
+		customize: {
+			username: {
+				label: "Username",
+				autocomplete: "username"
+			},
+			password: {
+				widget: PasswordInput,
+				autocomplete: "current-password"
+			},
+		},
+		submit: {
+			label: "Sign in",
+			pending_label: "Signing in..."
+		},
+	}
+	.into_page()
+}
+pub fn register(on_success: impl Fn() + 'static) -> Page {
+	let definition = RegisterRequestClientForm::new();
+	let runtime = use_form(&definition)
+		.on_submit_success(move |_| on_success())
+		.build();
+	let mutation = definition.server_mutation(&runtime).build();
+	form! {
+		client_form: RegisterRequestClientForm,
+		mutation: &mutation,
+		id: "register",
+		customize: {
+			username: {
+				autocomplete: "username"
+			},
+			email: {
+				widget: EmailInput,
+				autocomplete: "email"
+			},
+			password: {
+				widget: PasswordInput,
+				autocomplete: "new-password"
+			},
+		},
+		submit: {
+			label: "Create account",
+			pending_label: "Creating account..."
+		},
+	}
+	.into_page()
+}
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+	#[test]
+	fn cloud_shaped_pages_render_without_wrapper_endpoints() {
+		crate::pages_api::reactive::ReactiveScope::run(|| {
+			let handwritten = super::handwritten_login(|| {}).render_to_string();
+			let login = super::login(|| {}).render_to_string();
+			let register = super::register(|| {}).render_to_string();
+			assert_eq!(handwritten.matches("name=\"username\"").count(), 1);
+			assert_eq!(handwritten.matches("type=\"password\"").count(), 1);
+			assert_eq!(login.matches("name=\"username\"").count(), 1);
+			assert_eq!(register.matches("type=\"email\"").count(), 1);
+			assert_eq!(register.matches("name=\"password\"").count(), 1);
+		});
+	}
+}

--- a/crates/reinhardt-pages/tests/form_control_hydration_regressions.rs
+++ b/crates/reinhardt-pages/tests/form_control_hydration_regressions.rs
@@ -27,6 +27,42 @@ use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(form_control_hydration_dom)]
+async fn empty_presentation_text_preserves_sibling_alignment_during_hydration() {
+	form_scope::run(async {
+		for text in ["", " ", "\t\n"] {
+			// Arrange
+			let page = PageElement::new("div")
+				.child(Page::text(text))
+				.child(PageElement::new("label").child(Page::text(text)))
+				.child(
+					PageElement::new("select").child(
+						PageElement::new("option")
+							.attr("value", "none")
+							.child(Page::text(text)),
+					),
+				)
+				.child(Page::text("after"))
+				.into_page();
+			let mounted = MountedPage::new();
+			mounted.0.set_inner_html(&page.render_to_string());
+			// Act / Assert
+			assert_eq!(reconcile(&mounted.root(), &page), Ok(()));
+			assert_eq!(
+				reconcile_with_options(&mounted.root(), &page, &ReconcileOptions::default()),
+				Ok(())
+			);
+			assert_eq!(
+				attach_events_to_mounted_view(&mounted.root(), &page),
+				Ok(())
+			);
+		}
+	})
+	.await;
+}
+
 struct MountedPage(web_sys::Element);
 
 impl MountedPage {

--- a/crates/reinhardt-pages/tests/form_control_hydration_regressions.rs
+++ b/crates/reinhardt-pages/tests/form_control_hydration_regressions.rs
@@ -63,6 +63,32 @@ async fn empty_presentation_text_preserves_sibling_alignment_during_hydration() 
 	.await;
 }
 
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(form_control_hydration_dom)]
+async fn pre_whitespace_mismatch_is_not_filtered_during_hydration() {
+	form_scope::run(async {
+		// Arrange: whitespace is meaningful content inside a preformatted element.
+		let page = PageElement::new("pre").child(Page::text("\t")).into_page();
+		let mounted = MountedPage::new();
+		mounted.0.set_inner_html("<pre> </pre>");
+
+		// Act
+		let result = reconcile(&mounted.root(), &page);
+
+		// Assert: a whitespace-only difference remains a hydration mismatch.
+		let Err(ReconcileError::TextMismatch {
+			expected, actual, ..
+		}) = result
+		else {
+			panic!("expected pre text mismatch, got {result:?}");
+		};
+		assert_eq!(expected, "\t");
+		assert_eq!(actual, " ");
+	})
+	.await;
+}
+
 struct MountedPage(web_sys::Element);
 
 impl MountedPage {

--- a/crates/reinhardt-pages/tests/support/client_form_view_browser.rs
+++ b/crates/reinhardt-pages/tests/support/client_form_view_browser.rs
@@ -1,0 +1,245 @@
+//! RAII browser fixtures with private fetch state and retained DOM queries.
+
+use js_sys::{Function, Reflect};
+use reinhardt_pages::component::{Page, PageExt, cleanup_reactive_nodes};
+use reinhardt_pages::dom::Element;
+use wasm_bindgen::{JsCast, JsValue};
+
+pub(crate) fn flush() {
+	reinhardt_pages::reactive::with_runtime(|runtime| runtime.flush_updates());
+}
+
+pub(crate) async fn wait_for(mut ready: impl FnMut() -> bool) {
+	for _ in 0..200 {
+		flush();
+		if ready() {
+			return;
+		}
+		gloo_timers::future::TimeoutFuture::new(0).await;
+	}
+	assert!(ready(), "browser state did not become ready");
+}
+
+pub(crate) struct BrowserRoot(pub(crate) web_sys::Element);
+
+struct HydratedPage(Page);
+
+impl reinhardt_pages::component::Component for HydratedPage {
+	fn render(&self) -> Page {
+		self.0.clone()
+	}
+	fn name() -> &'static str {
+		"ClientFormFixture"
+	}
+}
+
+struct HydrationState(web_sys::Element);
+
+impl Drop for HydrationState {
+	fn drop(&mut self) {
+		self.0.remove();
+	}
+}
+
+#[cfg(feature = "testing")]
+pub(crate) struct RouterGuard {
+	href: String,
+	state: JsValue,
+}
+
+#[cfg(feature = "testing")]
+impl RouterGuard {
+	pub(crate) fn install(router: reinhardt_urls::routers::ClientRouter) -> Self {
+		let window = web_sys::window().unwrap();
+		let guard = Self {
+			href: window.location().href().unwrap(),
+			state: window.history().unwrap().state().unwrap(),
+		};
+		reinhardt_pages::app::__install_client_router_for_test(router);
+		guard
+	}
+}
+
+#[cfg(feature = "testing")]
+impl Drop for RouterGuard {
+	fn drop(&mut self) {
+		reinhardt_pages::app::__clear_spa_router_for_test();
+		web_sys::window()
+			.unwrap()
+			.history()
+			.unwrap()
+			.replace_state_with_url(&self.state, "", Some(&self.href))
+			.unwrap();
+	}
+}
+
+pub(crate) struct EventListenerGuard {
+	target: web_sys::EventTarget,
+	event: &'static str,
+	callback: wasm_bindgen::closure::Closure<dyn Fn(web_sys::Event)>,
+}
+impl EventListenerGuard {
+	pub(crate) fn new(
+		target: &web_sys::EventTarget,
+		event: &'static str,
+		callback: impl Fn(web_sys::Event) + 'static,
+	) -> Self {
+		let callback = wasm_bindgen::closure::Closure::new(callback);
+		target
+			.add_event_listener_with_callback(event, callback.as_ref().unchecked_ref())
+			.unwrap();
+		Self {
+			target: target.clone(),
+			event,
+			callback,
+		}
+	}
+}
+impl Drop for EventListenerGuard {
+	fn drop(&mut self) {
+		self.target
+			.remove_event_listener_with_callback(self.event, self.callback.as_ref().unchecked_ref())
+			.unwrap();
+	}
+}
+impl BrowserRoot {
+	pub(crate) fn new() -> Self {
+		let document = web_sys::window().unwrap().document().unwrap();
+		let root = Self(document.create_element("div").unwrap());
+		document.body().unwrap().append_child(&root.0).unwrap();
+		root
+	}
+	pub(crate) fn mount(page: &Page) -> Self {
+		let root = Self::new();
+		page.clone().mount(&Element::new(root.0.clone())).unwrap();
+		flush();
+		root
+	}
+	pub(crate) fn get<T: JsCast>(&self, selector: &str) -> T {
+		self.0
+			.query_selector(selector)
+			.unwrap()
+			.unwrap_or_else(|| panic!("missing {selector}"))
+			.unchecked_into()
+	}
+	pub(crate) fn input(&self, name: &str, value: &str) -> web_sys::HtmlInputElement {
+		let input: web_sys::HtmlInputElement = self.get(&format!("input[name='{name}']"));
+		input.set_value(value);
+		input
+			.dispatch_event(&web_sys::Event::new("input").unwrap())
+			.unwrap();
+		flush();
+		input
+	}
+	pub(crate) fn select(&self, name: &str, value: &str) {
+		let select: web_sys::HtmlSelectElement = self.get(&format!("select[name='{name}']"));
+		select.set_value(value);
+		select
+			.dispatch_event(&web_sys::Event::new("change").unwrap())
+			.unwrap();
+		flush();
+	}
+	pub(crate) fn submit(&self) {
+		let form: web_sys::HtmlFormElement = self.get("form");
+		let init = web_sys::EventInit::new();
+		init.set_bubbles(true);
+		init.set_cancelable(true);
+		let event = web_sys::Event::new_with_event_init_dict("submit", &init).unwrap();
+		assert!(
+			!form.dispatch_event(&event).unwrap(),
+			"generated submit must prevent navigation"
+		);
+		flush();
+	}
+	pub(crate) fn hydrate(&self, page: &Page) {
+		let document = web_sys::window().unwrap().document().unwrap();
+		let state = HydrationState(document.create_element("script").unwrap());
+		state.0.set_id("ssr-state");
+		state.0.set_attribute("type", "application/json").unwrap();
+		state.0.set_text_content(Some("{}"));
+		self.0.append_child(&state.0).unwrap();
+		let form = Element::new(self.0.first_element_child().unwrap());
+		reinhardt_pages::hydration::hydrate(&HydratedPage(page.clone()), &form).unwrap();
+		flush();
+	}
+}
+impl Drop for BrowserRoot {
+	fn drop(&mut self) {
+		self.0.remove();
+		cleanup_reactive_nodes();
+	}
+}
+
+pub(crate) struct FetchGuard {
+	window: web_sys::Window,
+	previous: JsValue,
+	state: JsValue,
+}
+impl FetchGuard {
+	pub(crate) fn install() -> Self {
+		let window = web_sys::window().unwrap();
+		let previous = Reflect::get(&window, &"fetch".into()).unwrap();
+		let state = Function::new_no_args(r#"
+            const requests = [];
+            const pending = [];
+            return {
+                fetch(request) {
+                    return request.clone().text().then(body => new Promise((resolve, reject) => {
+                        requests.push({path: new URL(request.url).pathname, body: JSON.parse(body)});
+                        pending.push({resolve, reject});
+                    }));
+                },
+                requests() { return JSON.stringify(requests); },
+                resolve(index, status, body) {
+                    const item = pending[index];
+                    pending[index] = null;
+                    item.resolve(new Response(body, {status, headers: {'content-type': 'application/json'}}));
+                },
+                cancel() {
+                    for (const item of pending) if (item) item.reject(new Error('Fixture disposed'));
+                }
+            };
+        "#).call0(&JsValue::NULL).unwrap();
+		Reflect::set(
+			&window,
+			&"fetch".into(),
+			&Reflect::get(&state, &"fetch".into()).unwrap(),
+		)
+		.unwrap();
+		Self {
+			window,
+			previous,
+			state,
+		}
+	}
+	fn method(&self, name: &str) -> Function {
+		Reflect::get(&self.state, &name.into())
+			.unwrap()
+			.unchecked_into()
+	}
+	pub(crate) fn requests(&self) -> Vec<serde_json::Value> {
+		let json = self
+			.method("requests")
+			.call0(&self.state)
+			.unwrap()
+			.as_string()
+			.unwrap();
+		serde_json::from_str(&json).unwrap()
+	}
+	pub(crate) fn resolve(&self, index: usize, status: u16, body: serde_json::Value) {
+		self.method("resolve")
+			.call3(
+				&self.state,
+				&JsValue::from_f64(index as f64),
+				&JsValue::from_f64(f64::from(status)),
+				&serde_json::to_string(&body).unwrap().into(),
+			)
+			.unwrap();
+	}
+}
+impl Drop for FetchGuard {
+	fn drop(&mut self) {
+		Reflect::set(&self.window, &"fetch".into(), &self.previous).unwrap();
+		self.method("cancel").call0(&self.state).unwrap();
+	}
+}

--- a/crates/reinhardt-pages/tests/support/client_form_view_shared.rs
+++ b/crates/reinhardt-pages/tests/support/client_form_view_shared.rs
@@ -1,0 +1,75 @@
+//! DTOs shared by native and browser named-view regression tests.
+
+use reinhardt_pages::server_fn::ServerFnError;
+use reinhardt_pages::{client_form, server_fn::server_fn};
+use serde::{Deserialize, Serialize};
+
+#[client_form(server_fn = login, validate)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, reinhardt_core::Validate)]
+pub struct LoginRequest {
+	#[validate(length(min = 1, max = 150))]
+	pub username: String,
+	#[validate(length(min = 1, max = 128))]
+	pub password: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AuthResponse {
+	pub token: String,
+}
+
+#[client_form(server_fn = register, validate)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, reinhardt_core::Validate)]
+pub struct RegisterRequest {
+	#[validate(length(min = 3, max = 32))]
+	pub username: String,
+	#[validate(email, length(max = 254))]
+	pub email: String,
+	#[validate(length(min = 8, max = 128))]
+	pub password: String,
+}
+
+#[server_fn]
+pub async fn register(
+	request: crate::support::RegisterRequest,
+) -> Result<AuthResponse, ServerFnError> {
+	Ok(AuthResponse {
+		token: request.username,
+	})
+}
+
+#[server_fn]
+pub async fn login(request: crate::support::LoginRequest) -> Result<AuthResponse, ServerFnError> {
+	Ok(AuthResponse {
+		token: request.username,
+	})
+}
+
+#[derive(
+	Clone, Debug, Default, PartialEq, Serialize, Deserialize, reinhardt_pages::ClientFormChoices,
+)]
+pub enum Choice {
+	#[default]
+	#[serde(rename = "")]
+	Empty,
+	Active,
+}
+
+#[client_form(server_fn = save_values)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ValuesRequest {
+	pub text: String,
+	pub notes: String,
+	pub optional_text: Option<String>,
+	pub number: i32,
+	pub optional_number: Option<i32>,
+	pub checked: bool,
+	pub optional_checked: Option<bool>,
+	pub choice: Choice,
+	pub optional_choice: Option<Choice>,
+}
+
+#[server_fn]
+pub async fn save_values(request: crate::support::ValuesRequest) -> Result<String, ServerFnError> {
+	Ok(request.text)
+}

--- a/crates/reinhardt-pages/tests/ui.rs
+++ b/crates/reinhardt-pages/tests/ui.rs
@@ -169,6 +169,18 @@ fn test_client_form_fail() {
 }
 
 #[test]
+fn test_client_form_view_pass() {
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/client_form/view/pass/*.rs");
+}
+
+#[test]
+fn test_client_form_view_fail() {
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/client_form/view/fail/*.rs");
+}
+
+#[test]
 fn test_wasm_server_api_macro_ui_pass() {
 	let t = trybuild::TestCases::new();
 	t.pass("tests/ui/wasm_server_api/pass/*.rs");

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_placeholder.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_placeholder.rs
@@ -1,0 +1,15 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			enabled: {
+				placeholder: "Type"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_placeholder.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_placeholder.stderr
@@ -1,0 +1,21 @@
+error[E0599]: the method `placeholder` exists for struct `reinhardt_pages::client_form::__private::FieldPresentation<reinhardt_pages::client_form::__private::BoolKind>`, but its trait bounds were not satisfied
+  --> tests/ui/client_form/view/fail/bool_placeholder.rs:11:5
+   |
+ 6 |       let _view = form! {
+   |  _________________-
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             enabled: {
+11 | |                 placeholder: "Type"
+   | |                -^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   | |________________|
+   |
+   |
+  ::: src/client_form/view/presentation.rs
+   |
+   |           pub struct $kind;
+   |           ----------------- doesn't satisfy `_: Placeholder`
+   |
+   = note: the following trait bounds were not satisfied:
+           `reinhardt_pages::client_form::__private::BoolKind: client_form::view::presentation::sealed::Placeholder`

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_select_widget.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_select_widget.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			enabled: { widget: Select }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_select_widget.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/bool_select_widget.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `reinhardt_pages::client_form::__private::Select: reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::BoolKind>` is not satisfied
+  --> tests/ui/client_form/view/fail/bool_select_widget.rs:6:14
+   |
+ 6 |       let _view = form! {
+   |  _________________^
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             enabled: { widget: Select }
+   | |                        ------ required by a bound introduced by this call
+11 | |         }
+12 | |     };
+   | |_____^ unsatisfied trait bound
+   |
+   = help: the trait `reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::BoolKind>` is not implemented for `reinhardt_pages::client_form::__private::Select`
+help: `reinhardt_pages::client_form::__private::Select` implements trait `reinhardt_pages::client_form::__private::AllowedWidget<Kind>`
+  --> src/client_form/view/presentation.rs
+   |
+   |           impl AllowedWidget<$kind> for $widget {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::OptionalBoolKind>`
+...
+   | / widgets!(
+   | |     TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+   | |     UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+   | |     CheckboxInput => BoolKind, Select => OptionalBoolKind,
+   | | );
+   | |_- in this macro invocation
+   |   impl<T> sealed::Widget<EnumKind<T>> for Select {}
+   |   impl<T> AllowedWidget<EnumKind<T>> for Select {
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::EnumKind<T>>`
+...
+   |   impl<T> AllowedWidget<OptionalEnumKind<T>> for Select {
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::OptionalEnumKind<T>>`
+note: required by a bound in `reinhardt_pages::client_form::__private::FieldPresentation::<Kind>::widget`
+  --> src/client_form/view/presentation.rs
+   |
+   |     pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `FieldPresentation::<Kind>::widget`
+   = note: this error originates in the macro `widgets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_clause.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_clause.rs
@@ -1,0 +1,12 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		id: "a",
+		id: "b"
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_clause.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_clause.stderr
@@ -1,0 +1,5 @@
+error: duplicate `id` property
+  --> tests/ui/client_form/view/fail/duplicate_clause.rs:10:3
+   |
+10 |         id: "b"
+   |         ^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_field.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_field.rs
@@ -1,0 +1,14 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			text: {},
+			text: {}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_field.stderr
@@ -1,0 +1,5 @@
+error: duplicate `text` field customization
+  --> tests/ui/client_form/view/fail/duplicate_field.rs:11:4
+   |
+11 |             text: {}
+   |             ^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_property.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_property.rs
@@ -1,0 +1,16 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			text: {
+				label: "a",
+				label: "b"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_property.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/duplicate_property.stderr
@@ -1,0 +1,5 @@
+error: duplicate `label` property
+  --> tests/ui/client_form/view/fail/duplicate_property.rs:12:5
+   |
+12 |                 label: "b"
+   |                 ^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_bool_label.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_bool_label.rs
@@ -1,0 +1,15 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			optional_mode: {
+				true_label: "Yes"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_bool_label.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_bool_label.stderr
@@ -1,0 +1,17 @@
+error[E0599]: no method named `true_label` found for struct `reinhardt_pages::client_form::__private::FieldPresentation<reinhardt_pages::client_form::__private::OptionalEnumKind<Mode>>` in the current scope
+  --> tests/ui/client_form/view/fail/enum_bool_label.rs:11:5
+   |
+ 6 |       let _view = form! {
+   |  _________________-
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             optional_mode: {
+11 | |                 true_label: "Yes"
+   | |________________-^^^^^^^^^^
+   |
+help: there is a method `label` with a similar name
+   |
+11 -                 true_label: "Yes"
+11 +                 label: "Yes"
+   |

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_text_widget.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_text_widget.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			mode: { widget: Textarea }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_text_widget.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/enum_text_widget.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `reinhardt_pages::client_form::__private::Textarea: reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::EnumKind<Mode>>` is not satisfied
+  --> tests/ui/client_form/view/fail/enum_text_widget.rs:6:14
+   |
+ 6 |       let _view = form! {
+   |  _________________^
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             mode: { widget: Textarea }
+   | |                     ------ required by a bound introduced by this call
+11 | |         }
+12 | |     };
+   | |_____^ unsatisfied trait bound
+   |
+help: the trait `AllowedWidget<reinhardt_pages::client_form::__private::EnumKind<Mode>>` is not implemented for `reinhardt_pages::client_form::__private::Textarea`
+      but trait `AllowedWidget<reinhardt_pages::client_form::__private::TextKind>` is implemented for it
+  --> src/client_form/view/presentation.rs
+   |
+   |           impl AllowedWidget<$kind> for $widget {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   | / widgets!(
+   | |     TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+   | |     UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+   | |     CheckboxInput => BoolKind, Select => OptionalBoolKind,
+   | | );
+   | |_- in this macro invocation
+   = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::TextKind`, found `reinhardt_pages::client_form::__private::EnumKind<Mode>`
+note: required by a bound in `reinhardt_pages::client_form::__private::FieldPresentation::<Kind>::widget`
+  --> src/client_form/view/presentation.rs
+   |
+   |     pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `FieldPresentation::<Kind>::widget`
+   = note: this error originates in the macro `widgets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/foreign_mutation.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/foreign_mutation.rs
@@ -1,0 +1,14 @@
+include!("../support.rs");
+#[derive(Clone, reinhardt_pages::ClientForm)]
+pub struct Other {
+	pub text: String,
+}
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: OtherClientForm,
+		mutation: &mutation
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/foreign_mutation.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/foreign_mutation.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> tests/ui/client_form/view/fail/foreign_mutation.rs:10:14
+   |
+10 |       let _view = form! {
+   |  _________________^
+11 | |         client_form: OtherClientForm,
+12 | |         mutation: &mutation
+13 | |     };
+   | |     ^
+   | |     |
+   | |_____expected `&FormServerMutation<..., _, ..., _>`, found `&FormServerMutation<..., ..., ..., ...>`
+   |       arguments to this function are incorrect
+   |
+   = note: expected reference `&FormServerMutation<OtherClientForm, _, Other, _>`
+              found reference `&FormServerMutation<RequestClientForm, NoDeps, Request, std::string::String>`
+note: associated function defined here
+  --> tests/ui/client_form/view/fail/foreign_mutation.rs:2:17
+   |
+ 2 | #[derive(Clone, reinhardt_pages::ClientForm)]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `form` which comes from the expansion of the derive macro `reinhardt_pages::ClientForm` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/invalid_id.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/invalid_id.rs
@@ -1,0 +1,11 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		id: "invalid id"
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/invalid_id.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/invalid_id.stderr
@@ -1,0 +1,5 @@
+error: `id` must be nonempty and contain no ASCII whitespace
+ --> tests/ui/client_form/view/fail/invalid_id.rs:9:7
+  |
+9 |         id: "invalid id"
+  |             ^^^^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/number_text_widget.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/number_text_widget.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			count: { widget: TextInput }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/number_text_widget.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/number_text_widget.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `reinhardt_pages::client_form::__private::TextInput: reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::NumberKind>` is not satisfied
+  --> tests/ui/client_form/view/fail/number_text_widget.rs:6:14
+   |
+ 6 |       let _view = form! {
+   |  _________________^
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             count: { widget: TextInput }
+   | |                      ------ required by a bound introduced by this call
+11 | |         }
+12 | |     };
+   | |_____^ unsatisfied trait bound
+   |
+help: the trait `AllowedWidget<reinhardt_pages::client_form::__private::NumberKind>` is not implemented for `reinhardt_pages::client_form::__private::TextInput`
+      but trait `AllowedWidget<reinhardt_pages::client_form::__private::TextKind>` is implemented for it
+  --> src/client_form/view/presentation.rs
+   |
+   |           impl AllowedWidget<$kind> for $widget {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   | / widgets!(
+   | |     TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+   | |     UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+   | |     CheckboxInput => BoolKind, Select => OptionalBoolKind,
+   | | );
+   | |_- in this macro invocation
+   = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::TextKind`, found `reinhardt_pages::client_form::__private::NumberKind`
+note: required by a bound in `reinhardt_pages::client_form::__private::FieldPresentation::<Kind>::widget`
+  --> src/client_form/view/presentation.rs
+   |
+   |     pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `FieldPresentation::<Kind>::widget`
+   = note: this error originates in the macro `widgets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/optional_bool_checkbox.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/optional_bool_checkbox.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			optional_enabled: { widget: CheckboxInput }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/optional_bool_checkbox.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/optional_bool_checkbox.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `reinhardt_pages::client_form::__private::CheckboxInput: reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::OptionalBoolKind>` is not satisfied
+  --> tests/ui/client_form/view/fail/optional_bool_checkbox.rs:6:14
+   |
+ 6 |       let _view = form! {
+   |  _________________^
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             optional_enabled: { widget: CheckboxInput }
+   | |                                 ------ required by a bound introduced by this call
+11 | |         }
+12 | |     };
+   | |_____^ unsatisfied trait bound
+   |
+help: the trait `AllowedWidget<reinhardt_pages::client_form::__private::OptionalBoolKind>` is not implemented for `reinhardt_pages::client_form::__private::CheckboxInput`
+      but trait `AllowedWidget<reinhardt_pages::client_form::__private::BoolKind>` is implemented for it
+  --> src/client_form/view/presentation.rs
+   |
+   |           impl AllowedWidget<$kind> for $widget {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   | / widgets!(
+   | |     TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+   | |     UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+   | |     CheckboxInput => BoolKind, Select => OptionalBoolKind,
+   | | );
+   | |_- in this macro invocation
+   = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::BoolKind`, found `reinhardt_pages::client_form::__private::OptionalBoolKind`
+note: required by a bound in `reinhardt_pages::client_form::__private::FieldPresentation::<Kind>::widget`
+  --> src/client_form/view/presentation.rs
+   |
+   |     pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `FieldPresentation::<Kind>::widget`
+   = note: this error originates in the macro `widgets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/required_empty_label.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/required_empty_label.rs
@@ -1,0 +1,15 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			mode: {
+				empty_label: "Unset"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/required_empty_label.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/required_empty_label.stderr
@@ -1,0 +1,21 @@
+error[E0599]: the method `empty_label` exists for struct `reinhardt_pages::client_form::__private::FieldPresentation<reinhardt_pages::client_form::__private::EnumKind<Mode>>`, but its trait bounds were not satisfied
+  --> tests/ui/client_form/view/fail/required_empty_label.rs:11:5
+   |
+ 6 |       let _view = form! {
+   |  _________________-
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             mode: {
+11 | |                 empty_label: "Unset"
+   | |                -^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   | |________________|
+   |
+   |
+  ::: src/client_form/view/presentation.rs
+   |
+   |   pub struct EnumKind<T>(PhantomData<T>);
+   |   ---------------------- doesn't satisfy `_: OptionalChoice`
+   |
+   = note: the following trait bounds were not satisfied:
+           `reinhardt_pages::client_form::__private::EnumKind<Mode>: client_form::view::presentation::sealed::OptionalChoice`

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/skipped_field.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/skipped_field.rs
@@ -1,0 +1,15 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			internal: {
+				label: "Internal"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/skipped_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/skipped_field.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `__reinhardt_field_internal` found for struct `__RequestClientFormView<Deps, Output>` in the current scope
+  --> tests/ui/client_form/view/fail/skipped_field.rs:10:4
+   |
+ 6 |       let _view = form! {
+   |  _________________-
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             internal: {
+   | |____________-^^^^^^^^
+   |
+  ::: tests/ui/client_form/view/fail/../support.rs
+   |
+   |   #[client_form(server_fn = endpoint)]
+   |   ------------------------------------ method `__reinhardt_field_internal` not found for this struct
+   |
+help: there is a method `__reinhardt_field_text` with a similar name
+   |
+10 -             internal: {
+10 +             __reinhardt_field_text: {
+   |

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/standalone_fields.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/standalone_fields.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		fields: {
+			text: CharField {}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/standalone_fields.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/standalone_fields.stderr
@@ -1,0 +1,5 @@
+error: `fields` is not allowed in a named ClientForm view
+ --> tests/ui/client_form/view/fail/standalone_fields.rs:9:3
+  |
+9 |         fields: {
+  |         ^^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/text_number_widget.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/text_number_widget.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			text: { widget: NumberInput }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/text_number_widget.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/text_number_widget.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `reinhardt_pages::client_form::__private::NumberInput: reinhardt_pages::client_form::__private::AllowedWidget<reinhardt_pages::client_form::__private::TextKind>` is not satisfied
+  --> tests/ui/client_form/view/fail/text_number_widget.rs:6:14
+   |
+ 6 |       let _view = form! {
+   |  _________________^
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             text: { widget: NumberInput }
+   | |                     ------ required by a bound introduced by this call
+11 | |         }
+12 | |     };
+   | |_____^ unsatisfied trait bound
+   |
+help: the trait `AllowedWidget<reinhardt_pages::client_form::__private::TextKind>` is not implemented for `reinhardt_pages::client_form::__private::NumberInput`
+      but trait `AllowedWidget<reinhardt_pages::client_form::__private::NumberKind>` is implemented for it
+  --> src/client_form/view/presentation.rs
+   |
+   |           impl AllowedWidget<$kind> for $widget {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   | / widgets!(
+   | |     TextInput => TextKind, Textarea => TextKind, EmailInput => TextKind,
+   | |     UrlInput => TextKind, PasswordInput => TextKind, NumberInput => NumberKind,
+   | |     CheckboxInput => BoolKind, Select => OptionalBoolKind,
+   | | );
+   | |_- in this macro invocation
+   = help: for that trait implementation, expected `reinhardt_pages::client_form::__private::NumberKind`, found `reinhardt_pages::client_form::__private::TextKind`
+note: required by a bound in `reinhardt_pages::client_form::__private::FieldPresentation::<Kind>::widget`
+  --> src/client_form/view/presentation.rs
+   |
+   |     pub fn widget<W: AllowedWidget<Kind>>(mut self, _: W) -> Self {
+   |                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `FieldPresentation::<Kind>::widget`
+   = note: this error originates in the macro `widgets` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/trailing_tokens.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/trailing_tokens.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		submit: {
+			label: "Submit" trailing
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/trailing_tokens.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/trailing_tokens.stderr
@@ -1,0 +1,5 @@
+error: expected `,`
+  --> tests/ui/client_form/view/fail/trailing_tokens.rs:10:20
+   |
+10 |             label: "Submit" trailing
+   |                             ^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/unknown_field.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/unknown_field.rs
@@ -1,0 +1,15 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			unknown: {
+				label: "Unknown"
+			}
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/unknown_field.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/unknown_field.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `__reinhardt_field_unknown` found for struct `__RequestClientFormView<Deps, Output>` in the current scope
+  --> tests/ui/client_form/view/fail/unknown_field.rs:10:4
+   |
+ 6 |       let _view = form! {
+   |  _________________-
+ 7 | |         client_form: RequestClientForm,
+ 8 | |         mutation: &mutation,
+ 9 | |         customize: {
+10 | |             unknown: {
+   | |____________-^^^^^^^
+   |
+  ::: tests/ui/client_form/view/fail/../support.rs
+   |
+   |   #[client_form(server_fn = endpoint)]
+   |   ------------------------------------ method `__reinhardt_field_unknown` not found for this struct
+   |
+help: there is a method `__reinhardt_field_count` with a similar name
+   |
+10 -             unknown: {
+10 +             __reinhardt_field_count: {
+   |

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/validation_override.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/validation_override.rs
@@ -1,0 +1,13 @@
+include!("../support.rs");
+fn main() {
+	let definition = RequestClientForm::new();
+	let runtime = use_form(&definition).build();
+	let mutation = definition.server_mutation(&runtime).build();
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: &mutation,
+		customize: {
+			text: { maxlength: 10 }
+		}
+	};
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/validation_override.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/validation_override.stderr
@@ -1,0 +1,5 @@
+error: unknown field presentation property `maxlength`
+  --> tests/ui/client_form/view/fail/validation_override.rs:10:12
+   |
+10 |             text: { maxlength: 10 }
+   |                     ^^^^^^^^^

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/wrong_input.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/wrong_input.rs
@@ -1,0 +1,12 @@
+include!("../support.rs");
+fn incompatible<Deps: Clone + PartialEq + 'static>(
+	mutation: &reinhardt_pages::FormServerMutation<RequestClientForm, Deps, String, String>,
+) {
+	let _view = form! {
+		client_form: RequestClientForm,
+		mutation: mutation
+	};
+}
+fn main() {
+	let _ = use_form::<RequestClientForm>;
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/fail/wrong_input.stderr
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/fail/wrong_input.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+ --> tests/ui/client_form/view/fail/wrong_input.rs:5:14
+  |
+5 |       let _view = form! {
+  |  _________________^
+6 | |         client_form: RequestClientForm,
+7 | |         mutation: mutation
+8 | |     };
+  | |     ^
+  | |     |
+  | |_____expected `&FormServerMutation<..., _, ..., _>`, found `&FormServerMutation<..., ..., ..., ...>`
+  |       arguments to this function are incorrect
+  |
+  = note: expected reference `&FormServerMutation<RequestClientForm, _, Request, _>`
+             found reference `&FormServerMutation<RequestClientForm, Deps, std::string::String, std::string::String>`
+note: associated function defined here
+ --> tests/ui/client_form/view/fail/../support.rs
+  |
+  | #[client_form(server_fn = endpoint)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `form` which comes from the expansion of the attribute macro `client_form` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/reinhardt-pages/tests/ui/client_form/view/pass/all_presentations.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/pass/all_presentations.rs
@@ -1,0 +1,51 @@
+include!("../support.rs");
+fn main() {
+	reinhardt_pages::reactive::ReactiveScope::run(|| {
+		let definition = RequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let _page = form! {
+			client_form: RequestClientForm,
+			mutation: &mutation,
+			id: "typed",
+			customize: {
+				text: {
+					widget: Textarea,
+					placeholder: "Text",
+					autocomplete: "off",
+					aria_label: "Text"
+				},
+				count: {
+					widget: NumberInput,
+					placeholder: "Count"
+				},
+				enabled: { widget: CheckboxInput },
+				optional_enabled: {
+					widget: Select,
+					empty_label: "Unset",
+					false_label: "No",
+					true_label: "Yes"
+				},
+				mode: { widget: Select },
+				optional_mode: {
+					empty_label: "Unset"
+				},
+				id: {
+					label: "ID"
+				},
+				submit: {
+					label: "Submit"
+				},
+				mutation: {
+					label: "Mutation"
+				},
+			},
+			submit: {
+				label: "Save",
+				pending_label: "Saving",
+				class: ""
+			},
+		}
+		.into_page();
+	});
+}

--- a/crates/reinhardt-pages/tests/ui/client_form/view/support.rs
+++ b/crates/reinhardt-pages/tests/ui/client_form/view/support.rs
@@ -1,0 +1,33 @@
+use reinhardt_pages::server_fn::{ServerFnError, server_fn};
+use reinhardt_pages::{ClientFormChoices, client_form, form, use_form};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, ClientFormChoices)]
+pub enum Mode {
+	#[default]
+	#[serde(rename = "")]
+	Empty,
+	Active,
+}
+
+#[client_form(server_fn = endpoint)]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Request {
+	pub text: String,
+	pub count: Option<i32>,
+	pub enabled: bool,
+	pub optional_enabled: Option<bool>,
+	pub mode: Mode,
+	pub optional_mode: Option<Mode>,
+	pub id: String,
+	pub submit: String,
+	pub mutation: String,
+	#[client_form(skip)]
+	pub internal: u32,
+}
+
+#[server_fn]
+pub async fn endpoint(request: crate::Request) -> Result<String, ServerFnError> {
+	let text = request.text;
+	Ok(text)
+}

--- a/crates/reinhardt-pages/tests/wasm/client_form_view_wasm_test.rs
+++ b/crates/reinhardt-pages/tests/wasm/client_form_view_wasm_test.rs
@@ -1,0 +1,841 @@
+//! Browser acceptance for named ClientForm views and their existing runtime.
+#![cfg(wasm)]
+
+#[path = "../support/client_form_view_browser.rs"]
+mod browser;
+#[path = "../fixtures/form_scope.rs"]
+mod form_scope;
+#[path = "../support/client_form_view_shared.rs"]
+pub mod support;
+
+use browser::{BrowserRoot, EventListenerGuard, FetchGuard, RouterGuard, flush, wait_for};
+use reinhardt_pages::reactive::{Effect, EffectTiming, ReactiveScope};
+use reinhardt_pages::{FieldError, FormRuntimeSource, form, use_form};
+use serial_test::serial;
+use std::{
+	cell::{Cell, RefCell},
+	rc::Rc,
+};
+use support::{Choice, LoginRequest, LoginRequestClientForm, ValuesRequestClientForm};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[reinhardt_pages::client_form]
+#[derive(Clone, serde::Serialize, reinhardt_core::Validate)]
+struct UnvalidatedRequest {
+	#[validate(length(min = 1, max = 150))]
+	username: String,
+}
+
+#[reinhardt_pages::client_form(validate)]
+#[derive(Clone, serde::Serialize, reinhardt_core::Validate)]
+struct CustomMessageRequest {
+	#[validate(length(
+		min = 1,
+		max = 150,
+		message = "Choose a username of 1 to 150 characters"
+	))]
+	username: String,
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn generated_views_preserve_validation_opt_in_and_custom_messages() {
+	form_scope::run(async {
+		// Arrange: the same DTO length rule is inactive until the form opts in.
+		let submitted = Rc::new(RefCell::new(Vec::new()));
+		let definition = UnvalidatedRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = reinhardt_pages::use_server_mutation({
+			let submitted = submitted.clone();
+			move |request: UnvalidatedRequest| {
+				submitted.borrow_mut().push(request.username);
+				async { Ok::<_, reinhardt_pages::server_fn::ServerFnError>(()) }
+			}
+		})
+		.with_generated_form(&runtime, |runtime| {
+			Ok(UnvalidatedRequestClientForm::to_request(runtime))
+		})
+		.build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: UnvalidatedRequestClientForm,
+				mutation: &mutation,
+			}
+			.into_page(),
+		);
+
+		// Act / Assert
+		let username = root.input("username", &"😀".repeat(151));
+		assert_eq!(username.get_attribute("required"), None);
+		root.submit();
+		wait_for(|| !mutation.is_pending()).await;
+		assert_eq!(*submitted.borrow(), ["😀".repeat(151)]);
+		assert_eq!(
+			runtime.get_field_state(definition.username_field()).error,
+			None
+		);
+		drop(root);
+
+		// Arrange: opting in retains the existing validator error formatting.
+		let definition = CustomMessageRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = reinhardt_pages::use_server_mutation({
+			let submitted = submitted.clone();
+			move |request: CustomMessageRequest| {
+				submitted.borrow_mut().push(request.username);
+				async { Ok::<_, reinhardt_pages::server_fn::ServerFnError>(()) }
+			}
+		})
+		.with_generated_form(&runtime, |runtime| {
+			Ok(CustomMessageRequestClientForm::to_request(runtime))
+		})
+		.build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: CustomMessageRequestClientForm,
+				mutation: &mutation,
+			}
+			.into_page(),
+		);
+
+		// Act / Assert
+		root.input("username", &"😀".repeat(151));
+		root.submit();
+		assert_eq!(submitted.borrow().len(), 1);
+		assert_eq!(
+			runtime
+				.get_field_state(definition.username_field())
+				.error
+				.as_ref()
+				.map(FieldError::message),
+			Some("Custom validation error: Choose a username of 1 to 150 characters")
+		);
+		assert_eq!(
+			root.get::<web_sys::Element>("[aria-live] a")
+				.text_content()
+				.as_deref(),
+			Some("Custom validation error: Choose a username of 1 to 150 characters")
+		);
+		root.input("username", &"😀".repeat(150));
+		root.submit();
+		wait_for(|| !mutation.is_pending()).await;
+		assert_eq!(*submitted.borrow(), ["😀".repeat(151), "😀".repeat(150)]);
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn configured_success_reset_invalidation_and_navigation_each_run_once() {
+	form_scope::run(async {
+		use reinhardt_pages::component::Page;
+		use reinhardt_pages::reactive::{QueryClient, QueryDefaults, QueryFamily, QueryOptions};
+		// Arrange
+		let fetch = FetchGuard::install();
+		let navigations = Rc::new(Cell::new(0));
+		let router = reinhardt_urls::routers::ClientRouter::new()
+			.route("home", "/", || Page::text("Home"))
+			.route("complete", "/client-form-complete", || {
+				Page::text("Complete")
+			});
+		let _navigation = router.on_navigate({
+			let navigations = navigations.clone();
+			move |path, _| {
+				assert_eq!(path, "/client-form-complete");
+				navigations.set(navigations.get() + 1);
+			}
+		});
+		let _router = RouterGuard::install(router);
+		let client = QueryClient::new(QueryDefaults::default());
+		let query = QueryFamily::<(), String, String>::new("client-form-view.auth");
+		let queries = Rc::new(Cell::new(0));
+		let _query = client.observe_for_test(
+			query.query((), {
+				let queries = queries.clone();
+				move || {
+					queries.set(queries.get() + 1);
+					async { Ok(String::from("auth")) }
+				}
+			}),
+			QueryOptions::new(),
+		);
+		wait_for(|| queries.get() == 1).await;
+		let successes = Rc::new(Cell::new(0));
+		let definition = LoginRequestClientForm::new();
+		let runtime = use_form(&definition)
+			.on_submit_success({
+				let successes = successes.clone();
+				move |_| successes.set(successes.get() + 1)
+			})
+			.build();
+		let mutation = definition
+			.server_mutation(&runtime)
+			.invalidate(client, query.key(()))
+			.redirect("/client-form-complete")
+			.reset_form_on_success()
+			.build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+			}
+			.into_page(),
+		);
+		root.input("username", "alice");
+		root.input("password", "secret");
+		// Act
+		root.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		fetch.resolve(0, 200, serde_json::json!({"token":"session"}));
+		wait_for(|| !mutation.is_pending()).await;
+		wait_for(|| queries.get() == 2 && navigations.get() == 1).await;
+		// Assert
+		assert_eq!(successes.get(), 1);
+		assert_eq!(queries.get(), 2);
+		assert_eq!(navigations.get(), 1);
+		assert_eq!(runtime.get_values().username, "");
+		assert_eq!(
+			root.get::<web_sys::HtmlInputElement>("input[name=username]")
+				.value(),
+			""
+		);
+		assert_eq!(
+			reinhardt_pages::app::__current_path_for_test().as_deref(),
+			Some("/client-form-complete")
+		);
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn pending_submission_retains_nodes_focus_selection_and_callbacks() {
+	form_scope::run(async {
+		// Arrange
+		let fetch = FetchGuard::install();
+		let callbacks = Rc::new(RefCell::new(Vec::new()));
+		let definition = LoginRequestClientForm::new();
+		let runtime = use_form(&definition)
+			.on_submit_success({
+				let callbacks = callbacks.clone();
+				move |_| callbacks.borrow_mut().push("runtime")
+			})
+			.build();
+		let mutation = definition
+			.server_mutation(&runtime)
+			.on_success({
+				let callbacks = callbacks.clone();
+				move |_| callbacks.borrow_mut().push("mutation")
+			})
+			.build();
+		let page = form! {
+			client_form: LoginRequestClientForm,
+			mutation: &mutation,
+			id: "login",
+			customize: {
+				password: { widget: PasswordInput }
+			},
+			submit: {
+				label: "Sign in",
+				pending_label: "Signing in..."
+			},
+		}
+		.into_page();
+		let root = BrowserRoot::mount(&page);
+		let second = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+				id: "second"
+			}
+			.into_page(),
+		);
+		let username = root.input("username", "alice");
+		root.input("password", "secret");
+		username.focus().unwrap();
+		username.set_selection_range(1, 3).unwrap();
+		let button: web_sys::HtmlButtonElement = root.get("button");
+		// Act
+		root.submit();
+		second.submit();
+		root.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		// Assert
+		assert_eq!(
+			fetch.requests()[0]["body"],
+			serde_json::json!({"request": {"username": "alice", "password": "secret"}})
+		);
+		assert!(mutation.is_pending());
+		assert!(button.disabled());
+		assert_eq!(button.text_content().as_deref(), Some("Signing in..."));
+		assert!(button.is_same_node(Some(&root.get::<web_sys::Node>("button"))));
+		assert!(username.is_same_node(Some(&root.get::<web_sys::Node>("input[name=username]"))));
+		assert_eq!(username.selection_start().unwrap(), Some(1));
+		assert_eq!(username.selection_end().unwrap(), Some(3));
+		assert!(
+			username.is_same_node(
+				web_sys::window()
+					.unwrap()
+					.document()
+					.unwrap()
+					.active_element()
+					.as_ref()
+					.map(|element| element.as_ref())
+			)
+		);
+		fetch.resolve(0, 200, serde_json::json!({"token":"session"}));
+		wait_for(|| !mutation.is_pending()).await;
+		assert_eq!(*callbacks.borrow(), vec!["runtime", "mutation"]);
+		assert!(!button.disabled());
+		assert_eq!(button.text_content().as_deref(), Some("Sign in"));
+		assert_eq!(fetch.requests().len(), 1);
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn native_controls_submit_one_typed_dto_including_optional_choices() {
+	form_scope::run(async {
+		let fetch = FetchGuard::install();
+		let definition = ValuesRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: ValuesRequestClientForm,
+				mutation: &mutation,
+				id: "values",
+				customize: {
+					notes: { widget: Textarea },
+					optional_checked: {
+						empty_label: "Unset",
+						true_label: "Yes",
+						false_label: "No"
+					}
+				},
+			}
+			.into_page(),
+		);
+		root.input("text", "hello");
+		let notes: web_sys::HtmlTextAreaElement = root.get("textarea");
+		notes.set_value("\nnotes");
+		notes
+			.dispatch_event(&web_sys::Event::new("input").unwrap())
+			.unwrap();
+		root.input("optional_text", "  trimmed  ");
+		root.input("number", "12");
+		root.input("optional_number", "1.5");
+		assert_eq!(runtime.get_values().optional_number, None);
+		assert!(
+			definition
+				.runtime_custom_widget_error(definition.optional_number_field())
+				.is_some()
+		);
+		root.submit();
+		assert_eq!(fetch.requests(), Vec::<serde_json::Value>::new());
+		root.input("optional_number", "7");
+		let checked: web_sys::HtmlInputElement = root.get("input[name=checked]");
+		checked.set_checked(true);
+		checked
+			.dispatch_event(&web_sys::Event::new("change").unwrap())
+			.unwrap();
+		for (token, expected) in [
+			("choice:0", Some(false)),
+			("choice:1", Some(true)),
+			("none", None),
+		] {
+			root.select("optional_checked", token);
+			assert_eq!(runtime.get_values().optional_checked, expected);
+		}
+		root.select("optional_checked", "choice:0");
+		root.select("choice", "choice:1");
+		root.select("optional_choice", "choice:0");
+		assert_eq!(runtime.get_values().optional_choice, Some(Choice::Empty));
+		root.select("optional_choice", "none");
+		assert_eq!(runtime.get_values().optional_choice, None);
+		root.select("optional_choice", "choice:0");
+		root.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		assert_eq!(
+			fetch.requests()[0]["body"],
+			serde_json::json!({"request": {
+				"text":"hello","notes":"\nnotes","optional_text":"trimmed","number":12,"optional_number":7,
+				"checked":true,"optional_checked":false,"choice":"Active","optional_choice":""
+			}})
+		);
+		fetch.resolve(0, 200, serde_json::json!("saved"));
+		wait_for(|| !mutation.is_pending()).await;
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn validation_regions_are_ordered_escaped_and_link_to_retained_controls() {
+	form_scope::run(async {
+        let fetch = FetchGuard::install();
+        let definition = LoginRequestClientForm::new();
+        let runtime = use_form(&definition).build();
+        let mutation = definition.server_mutation(&runtime).build();
+        let root = BrowserRoot::mount(&form! {
+	client_form: LoginRequestClientForm,
+	mutation: &mutation,
+	id: "errors",
+	customize: {
+		username: {
+			help_text: "Visible help",
+			aria_describedby: "external errors-help-0"
+		}
+	},
+}.into_page());
+        root.submit();
+        assert_eq!(fetch.requests(), Vec::<serde_json::Value>::new());
+        let username: web_sys::HtmlInputElement = root.get("input[name=username]");
+        assert_eq!(username.get_attribute("aria-invalid").as_deref(), Some("true"));
+        assert_eq!(username.get_attribute("aria-describedby").as_deref(), Some("errors-help-0 errors-error-0 external"));
+        root.input("username", "alice");
+        root.input("password", "secret");
+        root.submit();
+        wait_for(|| fetch.requests().len() == 1).await;
+        fetch.resolve(0, 422, serde_json::json!({
+            "version":1,"kind":"validation","status":422,"message":"Validation failed",
+            "field_errors":[{"field":"password","message":"<password>"},{"field":"username","message":"<username>"},{"field":"unknown","message":"unmatched"}]
+        }));
+        wait_for(|| !mutation.is_pending()).await;
+        let summary: web_sys::Element = root.get("#errors-summary");
+        let links = summary.query_selector_all("a").unwrap();
+        assert_eq!(links.length(), 2);
+        assert_eq!(links.item(0).unwrap().text_content().as_deref(), Some("<username>"));
+        assert_eq!(links.item(1).unwrap().text_content().as_deref(), Some("<password>"));
+        assert_eq!(summary.query_selector_all("username, password").unwrap().length(), 0);
+        assert_eq!(root.0.query_selector_all("[aria-live]").unwrap().length(), 1);
+        assert_eq!(runtime.form_state().form_error.get().as_deref(), Some("Validation failed\nunknown: unmatched"));
+        root.get::<web_sys::HtmlElement>("#errors-summary a").click();
+        assert_eq!(web_sys::window().unwrap().document().unwrap().active_element().unwrap().id(), "errors-field-0");
+        runtime.clear_errors();
+        flush();
+        assert_eq!(summary.text_content().as_deref(), Some(""));
+        assert_eq!(username.get_attribute("aria-invalid"), None);
+    }).await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn native_reset_batches_bookkeeping_and_respects_cancellation_and_later_writes() {
+	form_scope::run(async {
+		let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+			username: "initial".into(),
+			password: "secret".into(),
+		});
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+				id: "reset"
+			}
+			.into_page(),
+		);
+		let second = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+				id: "reset-second",
+			}
+			.into_page(),
+		);
+		root.input("username", "changed");
+		root.input("password", "changed");
+		runtime.set_error(definition.username_field(), FieldError::new("Invalid"));
+		let bookkeeping = Rc::new(Cell::new(0));
+		let state = runtime.form_state();
+		let _effect = Effect::new_with_timing(
+			{
+				let bookkeeping = bookkeeping.clone();
+				move || {
+					let _ = state.is_touched.get();
+					bookkeeping.set(bookkeeping.get() + 1);
+				}
+			},
+			EffectTiming::Layout,
+		);
+		bookkeeping.set(0);
+		let form: web_sys::HtmlFormElement = root.get("form");
+		let previous_epoch = definition.runtime_native_reset_epoch();
+		assert!(runtime.form_state().is_touched.get());
+		form.reset();
+		assert_eq!(
+			root.get::<web_sys::HtmlInputElement>("input[name=username]")
+				.value(),
+			"initial"
+		);
+		wait_for(|| definition.runtime_native_reset_epoch() != previous_epoch).await;
+		assert!(!runtime.form_state().is_touched.get());
+		assert_eq!(runtime.get_values().username, "initial");
+		assert_eq!(runtime.get_values().password, "secret");
+		assert_eq!(
+			runtime.form_state().field_errors.get(),
+			std::collections::HashMap::new()
+		);
+		assert_eq!(bookkeeping.get(), 1);
+		assert_eq!(
+			second
+				.get::<web_sys::HtmlInputElement>("input[name=username]")
+				.value(),
+			"initial"
+		);
+		root.input("username", "before-cancel");
+		let cancel =
+			EventListenerGuard::new(form.as_ref(), "reset", |event| event.prevent_default());
+		form.reset();
+		gloo_timers::future::TimeoutFuture::new(0).await;
+		flush();
+		assert_eq!(runtime.get_values().username, "before-cancel");
+		drop(cancel);
+		form.reset();
+		runtime.set_value(definition.username_field(), String::from("later"));
+		gloo_timers::future::TimeoutFuture::new(0).await;
+		flush();
+		assert_eq!(runtime.get_values().username, "later");
+		root.input("username", "edited");
+		form.reset();
+		runtime.reset_field(definition.username_field());
+		gloo_timers::future::TimeoutFuture::new(0).await;
+		flush();
+		assert_eq!(runtime.get_values().username, "initial");
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+fn hydration_preserves_pre_hydration_edits_and_password_omission() {
+	ReactiveScope::run(|| {
+		let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+			username: "initial".into(),
+			password: "secret".into(),
+		});
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let page = form! {
+			client_form: LoginRequestClientForm,
+			mutation: &mutation,
+			id: "hydrate",
+			customize: {
+				password: { widget: PasswordInput }
+			}
+		}
+		.into_page();
+		let root = BrowserRoot::new();
+		let html = page.render_to_string();
+		assert_eq!(html.matches("secret").count(), 0);
+		root.0.set_inner_html(&html);
+		let username: web_sys::HtmlInputElement = root.get("input[name=username]");
+		let password: web_sys::HtmlInputElement = root.get("input[name=password]");
+		assert_eq!(password.value(), "");
+		username.set_value("typed-before-hydration");
+		password.set_value("browser-password");
+		root.hydrate(&page);
+		assert_eq!(runtime.get_values().username, "typed-before-hydration");
+		assert_eq!(runtime.get_values().password, "browser-password");
+		root.input("username", "after-hydration");
+		assert_eq!(runtime.get_values().username, "after-hydration");
+		runtime.set_error(
+			definition.username_field(),
+			FieldError::new("After hydration"),
+		);
+		flush();
+		assert_eq!(
+			root.get::<web_sys::Element>("#hydrate-error-0")
+				.text_content()
+				.as_deref(),
+			Some("After hydration")
+		);
+		assert_eq!(
+			root.get::<web_sys::Element>("#hydrate-summary a")
+				.text_content()
+				.as_deref(),
+			Some("After hydration")
+		);
+		assert!(username.is_same_node(Some(&root.get::<web_sys::Node>("input[name=username]"))));
+	});
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn unicode_length_uses_dto_validation_instead_of_html_utf16_limits() {
+	form_scope::run(async {
+		let fetch = FetchGuard::install();
+		let definition = LoginRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+				id: "unicode"
+			}
+			.into_page(),
+		);
+		let username = root.input("username", &"😀".repeat(151));
+		root.input("password", "secret");
+		assert_eq!(username.get_attribute("maxlength"), None);
+		root.submit();
+		assert_eq!(fetch.requests(), Vec::<serde_json::Value>::new());
+		assert_eq!(
+			runtime
+				.get_field_state(definition.username_field())
+				.error
+				.as_ref()
+				.map(FieldError::message),
+			Some("Length too long: 151 (maximum: 150)")
+		);
+		root.input("username", &"😀".repeat(150));
+		root.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		assert_eq!(
+			fetch.requests()[0]["body"]["request"]["username"]
+				.as_str()
+				.unwrap()
+				.chars()
+				.count(),
+			150
+		);
+		fetch.resolve(0, 200, serde_json::json!({"token":"ok"}));
+		wait_for(|| !mutation.is_pending()).await;
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn disposed_views_ignore_pending_responses_and_deferred_resets() {
+	let fetch = FetchGuard::install();
+	let callbacks = Rc::new(Cell::new(0));
+	let scope = ReactiveScope::new();
+	let (root, source) = scope.enter(|| {
+		let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+			username: "alice".into(),
+			password: "secret".into(),
+		});
+		let runtime = use_form(&definition)
+			.on_submit_success({
+				let callbacks = callbacks.clone();
+				move |_| callbacks.set(callbacks.get() + 1)
+			})
+			.build();
+		let source = runtime.watch_field::<String>(definition.username_field());
+		let mutation = definition.server_mutation(&runtime).build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &mutation,
+				id: "dispose"
+			}
+			.into_page(),
+		);
+		root.submit();
+		(root, source)
+	});
+	wait_for(|| fetch.requests().len() == 1).await;
+	root.get::<web_sys::HtmlFormElement>("form").reset();
+	drop(scope);
+	drop(root);
+	fetch.resolve(0, 200, serde_json::json!({"token":"late"}));
+	gloo_timers::future::TimeoutFuture::new(0).await;
+	gloo_timers::future::TimeoutFuture::new(0).await;
+	assert_eq!(callbacks.get(), 0);
+	assert!(source.try_get_untracked().is_err());
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn response_clones_match_the_existing_mutation_without_a_view() {
+	form_scope::run(async {
+		struct Counted(Rc<Cell<usize>>);
+		impl Clone for Counted {
+			fn clone(&self) -> Self {
+				self.0.set(self.0.get() + 1);
+				Self(self.0.clone())
+			}
+		}
+		let mut counts = Vec::new();
+		for render in [false, true] {
+			let clones = Rc::new(Cell::new(0));
+			let definition = LoginRequestClientForm::new().with_defaults(LoginRequest {
+				username: "alice".into(),
+				password: "secret".into(),
+			});
+			let runtime = use_form(&definition).build();
+			let mutation = reinhardt_pages::use_server_mutation({
+				let clones = clones.clone();
+				move |_: LoginRequest| {
+					let clones = clones.clone();
+					async move { Ok::<_, reinhardt_pages::server_fn::ServerFnError>(Counted(clones)) }
+				}
+			})
+			.with_generated_form(&runtime, |runtime| {
+				Ok(LoginRequestClientForm::to_request(runtime))
+			})
+			.build();
+			let root = render.then(|| {
+				BrowserRoot::mount(
+					&form! {
+						client_form: LoginRequestClientForm,
+						mutation: &mutation
+					}
+					.into_page(),
+				)
+			});
+			assert_eq!(clones.get(), 0);
+			if let Some(root) = &root {
+				root.submit();
+			} else {
+				mutation.dispatch();
+			}
+			wait_for(|| !mutation.is_pending()).await;
+			counts.push(clones.get());
+			drop(root);
+		}
+		assert_eq!(counts[0], counts[1]);
+		assert!(counts[0] > 0, "the baseline includes response storage");
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn textarea_hydration_and_source_preferred_fields_keep_reset_defaults() {
+	form_scope::run(async {
+		let definition = ValuesRequestClientForm::new();
+		let runtime = use_form(&definition).build();
+		let mut defaults = ValuesRequestClientForm::to_request(&runtime);
+		defaults.notes = String::from("\nnotes");
+		let definition = ValuesRequestClientForm::new().with_defaults(defaults);
+		let runtime = use_form(&definition).build();
+		let mutation = definition.server_mutation(&runtime).build();
+		let page = form! {
+			client_form: ValuesRequestClientForm,
+			mutation: &mutation,
+			id: "textarea",
+			customize: {
+				notes: { widget: Textarea }
+			}
+		}
+		.into_page();
+		let root = BrowserRoot::new();
+		root.0.set_inner_html(&page.render_to_string());
+		let notes: web_sys::HtmlTextAreaElement = root.get("textarea");
+		assert_eq!(notes.value(), "\nnotes");
+		notes.set_value("browser-edit");
+		runtime.reset_field(definition.notes_field());
+		root.hydrate(&page);
+		assert_eq!(notes.value(), "\nnotes");
+		assert_eq!(runtime.get_values().notes, "\nnotes");
+		notes.set_value("after");
+		notes
+			.dispatch_event(&web_sys::Event::new("input").unwrap())
+			.unwrap();
+		assert_eq!(runtime.get_values().notes, "after");
+		root.get::<web_sys::HtmlFormElement>("form").reset();
+		wait_for(|| runtime.get_values().notes == "\nnotes").await;
+		assert_eq!(notes.default_value().unwrap(), "\nnotes");
+	})
+	.await;
+}
+
+#[rstest::rstest]
+#[test_attr(wasm_bindgen_test)]
+#[serial(client_form_view_dom)]
+async fn cloud_shaped_registration_keeps_named_payload_and_independent_login_state() {
+	form_scope::run(async {
+		let fetch = FetchGuard::install();
+		let registered = Rc::new(Cell::new(0));
+		let registration = support::RegisterRequestClientForm::new();
+		let runtime = use_form(&registration)
+			.on_submit_success({
+				let registered = registered.clone();
+				move |_| registered.set(registered.get() + 1)
+			})
+			.build();
+		let mutation = registration.server_mutation(&runtime).build();
+		let root = BrowserRoot::mount(
+			&form! {
+				client_form: support::RegisterRequestClientForm,
+				mutation: &mutation,
+				customize: {
+					username: {
+						autocomplete: "username"
+					},
+					email: {
+						widget: EmailInput,
+						autocomplete: "email"
+					},
+					password: {
+						widget: PasswordInput,
+						autocomplete: "new-password"
+					},
+				},
+				submit: {
+					label: "Create account",
+					pending_label: "Creating account..."
+				},
+			}
+			.into_page(),
+		);
+		let login = LoginRequestClientForm::new();
+		let login_runtime = use_form(&login).build();
+		let login_mutation = login.server_mutation(&login_runtime).build();
+		let other = BrowserRoot::mount(
+			&form! {
+				client_form: LoginRequestClientForm,
+				mutation: &login_mutation
+			}
+			.into_page(),
+		);
+		assert_ne!(
+			root.get::<web_sys::Element>("form").id(),
+			other.get::<web_sys::Element>("form").id()
+		);
+		root.input("username", "ab");
+		root.input("email", "invalid");
+		root.input("password", "short");
+		root.submit();
+		assert_eq!(fetch.requests().len(), 0);
+		assert_eq!(runtime.form_state().field_errors.get().len(), 3);
+		assert_eq!(login_runtime.form_state().field_errors.get().len(), 0);
+		root.input("username", "alice");
+		root.input("email", "alice@example.com");
+		root.input("password", "long-enough-password");
+		root.submit();
+		wait_for(|| fetch.requests().len() == 1).await;
+		assert!(!login_mutation.is_pending());
+		assert!(!other.get::<web_sys::HtmlButtonElement>("button").disabled());
+		assert_eq!(
+			fetch.requests()[0]["body"],
+			serde_json::json!({"request": {
+				"username":"alice","email":"alice@example.com","password":"long-enough-password",
+			}})
+		);
+		fetch.resolve(0, 200, serde_json::json!({"token":"registered"}));
+		wait_for(|| registered.get() == 1).await;
+		assert_eq!(registered.get(), 1);
+		assert_eq!(fetch.requests().len(), 1);
+	})
+	.await;
+}

--- a/docs/migration/0.4.0-client-form-views.md
+++ b/docs/migration/0.4.0-client-form-views.md
@@ -1,0 +1,81 @@
+# Named ClientForm views in 0.4.0
+
+A named `ClientForm` can render through `form! { client_form: ..., mutation: ... }`.
+Existing standalone `form!` declarations and handwritten `page!` bindings remain
+available.
+
+1. Keep the named request DTO and its existing server function.
+2. Keep the application-owned definition, `use_form` runtime, and configured
+   `FormServerMutation`.
+3. Replace repeated field/control/validation-summary markup with the new
+   `client_form` mode. Supply the existing mutation by reference.
+4. Move labels, classes, autocomplete hints, and supported widget selections to
+   `customize`, `styling`, `submit`, and `summary`.
+5. Remove repeated validation limits and submit event handlers from the view.
+   Validation comes from the DTO; the generated handler dispatches the existing
+   mutation once.
+
+The mutation's callbacks, request shape, invalidation, and navigation remain in
+their existing configuration. Do not create another runtime for rendering.
+A generated view includes every exposed editable field in declaration order;
+use a different DTO or handwritten layout when that field set is inappropriate.
+
+The [compiled authentication fixture](https://github.com/kent8192/reinhardt-web/blob/develop/0.4.0/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/pages.rs)
+contains the complete imports and setup for both renderings below, using an
+[external request DTO](https://github.com/kent8192/reinhardt-web/blob/develop/0.4.0/crates/reinhardt-pages/tests/fixtures/named_client_form_auth/src/dto.rs).
+Both retain this callback configuration:
+
+```rust,ignore
+let definition = LoginRequestClientForm::new();
+let runtime = use_form(&definition)
+    .on_submit_success(move |_| on_success())
+    .build();
+let mutation = definition.server_mutation(&runtime).build();
+```
+
+The handwritten view binds each input and submits through that mutation:
+
+```rust,ignore
+page!({
+    form {
+        novalidate: true,
+        @submit: move |event| { event.prevent_default(); mutation.dispatch(); },
+        label { r#for: "login-username", "Username" }
+        input {
+            id: "login-username", name: "username", autocomplete: "username",
+            bind: runtime.field(definition.username_field())
+        }
+        label { r#for: "login-password", "Password" }
+        input {
+            id: "login-password", name: "password", type: "password",
+            autocomplete: "current-password",
+            bind: runtime.field(definition.password_field())
+        }
+        button { type: "submit", "Sign in" }
+    }
+})
+```
+
+Replace the rendering expression with the generated view. It also supplies
+pending feedback and a linked validation summary:
+
+```rust,ignore
+form! {
+    client_form: LoginRequestClientForm,
+    mutation: &mutation,
+    id: "login",
+    customize: {
+        username: { label: "Username", autocomplete: "username" },
+        password: { widget: PasswordInput, autocomplete: "current-password" },
+    },
+    submit: { label: "Sign in", pending_label: "Signing in..." },
+}.into_page()
+```
+
+Optional choices use internal DOM tokens rather than serialized values.
+Applications reading select DOM values directly should instead read the typed
+runtime. Optional numeric and choice bindings are also available through
+existing handwritten `runtime.field(...)` controls.
+
+The `reinhardt_pages::client_form` API documentation contains a complete,
+tested example and the supported presentation contract.


### PR DESCRIPTION
## Summary

Named ClientForm DTOs now supply their generated controls as well as their request payload. Applications can render form! views over an already configured mutation, preserving its runtime, callbacks, pending state, and validation errors.

- Generate typed presentation adapters and optional scalar/choice bindings without repeating DTO fields.
- Retain DOM controls, focus, hydration state, and native reset ownership across runtime updates.
- Cover direct and renamed facade consumers, Cloud-shaped auth pages, and formatter round trips.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

The API is additive and existing form and router declarations retain their behavior.

## Motivation and Context

DTO-backed request forms previously needed duplicated standalone fields or a wrapper submit path. Named ClientForm views keep field metadata, validation, payload conversion, and configured mutation behavior together.

Fixes #6282

## How Was This Tested?

- Passed 33 native binding, rendering, and ClientForm regressions, plus the pending-observation clone regression.
- Passed 31 Chrome/WASM tests for named views, form hydration, and server mutations.
- Passed both isolated consumer tests: renamed facade auth pages in Chrome, and external DTOs through renamed Pages/facade dependencies on native and WASM targets.
- Passed all 20 named-view UI fixtures (19 compile-fail and one compile-pass), 1,225 Manouche and 481 Pages macro unit tests, five parser integration tests, and 107 formatter tests.
- Passed all 55 enabled Pages doctests (193 existing ignored examples) and strict documentation builds with `reinhardt-pages/model-server-fnset` enabled.
- Passed strict Clippy for the affected libraries and changed native test targets (`--no-deps -- -D warnings`), `cargo make fmt-check`, `cargo make placeholder-check`, and `git diff --check`.

Broader local checks have existing limits: all-targets Clippy reports `filter_map_bool_then` in unchanged `crates/reinhardt-pages/macros/src/form/codegen.rs`; default-feature strict rustdoc reports the existing link at `crates/reinhardt-pages/src/lib.rs:349` to a feature-gated method. The broader ClientForm UI sweep was interrupted after macOS pre-main executable startup delays; the affected named-view fixtures were rerun separately and all passed. Full workspace build/test checks remain a separate CI gate.

Focused validation used `15727e68bf8256497549f794518c96d46f48bf79`. The subsequent base merge `17f5519215e2a380a4ab2fbc7ff80bfa10a7dbd1` adds only upstream GraphQL and announcement changes; the feature diff against its new base is byte-for-byte identical.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New feature and related regression tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have verified formatting with `cargo make fmt-check`
- [x] I have checked the affected code and native test targets with strict Clippy
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6282
- kent8192/reinhardt-cloud#903

## Labels to Apply

- [x] `enhancement` - New feature or improvement
- [x] `forms` - Form handling, validation, rendering
- [ ] `breaking-change` - Breaking change

---

🤖 Generated with [Codex](https://openai.com/codex/)
