### PR TITLE
feat(routing): erase native handlers from shared URL declarations

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -93,6 +93,14 @@ filter = 'package(=reinhardt-macros) & binary(=model_wasm_parity) & test(=model_
 threads-required = 2
 slow-timeout = { period = "1200s", terminate-after = 3 }
 
+# This single consumer matrix runs 64 nested Cargo commands across native and
+# browser targets, including linked runtime tests and diagnostic controls.
+# Its measured duration exceeds the default timeout even with shared artifacts.
+[[profile.default.overrides]]
+filter = 'package(=reinhardt-integration-tests) & binary(=url_patterns_target_parity) & test(=url_patterns_target_matrix)'
+threads-required = 2
+slow-timeout = { period = "1200s", terminate-after = 3 }
+
 # Note: trybuild UI tests are now separated into a dedicated profile
 # Use `cargo make ui-test` to run UI tests with the ui-test profile
 # UI tests are identified by binary(/ui/) filter pattern

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -475,6 +475,9 @@ jobs:
           rust-save-if: ${{ github.ref == 'refs/heads/main' }}
           protoc-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install browser WASM target for macro-parity fixtures
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Install mold linker and build dependencies
         run: |
           sudo systemctl stop unattended-upgrades || true

--- a/.github/workflows/cross-crate-integration-test.yml
+++ b/.github/workflows/cross-crate-integration-test.yml
@@ -79,6 +79,9 @@ jobs:
           rust-save-if: ${{ github.ref == 'refs/heads/main' }}
           protoc-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install browser WASM target for consumer contract tests
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Install mold linker and build dependencies
         run: |
           sudo systemctl stop unattended-upgrades || true
@@ -144,6 +147,9 @@ jobs:
           rm -rf ~/.cargo/git/db || true
           echo "Disk usage after additional cleanup:"
           df -h
+
+      - name: Fetch browser dependencies for offline consumer checks
+        run: cargo fetch --target wasm32-unknown-unknown
 
       - name: Run cross-crate integration tests (partition ${{ matrix.partition }}/${{ inputs.partition-count || '5' }})
         env:

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ src/
 ├── config/
 │   ├── apps.rs                   # installed_apps! { polls: "polls" }
 │   ├── settings.rs               # #[cfg(server)] settings
-│   ├── urls.rs                   # #[routes(standalone)] entry
+│   ├── urls.rs                   # #[routes] entry
 │   └── wasm.rs                   # #[cfg(server)] wasm tooling config
 ├── lib.rs                        # crate root (`pub mod apps;` is un-gated)
 ├── shared.rs                     # bi-target shared module
@@ -471,56 +471,64 @@ src/
 
 ### 5. Register Routes
 
-Edit your app's `urls.rs`. **`urls.rs` plays two roles**: it **declares the URL
-submodules** of the app (via `pub mod ...;`) and **aggregates** them into a
-single `url_patterns` (or `server_url_patterns` / `unified_url_patterns`) entry
-point that `src/config/urls.rs` mounts:
+Edit your app's `urls.rs` to return a shared `UnifiedRouter`. Apply
+`#[url_patterns]` when its server handlers live in cfg-gated modules:
 
 ```rust
-// users/urls.rs
-//
-// 1. Module declarations for sub-URL files (optional, for larger apps):
-pub mod api;
-pub mod views;
-
-// 2. Aggregator — the single entry point mounted from src/config/urls.rs.
+// src/apps/users/urls.rs
 use reinhardt::url_patterns;
-use reinhardt::ServerRouter;
+use reinhardt::urls::prelude::UnifiedRouter;
 
-use crate::config::apps::InstalledApp;
-
-#[url_patterns(InstalledApp::users, mode = server)]
-pub fn server_url_patterns() -> ServerRouter {
-	ServerRouter::new()
-		.endpoint(views::list_users)
-		.endpoint(views::get_user)
-		.endpoint(views::create_user)
-		.mount("/api/v1/", api::routes())
+#[url_patterns]
+pub fn url_patterns() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.server(|server| {
+			server
+				.endpoint(crate::apps::users::views::list_users)
+				.endpoint(crate::apps::users::views::get_user)
+				.endpoint(crate::apps::users::views::create_user)
+		})
+		.with_namespace("users")
 }
 ```
 
-The `#[url_patterns]` attribute registers this router with the framework for
-automatic discovery. For Pages apps, keep the app-level `urls.rs` as the
-target-neutral aggregate and put route implementations in
-`urls/client_router.rs` and `urls/server_router.rs`; the project-level
-`src/config/urls.rs` mounts the aggregate functions.
+The argumentless `#[url_patterns]` attribute keeps server configuration only
+when the calling crate enables `cfg(server)` on a non-browser-WASM target.
+Other builds erase the complete `.server(...)` argument before resolving
+handler names. Keep native imports and handler modules cfg-gated, and enable
+`client-router` for browser routing. The attribute adds no inventory entry.
 
-Include in `src/config/urls.rs`:
+Declare and activate the application's custom cfg in `build.rs`, for example
+using an application Cargo feature named `server` (`server = []`):
+
+```rust
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(server)");
+	if std::env::var_os("CARGO_FEATURE_SERVER").is_some() {
+		println!("cargo::rustc-cfg=server");
+	}
+}
+```
+
+Mount app-level functions in the single project-level entry point:
 
 ```rust
 // src/config/urls.rs
-use reinhardt::prelude::*;
 use reinhardt::routes;
+use reinhardt::urls::prelude::UnifiedRouter;
+use crate::apps::users;
 
 #[routes]
-pub fn routes() -> ServerRouter {
-	ServerRouter::new()
-		.mount("/api/", users::urls::url_patterns())
+pub fn routes() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.mount_unified("/api/", users::urls::url_patterns())
 }
 ```
 
-The `#[routes]` attribute macro automatically registers this function with the
-framework for discovery via the `inventory` crate.
+`#[routes]` registers the root factory with the framework through `inventory`.
+If the root also contains native handler references, stack `#[url_patterns]`
+and `#[routes]` in either order. For larger apps, compose separately annotated
+functions with `mount_unified` or `merge`; avoid inline nested server builders.
 
 **Note:** The `reinhardt::prelude` includes commonly used types. Key exports include:
 

--- a/announcements/v0.4.0-alpha.15.md
+++ b/announcements/v0.4.0-alpha.15.md
@@ -1,0 +1,68 @@
+# reinhardt-web v0.4.0-alpha.15
+
+## Highlights
+
+This release lands the documented `RadioInput` widget for `pages`, enabling single-radio bindings for string-valued choice fields with checked-state binding, labels, disabled options, autofocus, and required-field validation for both scalar and collection values. `RadioInput` is intentionally rejected in model-form widget overrides across both the shared Manouche layer and macro validation, and native radio resets now correctly synchronize loaded/saved defaults, cancellation, and focus restoration during mounting and hydration.
+
+Alongside this, controlled file input bindings arrive for `pages`, adding typed `EventFile` value handling with reset synchronization across mounting, hydration, reactive remounts, and nested form ownership — plus compile-time validation and SSR omission of file values.
+
+A significant batch of reactive-core fixes improves correctness under load: layout effects are now deferred until batches settle and flushed before passive effects via notification epochs, reactive branch owners are retained when conditions re-evaluate without changing, and batched notification semantics and hydration error specificity are preserved. Explicit-dependency memo reads stay current, and panic recovery correctly retains queued work instead of losing it.
+
+On the database side, a new idempotent source upgrader allows pre-0.4 framework-generated `DropColumn` migration literals (which omit `old_definition`) to be automatically upgraded while preserving migration identity, dependency edges, and surrounding code — smoothing upgrades for projects with legacy migrations.
+
+Finally, this release merges 105 commits from `main` into the `develop/0.4.0` line, reconciling reactive ownership and admin API differences and carrying forward accessible field/radio metadata, generated form value synchronization, and textarea/select hydration fixes.
+
+## Breaking Changes
+
+- ⚠️ [[reinhardt-web#6289] fix!(pages): support the documented RadioInput widget](https://github.com/kent8192/reinhardt-web/discussions/6292)
+- ⚠️ [[reinhardt-web#6290] chore!(sync): merge main into develop/0.4.0](https://github.com/kent8192/reinhardt-web/discussions/6291)
+
+## Related PRs
+
+| PR | Title | Author |
+|----|-------|--------|
+| [#6272](https://github.com/kent8192/reinhardt-web/pull/6272) | feat(db): add pre-0.4 migration source upgrader | @kent8192 |
+| [#6273](https://github.com/kent8192/reinhardt-web/pull/6273) | feat(pages): add controlled file input bindings | @kent8192 |
+| [#6278](https://github.com/kent8192/reinhardt-web/pull/6278) | fix: restore reactive controls and regression checks on develop | @kent8192 |
+| [#6289](https://github.com/kent8192/reinhardt-web/pull/6289) | fix!(pages): support the documented RadioInput widget | @kent8192 |
+| [#6290](https://github.com/kent8192/reinhardt-web/pull/6290) | chore!(sync): merge main into develop/0.4.0 | @kent8192 |
+
+<details><summary>Full CHANGELOG</summary>
+
+## [0.4.0-alpha.15](https://github.com/kent8192/reinhardt-web/compare/reinhardt-web@v0.4.0-alpha.14...reinhardt-web@v0.4.0-alpha.15) - 2026-09-10
+
+### Documentation
+
+- add release announcement(s)
+
+### Fixed
+
+- *(core)* defer layout effects until reactive batches settle
+- *(pages)* preserve specific hydration installation errors
+- *(pages)* retain owners of unchanged reactive branches
+- *(core)* preserve batched notification semantics
+- *(pages)* reject unsupported RadioInput form overrides
+- *(pages)* complete native radio reset synchronization
+- *(manouche)* reject RadioInput model form overrides
+- *(pages)* validate required radios and synchronize saved defaults
+- *(pages)* preserve reset ownership and hydrated radio state
+
+### Maintenance
+
+- *(deps)* allow compatible hashlink 0.12 patch updates
+- chore!(sync): merge main into develop/0.4.0
+- merge develop/0.4.0 into RadioInput support
+- *(test)* allow cold native and wasm model parity builds
+
+### Testing
+
+- *(commands)* restore process state across admin script tests
+- *(macros)* refresh generated relation constructor diagnostics
+- *(pages)* align control assertions with effect timing
+- *(pages)* isolate upload alias diagnostics from MSW metadata
+- *(conf)* isolate audit backend database fixtures
+- compose regression setup from reinhardt fixtures
+- *(migrations)* enforce exact source upgrade assertions
+- *(migrations)* ship portable fixture capture tools
+
+</details>

--- a/crates/reinhardt-core/macros/Cargo.toml
+++ b/crates/reinhardt-core/macros/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["full", "extra-traits"] }
+syn = { workspace = true, features = ["full", "extra-traits", "visit"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 proc-macro-crate = "3.1"

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -324,10 +324,41 @@ Provides compile-time code generation for common patterns.
 
 #### URL Pattern Registration
 
+- **`#[url_patterns]`** - Share a `UnifiedRouter` builder with native-only HTTP handlers
+  - Takes no arguments and adds no inventory registration
+  - Keeps each complete `.server(...)` argument only under
+    `all(server, not(all(target_family = "wasm", target_os = "unknown")))`
+    in the calling crate; other builds erase it before name resolution
+  - Accepts safe, synchronous functions without `const` or `extern` qualifiers,
+    with no parameters or generics and an
+    explicit `UnifiedRouter` return type, including qualified paths
+  - Requires one tail expression rooted at `UnifiedRouter::new()` or `default()`;
+    supported methods are `server`, `client`, `with_prefix`, `with_namespace`,
+    `mount_unified`, and `merge`
+  - Put native imports inside the server argument or in cfg-gated modules.
+    Extract nested server builders into separate annotated functions
+  - Available as `reinhardt::url_patterns`, including on WASM. Declare the
+    caller's custom `server` cfg in `build.rs` and enable it for native server
+    builds; `client-router` is required for browser routing
+  - Example:
+    ```rust
+    use reinhardt::url_patterns;
+    use reinhardt::urls::prelude::UnifiedRouter;
+
+    #[url_patterns]
+    pub fn url_patterns() -> UnifiedRouter {
+        UnifiedRouter::new()
+            .server(|server| server.endpoint(crate::native_handlers::health))
+            .with_namespace("demo")
+    }
+    ```
+
 - **`#[routes]`** - Attribute macro for automatic URL pattern registration
   - Registers URL pattern function for framework discovery (via `inventory` crate)
   - Apply to project-level `routes()` function in `src/config/urls.rs`
   - Return type must be `UnifiedRouter` (framework handles Arc wrapping internally)
+  - Can be stacked with `#[url_patterns]` in either order; only `#[routes]`
+    registers the root factory
   - Example:
     ```rust
     use reinhardt::prelude::*;
@@ -336,7 +367,7 @@ Provides compile-time code generation for common patterns.
     #[routes]
     pub fn routes() -> UnifiedRouter {
         UnifiedRouter::new()
-            .mount("/api/", api_router())
+            .mount_unified("/api/", api_url_patterns())
     }
     ```
 

--- a/crates/reinhardt-core/macros/README.md
+++ b/crates/reinhardt-core/macros/README.md
@@ -325,6 +325,7 @@ Provides compile-time code generation for common patterns.
 #### URL Pattern Registration
 
 - **`#[url_patterns]`** - Share a `UnifiedRouter` builder with native-only HTTP handlers
+  - **Parity: P1 (symbol parity)** - available on native and browser-WASM builds; the server configuration is inert on browser WASM
   - Takes no arguments and adds no inventory registration
   - Keeps each complete `.server(...)` argument only under
     `all(server, not(all(target_family = "wasm", target_os = "unknown")))`

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -91,6 +91,10 @@ use user_attribute::user_attribute_impl;
 
 /// Declares shared URL patterns with native-only HTTP registration.
 ///
+/// **Parity: P1 (symbol parity).** The attribute is available on native and
+/// browser-WASM builds. Native builds retain the `.server(...)` configuration;
+/// browser-WASM builds erase it before resolving native-only handler paths.
+///
 /// The complete `.server(...)` argument is retained only when the caller has
 /// `cfg(server)` enabled and the target is not browser WASM
 /// (`all(target_family = "wasm", target_os = "unknown")`). Other builds erase

--- a/crates/reinhardt-core/macros/src/lib.rs
+++ b/crates/reinhardt-core/macros/src/lib.rs
@@ -5,6 +5,7 @@
 //! ## Macros
 //!
 //! - `#[routes]` - Register URL pattern function for automatic discovery
+//! - `#[url_patterns]` - Share URL declarations by erasing native-only HTTP builders
 //! - `#[api_view]` - Convert function to API view
 //! - `#[action]` - Define custom ViewSet action
 //! - `#[get]`, `#[post]`, etc. - HTTP method decorators
@@ -56,6 +57,7 @@ pub(crate) mod settings_parser;
 mod settings_schema;
 mod streaming;
 mod streaming_patterns;
+mod url_patterns;
 mod use_inject;
 mod user_attribute;
 mod user_field_mapping;
@@ -83,8 +85,82 @@ use routes_registration::routes_impl;
 mod viewset_macro;
 mod websocket;
 use schema::derive_schema_impl;
+use url_patterns::url_patterns_impl;
 use use_inject::use_inject_impl;
 use user_attribute::user_attribute_impl;
+
+/// Declares shared URL patterns with native-only HTTP registration.
+///
+/// The complete `.server(...)` argument is retained only when the caller has
+/// `cfg(server)` enabled and the target is not browser WASM
+/// (`all(target_family = "wasm", target_os = "unknown")`). Other builds erase
+/// that argument before resolving handler paths or checking their types.
+/// Prefixes, namespaces, client configuration, mounts, and merges keep their
+/// existing target-specific behavior.
+///
+/// Unlike [`routes`](macro@routes), this attribute does not register a router in inventory.
+/// Multiple app functions can use it; keep one project-level `#[routes]` entry
+/// point. Both attributes can be stacked in either order on that root function.
+///
+/// # Supported syntax
+///
+/// The attribute accepts no arguments. Apply it to a safe, synchronous,
+/// parameterless, non-generic function returning `UnifiedRouter` (qualified
+/// paths are supported), without `const` or `extern` qualifiers.
+/// Its body must be one tail expression starting with
+/// `UnifiedRouter::new()` or `UnifiedRouter::default()`, followed by `server`,
+/// `client`, `with_prefix`, `with_namespace`, `mount_unified`, or `merge` calls.
+/// Parentheses are supported. A server call takes exactly one expression and
+/// no explicit generic arguments. Inline nested server builders in preserved
+/// arguments must be extracted into separately annotated functions.
+///
+/// Native imports and capture construction belong inside the server argument
+/// or a cfg-gated module. The attribute cannot erase external imports or
+/// target-independent Cargo dependencies.
+///
+/// # Example
+///
+/// This facade example is exercised by the `url_patterns_target_parity`
+/// consumer fixture in the integration test suite.
+///
+/// ```rust,ignore
+/// use reinhardt::url_patterns;
+/// use reinhardt::urls::prelude::UnifiedRouter;
+///
+/// #[url_patterns]
+/// pub fn url_patterns() -> UnifiedRouter {
+///     UnifiedRouter::new()
+///         .server(|server| {
+///             server
+///                 .endpoint(crate::native_handlers::health)
+///                 .endpoint(crate::native_handlers::protected)
+///         })
+///         .with_namespace("demo")
+/// }
+/// ```
+///
+/// # Caller configuration
+///
+/// Declare `server` in the application's `build.rs`, even when unset, and
+/// enable it for server builds. For a local `server = []` Cargo feature, place
+/// the following inside the build script's `main` function:
+///
+/// ```rust,no_run
+/// println!("cargo::rustc-check-cfg=cfg(server)");
+/// if std::env::var_os("CARGO_FEATURE_SERVER").is_some() {
+///     println!("cargo::rustc-cfg=server");
+/// }
+/// ```
+///
+/// Browser consumers need the facade's `client-router` feature. Setting
+/// `cfg(server)` on browser WASM still leaves native references erased.
+#[proc_macro_attribute]
+pub fn url_patterns(args: TokenStream, input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as ItemFn);
+	url_patterns_impl(args.into(), input)
+		.unwrap_or_else(|error| error.to_compile_error())
+		.into()
+}
 
 /// Decorator for function-based API views
 #[proc_macro_attribute]

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -1,0 +1,478 @@
+//! Shared URL builder validation and target-specific HTTP expression erasure.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Expr, ItemFn, PathArguments, ReturnType, Stmt, Type, visit::Visit};
+
+pub(crate) fn url_patterns_impl(args: TokenStream, mut input: ItemFn) -> syn::Result<TokenStream> {
+	if !args.is_empty() {
+		return Err(syn::Error::new_spanned(
+			args,
+			"#[url_patterns] does not accept arguments",
+		));
+	}
+	validate_signature(&input)?;
+	let [Stmt::Expr(native_expr, None)] = input.block.stmts.as_slice() else {
+		return Err(syn::Error::new_spanned(
+			&input.block,
+			"#[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()",
+		));
+	};
+	let disabled_expr = erase_server_calls(native_expr)?;
+
+	// Keep the enabled expression intact, including its temporary lifetimes.
+	// The caller's cfg removes the other block before resolving handler paths.
+	*input.block = syn::parse_quote!({
+		#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+		{
+			#native_expr
+		}
+		#[cfg(not(all(server, not(all(target_family = "wasm", target_os = "unknown")))))]
+		{
+			#disabled_expr
+		}
+	});
+	Ok(quote!(#input))
+}
+
+fn validate_signature(input: &ItemFn) -> syn::Result<()> {
+	let signature = &input.sig;
+	if signature.asyncness.is_some()
+		|| signature.unsafety.is_some()
+		|| signature.constness.is_some()
+		|| signature.abi.is_some()
+		|| !signature.inputs.is_empty()
+		|| signature.variadic.is_some()
+		|| !signature.generics.params.is_empty()
+		|| signature.generics.where_clause.is_some()
+	{
+		return Err(syn::Error::new_spanned(
+			signature,
+			"#[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers",
+		));
+	}
+	if let ReturnType::Type(_, output) = &signature.output
+		&& let Type::Path(output) = output.as_ref()
+		&& output.qself.is_none()
+		&& output
+			.path
+			.segments
+			.last()
+			.is_some_and(|segment| segment.ident == "UnifiedRouter" && segment.arguments.is_empty())
+	{
+		return Ok(());
+	}
+	Err(syn::Error::new_spanned(
+		&signature.output,
+		"#[url_patterns] requires an explicit UnifiedRouter return type; qualified paths are supported",
+	))
+}
+
+fn erase_server_calls(expr: &Expr) -> syn::Result<Expr> {
+	match expr {
+		Expr::Paren(paren) => {
+			let mut paren = paren.clone();
+			paren.expr = Box::new(erase_server_calls(&paren.expr)?);
+			Ok(Expr::Paren(paren))
+		}
+		Expr::Group(group) => {
+			let mut group = group.clone();
+			group.expr = Box::new(erase_server_calls(&group.expr)?);
+			Ok(Expr::Group(group))
+		}
+		Expr::Call(_) if is_unified_router_constructor(expr) => Ok(expr.clone()),
+		Expr::MethodCall(call) if call.method == "server" => {
+			if call.args.len() != 1 || call.turbofish.is_some() {
+				return Err(syn::Error::new_spanned(
+					call,
+					"#[url_patterns] .server(...) requires exactly one argument and no explicit generic arguments",
+				));
+			}
+			// The complete argument is opaque: native-only setup and captures must
+			// disappear together with the closure or configuration function path.
+			erase_server_calls(&call.receiver)
+		}
+		Expr::MethodCall(call) => {
+			if ![
+				"client",
+				"with_prefix",
+				"with_namespace",
+				"mount_unified",
+				"merge",
+			]
+			.iter()
+			.any(|method| call.method == *method)
+			{
+				return Err(syn::Error::new_spanned(
+					&call.method,
+					format!(
+						"#[url_patterns] does not support the outer builder method `{}`; supported methods are server, client, with_prefix, with_namespace, mount_unified, and merge",
+						call.method
+					),
+				));
+			}
+			let receiver = erase_server_calls(&call.receiver)?;
+			for argument in &call.args {
+				reject_nested_server_builder(argument)?;
+			}
+			let mut call = call.clone();
+			call.receiver = Box::new(receiver);
+			Ok(Expr::MethodCall(call))
+		}
+		_ => Err(syn::Error::new_spanned(
+			expr,
+			"#[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain",
+		)),
+	}
+}
+
+fn unparenthesized(mut expr: &Expr) -> &Expr {
+	loop {
+		expr = match expr {
+			Expr::Paren(paren) => &paren.expr,
+			Expr::Group(group) => &group.expr,
+			_ => return expr,
+		};
+	}
+}
+
+fn is_unified_router_constructor(expr: &Expr) -> bool {
+	let Expr::Call(call) = unparenthesized(expr) else {
+		return false;
+	};
+	let Expr::Path(function) = unparenthesized(&call.func) else {
+		return false;
+	};
+	if !call.args.is_empty()
+		|| function.qself.is_some()
+		|| function
+			.path
+			.segments
+			.iter()
+			.any(|segment| !matches!(segment.arguments, PathArguments::None))
+	{
+		return false;
+	}
+	let mut segments = function.path.segments.iter().rev();
+	matches!(
+		(segments.next(), segments.next()),
+		(Some(method), Some(router))
+			if router.ident == "UnifiedRouter" && (method.ident == "new" || method.ident == "default")
+	)
+}
+
+fn has_unified_router_root(mut expr: &Expr) -> bool {
+	loop {
+		expr = unparenthesized(expr);
+		match expr {
+			Expr::MethodCall(call) => expr = &call.receiver,
+			_ => return is_unified_router_constructor(expr),
+		}
+	}
+}
+
+fn reject_nested_server_builder(expr: &Expr) -> syn::Result<()> {
+	#[derive(Default)]
+	struct NestedServerBuilder {
+		error: Option<syn::Error>,
+	}
+
+	impl<'ast> Visit<'ast> for NestedServerBuilder {
+		fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
+			if self.error.is_some() {
+				return;
+			}
+			if call.method == "server" && has_unified_router_root(&call.receiver) {
+				self.error = Some(syn::Error::new_spanned(
+					&call.method,
+					"nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function",
+				));
+				return;
+			}
+			syn::visit::visit_expr_method_call(self, call);
+		}
+	}
+
+	let mut visitor = NestedServerBuilder::default();
+	visitor.visit_expr(expr);
+	visitor.error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use proc_macro2::{Delimiter, Group, TokenStream};
+	use quote::quote;
+	use rstest::rstest;
+	use syn::{Expr, ItemFn, parse_quote};
+
+	#[rstest]
+	fn expansion_preserves_the_function_and_complete_native_chain() {
+		// Arrange
+		let input: ItemFn = parse_quote! {
+			#[doc = "Shared GitHub endpoints."]
+			#[reinhardt::routes]
+			pub(crate) fn github_urls() -> reinhardt::UnifiedRouter {
+				reinhardt::UnifiedRouter::new()
+					.server(|server| server.endpoint(crate::native_handlers::setup))
+					.with_namespace("github")
+			}
+		};
+		let expected: ItemFn = parse_quote! {
+			#[doc = "Shared GitHub endpoints."]
+			#[reinhardt::routes]
+			pub(crate) fn github_urls() -> reinhardt::UnifiedRouter {
+				#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+				{
+					reinhardt::UnifiedRouter::new()
+						.server(|server| server.endpoint(crate::native_handlers::setup))
+						.with_namespace("github")
+				}
+				#[cfg(not(all(server, not(all(target_family = "wasm", target_os = "unknown")))))]
+				{
+					reinhardt::UnifiedRouter::new().with_namespace("github")
+				}
+			}
+		};
+
+		// Act
+		let output = url_patterns_impl(TokenStream::new(), input).unwrap();
+		let actual: ItemFn = syn::parse2(output).unwrap();
+
+		// Assert
+		assert_eq!(actual, expected);
+	}
+
+	#[rstest]
+	#[case::empty(quote!(UnifiedRouter::new()), quote!(UnifiedRouter::new()))]
+	#[case::default(quote!(::framework::UnifiedRouter::default()), quote!(::framework::UnifiedRouter::default()))]
+	#[case::parentheses(quote!((UnifiedRouter::new()).server(configure)), quote!((UnifiedRouter::new())))]
+	#[case::outer_parentheses(quote!((UnifiedRouter::new().server(configure))), quote!((UnifiedRouter::new())))]
+	#[case::all_preserved_methods(
+		quote!(UnifiedRouter::new().with_prefix("/api/").server(first).client(client_config).with_namespace("api").mount_unified("/auth/", auth_urls()).merge(other_urls()).server(second)),
+		quote!(UnifiedRouter::new().with_prefix("/api/").client(client_config).with_namespace("api").mount_unified("/auth/", auth_urls()).merge(other_urls()))
+	)]
+	#[case::captured_closure(
+		quote!(UnifiedRouter::new().server({ let owned = String::from("native"); move |server| { consume(owned); server } }).with_prefix("/api/")),
+		quote!(UnifiedRouter::new().with_prefix("/api/"))
+	)]
+	#[case::unrelated_server_method(
+		quote!(UnifiedRouter::new().server(native).client(|client| transport.server(client))),
+		quote!(UnifiedRouter::new().client(|client| transport.server(client)))
+	)]
+	#[case::opaque_server_argument(
+		quote!(UnifiedRouter::new().server(|server| configure(server, UnifiedRouter::new().server(nested)))),
+		quote!(UnifiedRouter::new())
+	)]
+	fn erasure_only_removes_outer_server_calls(
+		#[case] input: TokenStream,
+		#[case] expected: TokenStream,
+	) {
+		// Arrange
+		let input: Expr = syn::parse2(input).unwrap();
+		let expected: Expr = syn::parse2(expected).unwrap();
+
+		// Act
+		let actual = erase_server_calls(&input).unwrap();
+
+		// Assert
+		assert_eq!(actual, expected);
+	}
+
+	#[rstest]
+	fn erasure_preserves_invisible_expression_groups() {
+		// Arrange
+		let input = Expr::Group(syn::ExprGroup {
+			attrs: Vec::new(),
+			group_token: Default::default(),
+			expr: Box::new(parse_quote!(UnifiedRouter::new().server(configure))),
+		});
+		let mut expected = input.clone();
+		let Expr::Group(group) = &mut expected else {
+			panic!("fixture must be an expression group");
+		};
+		group.expr = Box::new(parse_quote!(UnifiedRouter::new()));
+
+		// Act
+		let actual = erase_server_calls(&input).unwrap();
+
+		// Assert
+		assert_eq!(actual, expected);
+	}
+
+	#[rstest]
+	fn constructor_function_accepts_an_invisible_group() {
+		// Arrange
+		let constructor = Group::new(Delimiter::None, quote!(UnifiedRouter::new));
+		let input: Expr = syn::parse2(quote!(#constructor().server(configure))).unwrap();
+		let expected: Expr = syn::parse2(quote!(#constructor())).unwrap();
+
+		// Act
+		let actual = erase_server_calls(&input).unwrap();
+
+		// Assert
+		assert_eq!(actual, expected);
+	}
+
+	#[rstest]
+	#[case::async_fn(quote!(async fn urls() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::unsafe_fn(quote!(unsafe fn urls() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::const_fn(quote!(const fn urls() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::extern_fn(quote!(extern "C" fn urls() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::parameter(quote!(fn urls(value: u8) -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::type_parameter(quote!(fn urls<T>() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::lifetime(quote!(fn urls<'a>() -> UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::where_clause(quote!(fn urls() -> UnifiedRouter where (): Sized { UnifiedRouter::new() }))]
+	fn unsupported_signatures_have_a_direct_diagnostic(#[case] input: TokenStream) {
+		// Arrange
+		let input = syn::parse2(input).unwrap();
+
+		// Act
+		let error = url_patterns_impl(TokenStream::new(), input).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers"
+		);
+	}
+
+	#[rstest]
+	#[case::missing(quote!(fn urls() { UnifiedRouter::new() }))]
+	#[case::other_router(quote!(fn urls() -> ServerRouter { UnifiedRouter::new() }))]
+	#[case::alias(quote!(fn urls() -> AppRouter { UnifiedRouter::new() }))]
+	#[case::generic(quote!(fn urls() -> UnifiedRouter<()> { UnifiedRouter::new() }))]
+	#[case::reference(quote!(fn urls() -> &'static UnifiedRouter { UnifiedRouter::new() }))]
+	#[case::qualified_self(quote!(fn urls() -> <App as Routing>::UnifiedRouter { UnifiedRouter::new() }))]
+	fn unsupported_return_types_are_rejected(#[case] input: TokenStream) {
+		// Arrange
+		let input = syn::parse2(input).unwrap();
+
+		// Act
+		let error = url_patterns_impl(TokenStream::new(), input).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] requires an explicit UnifiedRouter return type; qualified paths are supported"
+		);
+	}
+
+	#[rstest]
+	#[case::empty(quote!({}))]
+	#[case::let_binding(quote!({ let router = UnifiedRouter::new(); router }))]
+	#[case::semicolon(quote!({ UnifiedRouter::new(); }))]
+	fn non_tail_bodies_are_rejected(#[case] body: TokenStream) {
+		// Arrange
+		let input = syn::parse2(quote!(fn urls() -> UnifiedRouter #body)).unwrap();
+
+		// Act
+		let error = url_patterns_impl(TokenStream::new(), input).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()"
+		);
+	}
+
+	#[rstest]
+	#[case::helper(quote!(make_router()))]
+	#[case::variable(quote!(router))]
+	#[case::return_expr(quote!(return UnifiedRouter::new()))]
+	#[case::condition(quote!(if enabled { UnifiedRouter::new() } else { UnifiedRouter::default() }))]
+	#[case::match_expr(quote!(match enabled { _ => UnifiedRouter::new() }))]
+	#[case::other_constructor(quote!(ServerRouter::new()))]
+	#[case::constructor_argument(quote!(UnifiedRouter::new(42)))]
+	#[case::constructor_generic(quote!(UnifiedRouter::new::<()>()))]
+	#[case::type_generic(quote!(UnifiedRouter::<()>::new()))]
+	fn unsupported_roots_are_rejected(#[case] expr: TokenStream) {
+		// Arrange
+		let expr = syn::parse2(expr).unwrap();
+
+		// Act
+		let error = erase_server_calls(&expr).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain"
+		);
+	}
+
+	#[rstest]
+	#[case(quote!(UnifiedRouter::new().server()))]
+	#[case(quote!(UnifiedRouter::new().server(first, second)))]
+	#[case(quote!(UnifiedRouter::new().server::<()>(configure)))]
+	fn invalid_server_calls_are_rejected(#[case] expr: TokenStream) {
+		// Arrange
+		let expr = syn::parse2(expr).unwrap();
+
+		// Act
+		let error = erase_server_calls(&expr).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] .server(...) requires exactly one argument and no explicit generic arguments"
+		);
+	}
+
+	#[rstest]
+	#[case(quote!(UnifiedRouter::new().merge(UnifiedRouter::new().server(configure))))]
+	#[case(quote!(UnifiedRouter::new().mount_unified("/", (UnifiedRouter::default()).server(configure))))]
+	#[case(quote!(UnifiedRouter::new().client(|client| { use_nested(UnifiedRouter::new().server(configure)); client })))]
+	fn nested_builders_require_separate_annotated_functions(#[case] expr: TokenStream) {
+		// Arrange
+		let expr = syn::parse2(expr).unwrap();
+
+		// Act
+		let error = erase_server_calls(&expr).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function"
+		);
+	}
+
+	#[rstest]
+	fn attribute_arguments_are_rejected() {
+		// Arrange
+		let input = parse_quote!(
+			fn urls() -> UnifiedRouter {
+				UnifiedRouter::new()
+			}
+		);
+
+		// Act
+		let error = url_patterns_impl(quote!(server), input).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			"#[url_patterns] does not accept arguments"
+		);
+	}
+
+	#[rstest]
+	#[case("websocket")]
+	#[case("grpc")]
+	#[case("custom")]
+	fn unsupported_outer_methods_are_rejected(#[case] method: &str) {
+		// Arrange
+		let method = syn::Ident::new(method, proc_macro2::Span::call_site());
+		let expr = parse_quote!(UnifiedRouter::new().#method(configure));
+
+		// Act
+		let error = erase_server_calls(&expr).unwrap_err();
+
+		// Assert
+		assert_eq!(
+			error.to_string(),
+			format!(
+				"#[url_patterns] does not support the outer builder method `{method}`; supported methods are server, client, with_prefix, with_namespace, mount_unified, and merge"
+			)
+		);
+	}
+}

--- a/crates/reinhardt-core/macros/src/url_patterns.rs
+++ b/crates/reinhardt-core/macros/src/url_patterns.rs
@@ -2,7 +2,8 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Expr, ItemFn, PathArguments, ReturnType, Stmt, Type, visit::Visit};
+use std::collections::HashSet;
+use syn::{Expr, ItemFn, Pat, PathArguments, ReturnType, Stmt, Type, visit::Visit};
 
 pub(crate) fn url_patterns_impl(args: TokenStream, mut input: ItemFn) -> syn::Result<TokenStream> {
 	if !args.is_empty() {
@@ -161,13 +162,23 @@ fn is_unified_router_constructor(expr: &Expr) -> bool {
 	)
 }
 
-fn has_unified_router_root(mut expr: &Expr) -> bool {
-	loop {
-		expr = unparenthesized(expr);
-		match expr {
-			Expr::MethodCall(call) => expr = &call.receiver,
-			_ => return is_unified_router_constructor(expr),
+fn is_unified_router_builder(expr: &Expr, aliases: &HashSet<String>) -> bool {
+	let expr = unparenthesized(expr);
+	if is_unified_router_constructor(expr) {
+		return true;
+	}
+	match expr {
+		Expr::MethodCall(call) => is_unified_router_builder(&call.receiver, aliases),
+		Expr::Path(path) => {
+			let mut segments = path.path.segments.iter();
+			let Some(segment) = segments.next() else {
+				return false;
+			};
+			segments.next().is_none()
+				&& segment.arguments.is_empty()
+				&& aliases.contains(&segment.ident.to_string())
 		}
+		_ => false,
 	}
 }
 
@@ -175,14 +186,32 @@ fn reject_nested_server_builder(expr: &Expr) -> syn::Result<()> {
 	#[derive(Default)]
 	struct NestedServerBuilder {
 		error: Option<syn::Error>,
+		router_aliases: HashSet<String>,
 	}
 
 	impl<'ast> Visit<'ast> for NestedServerBuilder {
+		fn visit_local(&mut self, local: &'ast syn::Local) {
+			if let Pat::Ident(binding) = &local.pat {
+				let name = binding.ident.to_string();
+				let is_router = local.init.as_ref().is_some_and(|init| {
+					is_unified_router_builder(&init.expr, &self.router_aliases)
+				});
+				if is_router {
+					self.router_aliases.insert(name);
+				} else {
+					self.router_aliases.remove(&name);
+				}
+			}
+			syn::visit::visit_local(self, local);
+		}
+
 		fn visit_expr_method_call(&mut self, call: &'ast syn::ExprMethodCall) {
 			if self.error.is_some() {
 				return;
 			}
-			if call.method == "server" && has_unified_router_root(&call.receiver) {
+			if call.method == "server"
+				&& is_unified_router_builder(&call.receiver, &self.router_aliases)
+			{
 				self.error = Some(syn::Error::new_spanned(
 					&call.method,
 					"nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function",
@@ -420,6 +449,7 @@ mod tests {
 
 	#[rstest]
 	#[case(quote!(UnifiedRouter::new().merge(UnifiedRouter::new().server(configure))))]
+	#[case(quote!(UnifiedRouter::new().merge({ let router = UnifiedRouter::new(); router.server(configure) })))]
 	#[case(quote!(UnifiedRouter::new().mount_unified("/", (UnifiedRouter::default()).server(configure))))]
 	#[case(quote!(UnifiedRouter::new().client(|client| { use_nested(UnifiedRouter::new().server(configure)); client })))]
 	fn nested_builders_require_separate_annotated_functions(#[case] expr: TokenStream) {

--- a/crates/reinhardt-core/macros/tests/ui.rs
+++ b/crates/reinhardt-core/macros/tests/ui.rs
@@ -105,6 +105,15 @@ fn test_routes_registration_macro_fail() {
 	t.compile_fail("tests/ui/routes_registration/fail/*.rs");
 }
 
+#[rstest::rstest]
+fn test_url_patterns_macro_fail() {
+	// Arrange
+	let cases = trybuild::TestCases::new();
+
+	// Act / Assert
+	cases.compile_fail("tests/ui/url_patterns/fail/*.rs");
+}
+
 // ===== Injectable =====
 
 #[test]

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/attribute_arguments.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/attribute_arguments.rs
@@ -1,0 +1,8 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns(server)]
+fn urls() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/attribute_arguments.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/attribute_arguments.stderr
@@ -1,0 +1,5 @@
+error: #[url_patterns] does not accept arguments
+ --> tests/ui/url_patterns/fail/attribute_arguments.rs:3:16
+  |
+3 | #[url_patterns(server)]
+  |                ^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_return_type.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_return_type.rs
@@ -1,0 +1,18 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn missing() {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+fn wrong_router() -> ServerRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+fn aliased() -> AppRouter {
+	UnifiedRouter::new()
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_return_type.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_return_type.stderr
@@ -1,0 +1,19 @@
+error: #[url_patterns] requires an explicit UnifiedRouter return type; qualified paths are supported
+ --> tests/ui/url_patterns/fail/invalid_return_type.rs:3:1
+  |
+3 | #[url_patterns]
+  | ^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `url_patterns` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: #[url_patterns] requires an explicit UnifiedRouter return type; qualified paths are supported
+ --> tests/ui/url_patterns/fail/invalid_return_type.rs:9:19
+  |
+9 | fn wrong_router() -> ServerRouter {
+  |                   ^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires an explicit UnifiedRouter return type; qualified paths are supported
+  --> tests/ui/url_patterns/fail/invalid_return_type.rs:14:14
+   |
+14 | fn aliased() -> AppRouter {
+   |              ^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_server_call.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_server_call.rs
@@ -1,0 +1,18 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn empty() -> UnifiedRouter {
+	UnifiedRouter::new().server()
+}
+
+#[url_patterns]
+fn multiple() -> UnifiedRouter {
+	UnifiedRouter::new().server(first, second)
+}
+
+#[url_patterns]
+fn generic() -> UnifiedRouter {
+	UnifiedRouter::new().server::<()>(configure)
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_server_call.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/invalid_server_call.stderr
@@ -1,0 +1,17 @@
+error: #[url_patterns] .server(...) requires exactly one argument and no explicit generic arguments
+ --> tests/ui/url_patterns/fail/invalid_server_call.rs:5:2
+  |
+5 |     UnifiedRouter::new().server()
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] .server(...) requires exactly one argument and no explicit generic arguments
+  --> tests/ui/url_patterns/fail/invalid_server_call.rs:10:2
+   |
+10 |     UnifiedRouter::new().server(first, second)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] .server(...) requires exactly one argument and no explicit generic arguments
+  --> tests/ui/url_patterns/fail/invalid_server_call.rs:15:2
+   |
+15 |     UnifiedRouter::new().server::<()>(configure)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.rs
@@ -6,6 +6,14 @@ fn merged() -> UnifiedRouter {
 }
 
 #[url_patterns]
+fn aliased() -> UnifiedRouter {
+	UnifiedRouter::new().merge({
+		let router = UnifiedRouter::new();
+		router.server(configure)
+	})
+}
+
+#[url_patterns]
 fn mounted() -> UnifiedRouter {
 	UnifiedRouter::new().mount_unified("/", UnifiedRouter::new().server(configure))
 }

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.rs
@@ -1,0 +1,21 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn merged() -> UnifiedRouter {
+	UnifiedRouter::new().merge(UnifiedRouter::new().server(configure))
+}
+
+#[url_patterns]
+fn mounted() -> UnifiedRouter {
+	UnifiedRouter::new().mount_unified("/", UnifiedRouter::new().server(configure))
+}
+
+#[url_patterns]
+fn client_argument() -> UnifiedRouter {
+	UnifiedRouter::new().client(|client| {
+		consume(UnifiedRouter::new().server(configure));
+		client
+	})
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.stderr
@@ -5,13 +5,19 @@ error: nested UnifiedRouter .server(...) calls are unsupported here; extract the
   |                                                     ^^^^^^
 
 error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
-  --> tests/ui/url_patterns/fail/nested_server_builder.rs:10:63
+  --> tests/ui/url_patterns/fail/nested_server_builder.rs:12:10
    |
-10 |     UnifiedRouter::new().mount_unified("/", UnifiedRouter::new().server(configure))
+12 |         router.server(configure)
+   |                ^^^^^^
+
+error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
+  --> tests/ui/url_patterns/fail/nested_server_builder.rs:18:63
+   |
+18 |     UnifiedRouter::new().mount_unified("/", UnifiedRouter::new().server(configure))
    |                                                                  ^^^^^^
 
 error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
-  --> tests/ui/url_patterns/fail/nested_server_builder.rs:16:32
+  --> tests/ui/url_patterns/fail/nested_server_builder.rs:24:32
    |
-16 |         consume(UnifiedRouter::new().server(configure));
+24 |         consume(UnifiedRouter::new().server(configure));
    |                                      ^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/nested_server_builder.stderr
@@ -1,0 +1,17 @@
+error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
+ --> tests/ui/url_patterns/fail/nested_server_builder.rs:5:50
+  |
+5 |     UnifiedRouter::new().merge(UnifiedRouter::new().server(configure))
+  |                                                     ^^^^^^
+
+error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
+  --> tests/ui/url_patterns/fail/nested_server_builder.rs:10:63
+   |
+10 |     UnifiedRouter::new().mount_unified("/", UnifiedRouter::new().server(configure))
+   |                                                                  ^^^^^^
+
+error: nested UnifiedRouter .server(...) calls are unsupported here; extract the nested builder into a separate #[url_patterns] function
+  --> tests/ui/url_patterns/fail/nested_server_builder.rs:16:32
+   |
+16 |         consume(UnifiedRouter::new().server(configure));
+   |                                      ^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_function_item.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_function_item.rs
@@ -1,0 +1,6 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+struct Router;
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_function_item.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_function_item.stderr
@@ -1,0 +1,5 @@
+error: expected `fn`
+ --> tests/ui/url_patterns/fail/non_function_item.rs:4:1
+  |
+4 | struct Router;
+  | ^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_tail_body.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_tail_body.rs
@@ -1,0 +1,22 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn local_binding() -> UnifiedRouter {
+	let router = UnifiedRouter::new();
+	router
+}
+
+#[url_patterns]
+fn explicit_return() -> UnifiedRouter {
+	return UnifiedRouter::new();
+}
+
+#[url_patterns]
+fn empty() -> UnifiedRouter {}
+
+#[url_patterns]
+fn semicolon() -> UnifiedRouter {
+	UnifiedRouter::new();
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_tail_body.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/non_tail_body.stderr
@@ -1,0 +1,33 @@
+error: #[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()
+ --> tests/ui/url_patterns/fail/non_tail_body.rs:4:37
+  |
+4 |   fn local_binding() -> UnifiedRouter {
+  |  _____________________________________^
+5 | |     let router = UnifiedRouter::new();
+6 | |     router
+7 | | }
+  | |_^
+
+error: #[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()
+  --> tests/ui/url_patterns/fail/non_tail_body.rs:10:39
+   |
+10 |   fn explicit_return() -> UnifiedRouter {
+   |  _______________________________________^
+11 | |     return UnifiedRouter::new();
+12 | | }
+   | |_^
+
+error: #[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()
+  --> tests/ui/url_patterns/fail/non_tail_body.rs:15:29
+   |
+15 | fn empty() -> UnifiedRouter {}
+   |                             ^^
+
+error: #[url_patterns] requires one tail builder expression, starting with UnifiedRouter::new() or UnifiedRouter::default()
+  --> tests/ui/url_patterns/fail/non_tail_body.rs:18:33
+   |
+18 |   fn semicolon() -> UnifiedRouter {
+   |  _________________________________^
+19 | |     UnifiedRouter::new();
+20 | | }
+   | |_^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_method.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_method.rs
@@ -1,0 +1,18 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn websocket() -> UnifiedRouter {
+	UnifiedRouter::new().websocket(configure)
+}
+
+#[url_patterns]
+fn grpc() -> UnifiedRouter {
+	UnifiedRouter::new().grpc(configure)
+}
+
+#[url_patterns]
+fn custom() -> UnifiedRouter {
+	UnifiedRouter::new().custom(configure)
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_method.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_method.stderr
@@ -1,0 +1,17 @@
+error: #[url_patterns] does not support the outer builder method `websocket`; supported methods are server, client, with_prefix, with_namespace, mount_unified, and merge
+ --> tests/ui/url_patterns/fail/unsupported_method.rs:5:23
+  |
+5 |     UnifiedRouter::new().websocket(configure)
+  |                          ^^^^^^^^^
+
+error: #[url_patterns] does not support the outer builder method `grpc`; supported methods are server, client, with_prefix, with_namespace, mount_unified, and merge
+  --> tests/ui/url_patterns/fail/unsupported_method.rs:10:23
+   |
+10 |     UnifiedRouter::new().grpc(configure)
+   |                          ^^^^
+
+error: #[url_patterns] does not support the outer builder method `custom`; supported methods are server, client, with_prefix, with_namespace, mount_unified, and merge
+  --> tests/ui/url_patterns/fail/unsupported_method.rs:15:23
+   |
+15 |     UnifiedRouter::new().custom(configure)
+   |                          ^^^^^^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_root.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_root.rs
@@ -1,0 +1,29 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+fn helper_call() -> UnifiedRouter {
+	make_router()
+}
+
+#[url_patterns]
+fn variable() -> UnifiedRouter {
+	router
+}
+
+#[url_patterns]
+fn conditional() -> UnifiedRouter {
+	if enabled {
+		UnifiedRouter::new()
+	} else {
+		UnifiedRouter::default()
+	}
+}
+
+#[url_patterns]
+fn matching() -> UnifiedRouter {
+	match enabled {
+		_ => UnifiedRouter::new(),
+	}
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_root.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_root.stderr
@@ -1,0 +1,29 @@
+error: #[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain
+ --> tests/ui/url_patterns/fail/unsupported_root.rs:5:2
+  |
+5 |     make_router()
+  |     ^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain
+  --> tests/ui/url_patterns/fail/unsupported_root.rs:10:2
+   |
+10 |     router
+   |     ^^^^^^
+
+error: #[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain
+  --> tests/ui/url_patterns/fail/unsupported_root.rs:15:2
+   |
+15 | /     if enabled {
+16 | |         UnifiedRouter::new()
+17 | |     } else {
+18 | |         UnifiedRouter::default()
+19 | |     }
+   | |_____^
+
+error: #[url_patterns] requires a direct UnifiedRouter::new() or UnifiedRouter::default() builder chain
+  --> tests/ui/url_patterns/fail/unsupported_root.rs:24:2
+   |
+24 | /     match enabled {
+25 | |         _ => UnifiedRouter::new(),
+26 | |     }
+   | |_____^

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_signature.rs
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_signature.rs
@@ -1,0 +1,41 @@
+use reinhardt_macros::url_patterns;
+
+#[url_patterns]
+async fn asynchronous() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+unsafe fn unsafe_builder() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+const fn constant_builder() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+extern "C" fn external_builder() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+fn parameter(value: u8) -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+fn generic<T>() -> UnifiedRouter {
+	UnifiedRouter::new()
+}
+
+#[url_patterns]
+fn constrained() -> UnifiedRouter
+where
+	(): Sized,
+{
+	UnifiedRouter::new()
+}
+
+fn main() {}

--- a/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_signature.stderr
+++ b/crates/reinhardt-core/macros/tests/ui/url_patterns/fail/unsupported_signature.stderr
@@ -1,0 +1,43 @@
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+ --> tests/ui/url_patterns/fail/unsupported_signature.rs:4:1
+  |
+4 | async fn asynchronous() -> UnifiedRouter {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+ --> tests/ui/url_patterns/fail/unsupported_signature.rs:9:1
+  |
+9 | unsafe fn unsafe_builder() -> UnifiedRouter {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+  --> tests/ui/url_patterns/fail/unsupported_signature.rs:14:1
+   |
+14 | const fn constant_builder() -> UnifiedRouter {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+  --> tests/ui/url_patterns/fail/unsupported_signature.rs:19:1
+   |
+19 | extern "C" fn external_builder() -> UnifiedRouter {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+  --> tests/ui/url_patterns/fail/unsupported_signature.rs:24:1
+   |
+24 | fn parameter(value: u8) -> UnifiedRouter {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+  --> tests/ui/url_patterns/fail/unsupported_signature.rs:29:1
+   |
+29 | fn generic<T>() -> UnifiedRouter {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: #[url_patterns] requires a safe synchronous function without parameters, generics, const, or extern qualifiers
+  --> tests/ui/url_patterns/fail/unsupported_signature.rs:34:1
+   |
+34 | / fn constrained() -> UnifiedRouter
+35 | | where
+36 | |     (): Sized,
+   | |______________^

--- a/crates/reinhardt-graphql/README.md
+++ b/crates/reinhardt-graphql/README.md
@@ -81,6 +81,11 @@ Users should depend on `` `reinhardt-graphql` `` (this facade crate) for all Gra
   - `execute_query()`: Execute GraphQL queries via unary RPC
   - `execute_mutation()`: Execute GraphQL mutations via unary RPC
   - `execute_subscription()`: Execute GraphQL subscriptions via server streaming RPC
+- **Operation-Class Enforcement**: Each RPC validates the selected operation before
+  execution. Malformed documents, invalid or ambiguous operation selections, and
+  operation-class mismatches return gRPC `INVALID_ARGUMENT` before any resolver
+  runs. Subscription failures are reported as stream errors. Multiple operations
+  require an exact `operation_name`; a single operation may omit it or use an empty name.
 - **Protocol Buffers**: Complete proto definitions in `reinhardt-grpc` crate
   - `GraphQLRequest`: query, variables, operation_name
   - `GraphQLResponse`: data, errors, extensions
@@ -250,8 +255,20 @@ async fn handler(
 
 ### GraphQL over gRPC Server
 
+**Migration:** Replace `Schema::build(...)` or `Schema::new(...)` with
+`GraphQLGrpcService::schema_builder(...).finish()` (keep existing builder calls
+before `finish`). `GraphQLGrpcService::new` rejects schemas without the guard at
+construction time. The built-in `create_schema` helpers install it automatically
+when `graphql-grpc` is enabled.
+
+The guard runs after all `prepare_request` and `parse_query` extensions. Request
+rewrites, persisted documents, and parsing limits therefore retain their normal
+order, while the final selected operation must match the RPC. Schema validation
+and resolver authorization still apply. The finished schema can also serve HTTP
+requests without a gRPC operation restriction.
+
 ```rust
-use async_graphql::{EmptySubscription, Schema};
+use async_graphql::EmptySubscription;
 use reinhardt::graphql::grpc_service::GraphQLGrpcService;
 use reinhardt::graphql::schema::{Mutation, Query, UserStorage};
 use reinhardt::grpc::proto::graphql::graph_ql_service_server::GraphQlServiceServer;
@@ -260,7 +277,7 @@ use tonic::transport::Server;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let storage = UserStorage::new();
-    let schema = Schema::build(Query, Mutation, EmptySubscription)
+    let schema = GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription)
         .data(storage)
         .finish();
 

--- a/crates/reinhardt-graphql/SECURITY.md
+++ b/crates/reinhardt-graphql/SECURITY.md
@@ -33,11 +33,19 @@ resolver arguments are attacker-controlled.
   resolver and subscription execution. Protected deployments must fork a
   request context for each GraphQL request; the schema-level
   `with_di_context` helper reuses one context and does not provide request
-  isolation automatically. GraphQL-over-gRPC preserves the same GraphQL and
-  gRPC authorization, validation, isolation, and resource limits only when
-  each RPC rejects documents whose operation type does not match the RPC and
-  applies the corresponding controls; the current service forwards documents
-  to schema execution without enforcing that operation-type match.
+  isolation automatically.
+- GraphQL-over-gRPC binds the selected document operation to the advertised RPC
+  class before execution. Malformed documents, invalid or ambiguous operation
+  selections, and class mismatches fail with gRPC `INVALID_ARGUMENT` before
+  resolver execution or resolver subscription creation. Subscription errors are
+  delivered through the response stream. Validation applies to the final document
+  and operation name produced by schema extensions, without parsing before their
+  preparation checks. Custom schemas must use `GraphQLGrpcService::schema_builder`
+  to register the guard before user extensions; service construction rejects
+  unguarded schemas. The built-in schema helpers install the guard automatically
+  when `graphql-grpc` is enabled.
+  Deployments must still configure and enforce schema and resolver authorization,
+  request isolation, and resource limits.
 
 ## Reportable Findings
 

--- a/crates/reinhardt-graphql/src/grpc_service.rs
+++ b/crates/reinhardt-graphql/src/grpc_service.rs
@@ -1,7 +1,16 @@
 //! GraphQL over gRPC service implementation
 
+mod operation_guard;
+
+#[cfg(test)]
+mod tests;
+
+use operation_guard::{GuardedSchema, OperationCheck, OperationGuard};
+
 #[cfg(feature = "graphql-grpc")]
-use async_graphql::Schema;
+use async_graphql::parser::types::OperationType;
+#[cfg(feature = "graphql-grpc")]
+use async_graphql::{Schema, SchemaBuilder};
 #[cfg(feature = "graphql-grpc")]
 use reinhardt_grpc::proto::graphql::{
 	GraphQlRequest, GraphQlResponse, SubscriptionEvent, graph_ql_service_server::GraphQlService,
@@ -13,7 +22,12 @@ use tokio_stream::{Stream, StreamExt};
 #[cfg(feature = "graphql-grpc")]
 use tonic::{Request, Response, Status};
 
-/// GraphQL service implementation for gRPC
+/// GraphQL service implementation for gRPC.
+///
+/// Build the schema with [`Self::schema_builder`] so operation checks run after
+/// request preparation and document transformations, before any resolver runs.
+/// Invalid documents, operation selections, and class mismatches return gRPC
+/// `INVALID_ARGUMENT`. Subscriptions report these errors through their stream.
 #[cfg(feature = "graphql-grpc")]
 pub struct GraphQLGrpcService<Query, Mutation, Subscription> {
 	schema: Arc<Schema<Query, Mutation, Subscription>>,
@@ -26,16 +40,60 @@ where
 	Mutation: async_graphql::ObjectType + 'static,
 	Subscription: async_graphql::SubscriptionType + 'static,
 {
-	/// Create a new GraphQL gRPC service
+	/// Create a new GraphQL gRPC service.
+	///
+	/// # Panics
+	///
+	/// Panics if the schema was not created with [`Self::schema_builder`] (or the
+	/// built-in `create_schema` helpers with `graphql-grpc` enabled). A completed
+	/// schema cannot be retrofitted with the operation guard.
 	pub fn new(schema: Schema<Query, Mutation, Subscription>) -> Self {
+		assert!(
+			schema.data::<GuardedSchema>().is_some(),
+			"GraphQLGrpcService requires a schema built with GraphQLGrpcService::schema_builder"
+		);
 		Self {
 			schema: Arc::new(schema),
 		}
 	}
 
-	/// Convert GraphQL request to async-graphql request
-	fn convert_request(&self, req: GraphQlRequest) -> async_graphql::Request {
-		let mut gql_req = async_graphql::Request::new(&req.query);
+	/// Build a schema with transport validation surrounding all user extensions.
+	///
+	/// Replace `Schema::build` with this method and keep subsequent builder calls.
+	/// The finished schema can be shared with HTTP handlers; ordinary requests are
+	/// unaffected by the gRPC operation constraint.
+	///
+	/// ```
+	/// use async_graphql::{EmptyMutation, EmptySubscription, Object};
+	/// use reinhardt_graphql::GraphQLGrpcService;
+	/// struct Query;
+	/// #[Object]
+	/// impl Query {
+	///     async fn value(&self) -> i32 { 7 }
+	/// }
+	/// let schema = GraphQLGrpcService::schema_builder(Query, EmptyMutation, EmptySubscription)
+	///     .limit_depth(10)
+	///     .finish();
+	/// let service = GraphQLGrpcService::new(schema);
+	/// ```
+	pub fn schema_builder(
+		query: Query,
+		mutation: Mutation,
+		subscription: Subscription,
+	) -> SchemaBuilder<Query, Mutation, Subscription> {
+		Schema::build(query, mutation, subscription)
+			.extension(OperationGuard)
+			.data(GuardedSchema)
+	}
+
+	/// Convert the request without parsing ahead of schema preparation hooks.
+	fn convert_request(
+		&self,
+		req: GraphQlRequest,
+		expected: OperationType,
+	) -> (async_graphql::Request, Arc<OperationCheck>) {
+		let check = OperationCheck::new(expected);
+		let mut gql_req = async_graphql::Request::new(req.query).data(Arc::clone(&check));
 
 		// Add variables if present
 		if let Some(variables) = req.variables
@@ -52,7 +110,7 @@ where
 			gql_req = gql_req.operation_name(operation_name);
 		}
 
-		gql_req
+		(gql_req, check)
 	}
 
 	/// Convert async-graphql response to gRPC response
@@ -151,10 +209,13 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<GraphQlResponse>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Query);
 
 		// Execute query
 		let gql_resp = self.schema.execute(gql_req).await;
+		if let Some(error) = check.error() {
+			return Err(error);
+		}
 
 		// Convert response
 		let grpc_resp = self.convert_response(gql_resp);
@@ -168,10 +229,13 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<GraphQlResponse>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Mutation);
 
 		// Execute mutation
 		let gql_resp = self.schema.execute(gql_req).await;
+		if let Some(error) = check.error() {
+			return Err(error);
+		}
 
 		// Convert response
 		let grpc_resp = self.convert_response(gql_resp);
@@ -188,7 +252,7 @@ where
 		request: Request<GraphQlRequest>,
 	) -> Result<Response<Self::ExecuteSubscriptionStream>, Status> {
 		let req = request.into_inner();
-		let gql_req = self.convert_request(req);
+		let (gql_req, check) = self.convert_request(req, OperationType::Subscription);
 
 		// Clone schema for 'static lifetime requirement
 		let schema = Arc::clone(&self.schema);
@@ -200,6 +264,10 @@ where
 
 			let mut event_id = 0u64;
 			while let Some(resp) = stream.next().await {
+				if let Some(error) = check.error() {
+					yield Err(error);
+					return;
+				}
 				event_id += 1;
 
 				let grpc_resp = GraphQlResponse {

--- a/crates/reinhardt-graphql/src/grpc_service/operation_guard.rs
+++ b/crates/reinhardt-graphql/src/grpc_service/operation_guard.rs
@@ -1,0 +1,143 @@
+//! Enforce the transport constraint on the document produced by schema extensions.
+
+use async_graphql::extensions::{
+	Extension, ExtensionContext, ExtensionFactory, NextParseQuery, NextPrepareRequest,
+};
+use async_graphql::parser::types::{DocumentOperations, ExecutableDocument, OperationType};
+use async_graphql::{Request, ServerError, ServerResult, Variables};
+use std::any::TypeId;
+use std::sync::{Arc, OnceLock};
+use tonic::Status;
+
+pub(super) struct GuardedSchema;
+
+pub(super) struct OperationCheck {
+	expected: OperationType,
+	error: OnceLock<Status>,
+}
+
+impl OperationCheck {
+	pub(super) fn new(expected: OperationType) -> Arc<Self> {
+		Arc::new(Self {
+			expected,
+			error: OnceLock::new(),
+		})
+	}
+
+	pub(super) fn error(&self) -> Option<Status> {
+		self.error.get().cloned()
+	}
+
+	fn reject(&self, status: Status) -> ServerError {
+		let error = ServerError::new(status.message(), None);
+		let _ = self.error.set(status);
+		error
+	}
+}
+
+pub(super) struct OperationGuard;
+
+impl ExtensionFactory for OperationGuard {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(OperationGuardExtension::default())
+	}
+}
+
+struct PreparedOperation {
+	check: Arc<OperationCheck>,
+	operation_name: Option<String>,
+}
+
+#[derive(Default)]
+struct OperationGuardExtension {
+	prepared: OnceLock<PreparedOperation>,
+}
+
+#[async_trait::async_trait]
+impl Extension for OperationGuardExtension {
+	async fn prepare_request(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		request: Request,
+		next: NextPrepareRequest<'_>,
+	) -> ServerResult<Request> {
+		// Keep the RPC constraint even when an extension replaces the entire request.
+		let check = request
+			.data
+			.get(&TypeId::of::<Arc<OperationCheck>>())
+			.and_then(|data| data.downcast_ref::<Arc<OperationCheck>>())
+			.cloned();
+		let request = next.run(ctx, request).await?;
+		if let Some(check) = check {
+			let _ = self.prepared.set(PreparedOperation {
+				check,
+				operation_name: request.operation_name.clone(),
+			});
+		}
+		Ok(request)
+	}
+
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &Variables,
+		next: NextParseQuery<'_>,
+	) -> ServerResult<ExecutableDocument> {
+		// This is the first registered extension, so all request and document
+		// transformations finish before the transport constraint is checked.
+		let result = next.run(ctx, query, variables).await;
+		let Some(prepared) = self.prepared.get() else {
+			// The same schema can also serve ordinary GraphQL requests.
+			return result;
+		};
+		let document = result.map_err(|error| {
+			prepared.check.reject(Status::invalid_argument(format!(
+				"Invalid GraphQL document: {}",
+				error.message
+			)))
+		})?;
+		validate_operation(
+			&document,
+			prepared.operation_name.as_deref(),
+			prepared.check.expected,
+		)
+		.map_err(|status| prepared.check.reject(status))?;
+		Ok(document)
+	}
+}
+
+fn validate_operation(
+	document: &ExecutableDocument,
+	operation_name: Option<&str>,
+	expected: OperationType,
+) -> Result<(), Status> {
+	// Match async-graphql's operation selection, including a lone named operation.
+	let operation = match (&document.operations, operation_name) {
+		(DocumentOperations::Single(operation), None) => operation,
+		(DocumentOperations::Single(_), Some(_)) => {
+			return Err(Status::invalid_argument(
+				"operation_name cannot select an anonymous operation",
+			));
+		}
+		(DocumentOperations::Multiple(operations), Some(name)) => operations
+			.get(name)
+			.ok_or_else(|| Status::invalid_argument("operation_name was not found"))?,
+		(DocumentOperations::Multiple(operations), None) if operations.len() == 1 => operations
+			.values()
+			.next()
+			.expect("single operation was checked"),
+		(DocumentOperations::Multiple(_), None) => {
+			return Err(Status::invalid_argument(
+				"operation_name is required for documents with multiple operations",
+			));
+		}
+	};
+	if operation.node.ty != expected {
+		return Err(Status::invalid_argument(format!(
+			"Expected a {expected} operation, received {}",
+			operation.node.ty
+		)));
+	}
+	Ok(())
+}

--- a/crates/reinhardt-graphql/src/grpc_service/tests.rs
+++ b/crates/reinhardt-graphql/src/grpc_service/tests.rs
@@ -1,0 +1,633 @@
+use super::*;
+use async_graphql::extensions::{
+	Extension, ExtensionContext, ExtensionFactory, NextParseQuery, NextPrepareRequest,
+};
+use async_graphql::parser::types::ExecutableDocument;
+use async_graphql::parser::types::OperationType;
+use rstest::{fixture, rstest};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Default)]
+struct RequestExtension {
+	replacement: Option<String>,
+	operation_name: Option<String>,
+	max_bytes: Option<usize>,
+	replace_entire: bool,
+	prepared: Arc<AtomicUsize>,
+	parsed: Arc<AtomicUsize>,
+}
+
+impl ExtensionFactory for RequestExtension {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(self.clone())
+	}
+}
+
+#[async_trait::async_trait]
+impl Extension for RequestExtension {
+	async fn prepare_request(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		mut request: async_graphql::Request,
+		next: NextPrepareRequest<'_>,
+	) -> async_graphql::ServerResult<async_graphql::Request> {
+		self.prepared.fetch_add(1, Ordering::SeqCst);
+		if self
+			.max_bytes
+			.is_some_and(|limit| request.query.len() > limit)
+		{
+			return Err(async_graphql::ServerError::new(
+				"Document size limit exceeded",
+				None,
+			));
+		}
+		if let Some(query) = &self.replacement {
+			// Replacing the whole request must not discard the transport's constraint.
+			if self.replace_entire {
+				let variables = request.variables;
+				request = async_graphql::Request::new(query).variables(variables);
+			} else {
+				request.query.clone_from(query);
+			}
+			request.operation_name = self.operation_name.clone();
+		}
+		next.run(ctx, request).await
+	}
+
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &async_graphql::Variables,
+		next: NextParseQuery<'_>,
+	) -> async_graphql::ServerResult<ExecutableDocument> {
+		self.parsed.fetch_add(1, Ordering::SeqCst);
+		next.run(ctx, query, variables).await
+	}
+}
+
+fn service_with_extension(extension: RequestExtension) -> (TestService, Arc<Calls>) {
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.extension(extension)
+	.finish();
+	(TestService::new(schema), calls)
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_executes_prepared_document(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[values(false, true)] invalid_original: bool,
+	#[values(false, true)] replace_entire: bool,
+) {
+	// Arrange: preparation replaces the document, selected name, and request data.
+	let prepared = Arc::new(AtomicUsize::new(0));
+	let parsed = Arc::new(AtomicUsize::new(0));
+	let (service, calls) = service_with_extension(RequestExtension {
+		replacement: Some(format!(
+			"{rpc} Prepared($amount: Int!) {{ value(amount: $amount) }}"
+		)),
+		operation_name: Some("Prepared".into()),
+		max_bytes: None,
+		replace_entire,
+		prepared: Arc::clone(&prepared),
+		parsed: Arc::clone(&parsed),
+	});
+	let original = if invalid_original {
+		"not a GraphQL document".into()
+	} else {
+		format!("{rpc} Original {{ value(amount: 1) }}")
+	};
+
+	// Act
+	let response = dispatch(&service, rpc, request(&original, Some("Original")))
+		.await
+		.unwrap();
+
+	// Assert: only the prepared document executes, and hooks run once.
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts().iter().sum::<usize>(), 1);
+	assert_eq!(prepared.load(Ordering::SeqCst), 1);
+	assert_eq!(parsed.load(Ordering::SeqCst), 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_runs_preparation_limits_before_parsing(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+) {
+	// Arrange: this invalid document must be rejected by preparation, before parsing.
+	let prepared = Arc::new(AtomicUsize::new(0));
+	let parsed = Arc::new(AtomicUsize::new(0));
+	let (service, calls) = service_with_extension(RequestExtension {
+		replacement: None,
+		operation_name: None,
+		max_bytes: Some(8),
+		replace_entire: false,
+		prepared: Arc::clone(&prepared),
+		parsed: Arc::clone(&parsed),
+	});
+
+	// Act
+	let response = dispatch(&service, rpc, request("not a GraphQL document", None))
+		.await
+		.unwrap();
+
+	// Assert: preserve the extension's rejection and never run a resolver.
+	assert_eq!(response.data, None);
+	assert_eq!(response.errors.len(), 1);
+	assert_eq!(response.errors[0].message, "Document size limit exceeded");
+	assert_eq!(calls.counts(), [0, 0, 0]);
+	assert_eq!(prepared.load(Ordering::SeqCst), 1);
+	assert_eq!(parsed.load(Ordering::SeqCst), 0);
+}
+
+#[derive(Clone)]
+struct ReplaceDocument(String);
+
+impl ExtensionFactory for ReplaceDocument {
+	fn create(&self) -> Arc<dyn Extension> {
+		Arc::new(self.clone())
+	}
+}
+
+#[async_trait::async_trait]
+impl Extension for ReplaceDocument {
+	async fn parse_query(
+		&self,
+		ctx: &ExtensionContext<'_>,
+		query: &str,
+		variables: &async_graphql::Variables,
+		next: NextParseQuery<'_>,
+	) -> async_graphql::ServerResult<ExecutableDocument> {
+		next.run(ctx, query, variables).await?;
+		// A user extension can return a different AST after the parser finishes.
+		async_graphql::parser::parse_query(&self.0).map_err(Into::into)
+	}
+}
+
+#[rstest]
+#[case(OperationType::Query, OperationType::Mutation)]
+#[case(OperationType::Query, OperationType::Subscription)]
+#[case(OperationType::Mutation, OperationType::Query)]
+#[case(OperationType::Mutation, OperationType::Subscription)]
+#[case(OperationType::Subscription, OperationType::Query)]
+#[case(OperationType::Subscription, OperationType::Mutation)]
+#[tokio::test]
+async fn rpc_rejects_class_changes_from_extensions(
+	#[case] rpc: OperationType,
+	#[case] replacement: OperationType,
+	#[values(false, true)] replace_at_parse: bool,
+) {
+	// Arrange: the original document matches the RPC, but the final one does not.
+	let calls = Arc::new(Calls::default());
+	let builder = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	);
+	let query = format!("{replacement} {{ value(amount: 7) }}");
+	let schema = if replace_at_parse {
+		builder.extension(ReplaceDocument(query)).finish()
+	} else {
+		builder
+			.extension(RequestExtension {
+				replacement: Some(query),
+				replace_entire: true,
+				..Default::default()
+			})
+			.finish()
+	};
+	let service = TestService::new(schema);
+	let original = format!("{rpc} {{ value(amount: 1) }}");
+
+	// Act
+	let error = dispatch(&service, rpc, request(&original, None))
+		.await
+		.unwrap_err();
+
+	// Assert: every transformed mismatch is rejected before side effects.
+	assert_eq!(error.code(), tonic::Code::InvalidArgument);
+	assert_eq!(
+		error.message(),
+		format!("Expected a {rpc} operation, received {replacement}")
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_executes_document_returned_by_parse_extension(
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+) {
+	// Arrange
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.extension(ReplaceDocument(format!("{rpc} {{ value(amount: 7) }}")))
+	.finish();
+	let service = TestService::new(schema);
+
+	// Act
+	let response = dispatch(
+		&service,
+		rpc,
+		request(&format!("{rpc} {{ value(amount: 1) }}"), None),
+	)
+	.await
+	.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts().iter().sum::<usize>(), 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn schema_remains_shareable_with_ordinary_graphql_requests(
+	service: (TestService, Arc<Calls>),
+) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act: ordinary requests do not carry an RPC operation constraint.
+	let response = service
+		.schema
+		.execute("mutation { value(amount: 7) }")
+		.await;
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data, async_graphql::value!({"value": 7}));
+	assert_eq!(calls.counts(), [0, 1, 0]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn concurrent_rpcs_keep_independent_constraints(service: (TestService, Arc<Calls>)) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act
+	let (query, mutation, subscription) = tokio::join!(
+		dispatch(
+			&service,
+			OperationType::Query,
+			request("mutation { value(amount: 1) }", None)
+		),
+		dispatch(
+			&service,
+			OperationType::Mutation,
+			request("mutation { value(amount: 7) }", None)
+		),
+		dispatch(
+			&service,
+			OperationType::Subscription,
+			request("subscription { value(amount: 7) }", None)
+		),
+	);
+
+	// Assert
+	assert_eq!(query.unwrap_err().code(), tonic::Code::InvalidArgument);
+	assert_eq!(mutation.unwrap().data.as_deref(), Some("{value: 7}"));
+	assert_eq!(subscription.unwrap().data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts(), [0, 1, 1]);
+}
+
+#[rstest]
+#[should_panic(
+	expected = "GraphQLGrpcService requires a schema built with GraphQLGrpcService::schema_builder"
+)]
+fn service_rejects_schema_without_operation_guard() {
+	// Arrange
+	let calls = Arc::new(Calls::default());
+	let schema = Schema::new(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(calls),
+	);
+
+	// Act / Assert: an unguarded schema cannot become an executable gRPC service.
+	TestService::new(schema);
+}
+
+#[derive(Default)]
+struct Calls([AtomicUsize; 3]);
+
+impl Calls {
+	fn counts(&self) -> [usize; 3] {
+		self.0.each_ref().map(|count| count.load(Ordering::SeqCst))
+	}
+}
+
+struct Query(Arc<Calls>);
+struct Mutation(Arc<Calls>);
+struct Subscription(Arc<Calls>);
+
+#[async_graphql::Object]
+impl Query {
+	async fn value(&self, amount: i32) -> i32 {
+		self.0.0[0].fetch_add(1, Ordering::SeqCst);
+		amount
+	}
+}
+
+#[async_graphql::Object]
+impl Mutation {
+	async fn value(&self, amount: i32) -> i32 {
+		self.0.0[1].fetch_add(1, Ordering::SeqCst);
+		amount
+	}
+}
+
+#[async_graphql::Subscription]
+impl Subscription {
+	async fn value(&self, amount: i32) -> impl Stream<Item = i32> {
+		self.0.0[2].fetch_add(1, Ordering::SeqCst);
+		tokio_stream::iter([amount])
+	}
+}
+
+type TestService = GraphQLGrpcService<Query, Mutation, Subscription>;
+
+#[fixture]
+fn service() -> (TestService, Arc<Calls>) {
+	let calls = Arc::new(Calls::default());
+	let schema = TestService::schema_builder(
+		Query(Arc::clone(&calls)),
+		Mutation(Arc::clone(&calls)),
+		Subscription(Arc::clone(&calls)),
+	)
+	.finish();
+	(TestService::new(schema), calls)
+}
+
+fn request(query: &str, operation_name: Option<&str>) -> Request<GraphQlRequest> {
+	Request::new(GraphQlRequest {
+		query: query.into(),
+		operation_name: operation_name.map(str::to_owned),
+		variables: Some(r#"{"amount":7}"#.into()),
+	})
+}
+
+async fn dispatch(
+	service: &TestService,
+	rpc: OperationType,
+	request: Request<GraphQlRequest>,
+) -> Result<GraphQlResponse, Status> {
+	match rpc {
+		OperationType::Query => service
+			.execute_query(request)
+			.await
+			.map(Response::into_inner),
+		OperationType::Mutation => service
+			.execute_mutation(request)
+			.await
+			.map(Response::into_inner),
+		OperationType::Subscription => {
+			let mut stream = service.execute_subscription(request).await?.into_inner();
+			let event = stream.next().await.expect("one subscription event")?;
+			assert_eq!(event.event_type, "data");
+			assert_eq!(event.id, "1");
+			assert_eq!(stream.next().await.map(|_| ()), None);
+			Ok(event.payload.expect("subscription payload"))
+		}
+	}
+}
+
+#[rstest]
+#[case(OperationType::Query, "mutation", None)]
+#[case(OperationType::Query, "subscription", None)]
+#[case(OperationType::Mutation, "query", None)]
+#[case(OperationType::Mutation, "subscription", None)]
+#[case(OperationType::Subscription, "query", None)]
+#[case(OperationType::Subscription, "mutation", None)]
+#[case(OperationType::Query, "mutation", Some("Selected"))]
+#[case(OperationType::Query, "subscription", Some("Selected"))]
+#[case(OperationType::Mutation, "query", Some("Selected"))]
+#[case(OperationType::Mutation, "subscription", Some("Selected"))]
+#[case(OperationType::Subscription, "query", Some("Selected"))]
+#[case(OperationType::Subscription, "mutation", Some("Selected"))]
+#[tokio::test]
+async fn rpc_rejects_mismatched_operation_before_resolver_execution(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] submitted: &str,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange: include a matching decoy before the selected mismatched operation.
+	let (service, calls) = service;
+	let query = if operation_name.is_some() {
+		format!("{rpc} Decoy {{ value(amount: 1) }} {submitted} Selected {{ value(amount: 7) }}")
+	} else {
+		format!("{submitted} {{ value(amount: 7) }}")
+	};
+	let request = request(&query, operation_name);
+
+	// Act: drive subscription preparation without allowing a resolver to run.
+	let result = dispatch(&service, rpc, request).await;
+
+	// Assert: no query, mutation, or subscription resolver ran.
+	assert_eq!(calls.counts(), [0, 0, 0]);
+	let error = result.expect_err("RPC must reject the selected operation class");
+	assert_eq!(error.code(), tonic::Code::InvalidArgument);
+	assert_eq!(
+		error.message(),
+		format!("Expected a {rpc} operation, received {submitted}")
+	);
+}
+
+#[rstest]
+#[case("", None)]
+#[case("query {", None)]
+#[case("fragment Fields on Query { value(amount: 7) }", None)]
+#[case(
+	"query Same { value(amount: 7) } mutation Same { value(amount: 7) }",
+	Some("Same")
+)]
+#[case("{ value(amount: 7) } query Read { value(amount: 7) }", None)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	None
+)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	Some("")
+)]
+#[case(
+	"query Read { value(amount: 7) } mutation Change { value(amount: 7) }",
+	Some("Missing")
+)]
+#[case("query Read { value(amount: 7) }", Some("read"))]
+#[case("query Read { value(amount: 7) }", Some(" Read "))]
+#[case("{ value(amount: 7) }", Some("Read"))]
+#[tokio::test]
+async fn rpc_rejects_invalid_or_ambiguous_selection(
+	service: (TestService, Arc<Calls>),
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[case] query: &str,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let request = request(query, operation_name);
+
+	// Act
+	let result = dispatch(&service, rpc, request).await;
+
+	// Assert
+	assert_eq!(
+		result.expect_err("invalid operation selection").code(),
+		tonic::Code::InvalidArgument
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}
+
+#[rstest]
+#[case(false, None)]
+#[case(false, Some(""))]
+#[case(true, None)]
+#[case(true, Some(""))]
+#[case(true, Some("Selected"))]
+#[tokio::test]
+async fn rpc_accepts_single_operation(
+	service: (TestService, Arc<Calls>),
+	#[values(
+		OperationType::Query,
+		OperationType::Mutation,
+		OperationType::Subscription
+	)]
+	rpc: OperationType,
+	#[case] named: bool,
+	#[case] operation_name: Option<&str>,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let name = if named { "Selected" } else { "" };
+	let query = format!("{rpc} {name}($amount: Int!) {{ value(amount: $amount) }}");
+
+	// Act
+	let response = dispatch(&service, rpc, request(&query, operation_name))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(
+		calls.counts(),
+		match rpc {
+			OperationType::Query => [1, 0, 0],
+			OperationType::Mutation => [0, 1, 0],
+			OperationType::Subscription => [0, 0, 1],
+		}
+	);
+}
+
+#[rstest]
+#[case(OperationType::Query, "Read", [1, 0, 0])]
+#[case(OperationType::Mutation, "Change", [0, 1, 0])]
+#[case(OperationType::Subscription, "Watch", [0, 0, 1])]
+#[tokio::test]
+async fn rpc_selects_matching_operation_with_variables_aliases_and_fragments(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] operation_name: &str,
+	#[case] expected_calls: [usize; 3],
+) {
+	// Arrange: only the selected operation may execute, regardless of document order.
+	let (service, calls) = service;
+	let query = "mutation Change($amount: Int!) { ...MutationFields }
+		subscription Watch($amount: Int!) { result: value(amount: $amount) }
+		query Read($amount: Int!) { ...QueryFields }
+		fragment QueryFields on Query { result: value(amount: $amount) }
+		fragment MutationFields on Mutation { result: value(amount: $amount) }";
+
+	// Act
+	let response = dispatch(&service, rpc, request(query, Some(operation_name)))
+		.await
+		.unwrap();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{result: 7}"));
+	assert_eq!(calls.counts(), expected_calls);
+}
+
+#[rstest]
+#[tokio::test]
+async fn rpc_accepts_shorthand_query(service: (TestService, Arc<Calls>)) {
+	// Arrange
+	let (service, calls) = service;
+
+	// Act
+	let response = service
+		.execute_query(request("{ value(amount: 7) }", None))
+		.await
+		.unwrap()
+		.into_inner();
+
+	// Assert
+	assert_eq!(response.errors, []);
+	assert_eq!(response.data.as_deref(), Some("{value: 7}"));
+	assert_eq!(calls.counts(), [1, 0, 0]);
+}
+
+#[rstest]
+#[case(OperationType::Query, "Query")]
+#[case(OperationType::Mutation, "Mutation")]
+#[case(OperationType::Subscription, "Subscription")]
+#[tokio::test]
+async fn rpc_preserves_schema_validation_errors(
+	service: (TestService, Arc<Calls>),
+	#[case] rpc: OperationType,
+	#[case] root_type: &str,
+) {
+	// Arrange
+	let (service, calls) = service;
+	let query = format!("{rpc} {{ missing }}");
+
+	// Act: valid operation selection still reaches schema validation.
+	let response = dispatch(&service, rpc, request(&query, None))
+		.await
+		.unwrap();
+
+	// Assert: schema errors retain their GraphQL response shape.
+	assert_eq!(response.data, None);
+	assert_eq!(response.errors.len(), 1);
+	assert_eq!(
+		response.errors[0].message,
+		format!("Unknown field \"missing\" on type \"{root_type}\".")
+	);
+	assert_eq!(calls.counts(), [0, 0, 0]);
+}

--- a/crates/reinhardt-graphql/src/lib.rs
+++ b/crates/reinhardt-graphql/src/lib.rs
@@ -10,6 +10,22 @@
 //! - **di**: Dependency injection support for GraphQL resolvers
 //! - **full**: All features enabled
 //!
+//! # GraphQL over gRPC
+//!
+//! Each RPC accepts only its advertised query, mutation, or subscription operation.
+//! The adapter returns gRPC `INVALID_ARGUMENT` for malformed documents, invalid or
+//! ambiguous operation selections, and operation-class mismatches before execution.
+//! Documents with multiple operations require an exact operation name. A single
+//! operation may omit the name or pass an empty name. Schema validation and resolver
+//! authorization still apply after this transport-level check. Subscription errors
+//! are delivered through the response stream.
+//!
+//! Build custom gRPC schemas with `GraphQLGrpcService::schema_builder` instead of
+//! `Schema::build` / `Schema::new`. This installs the operation guard before user
+//! extensions, so preparation limits and document rewrites run in their normal
+//! order. `GraphQLGrpcService::new` panics for unguarded schemas. The built-in
+//! `create_schema` helpers install the guard when `graphql-grpc` is enabled.
+//!
 //! # Dependency Injection
 //!
 //! Enable the `di` feature to use dependency injection in GraphQL resolvers:

--- a/crates/reinhardt-graphql/src/schema.rs
+++ b/crates/reinhardt-graphql/src/schema.rs
@@ -653,7 +653,11 @@ pub fn create_schema(storage: UserStorage) -> AppSchema {
 /// * `storage` - User data storage
 /// * `limits` - Query protection limits configuration
 pub fn create_schema_with_limits(storage: UserStorage, limits: QueryLimits) -> AppSchema {
-	Schema::build(Query, Mutation, EmptySubscription)
+	#[cfg(feature = "graphql-grpc")]
+	let builder = crate::GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription);
+	#[cfg(not(feature = "graphql-grpc"))]
+	let builder = Schema::build(Query, Mutation, EmptySubscription);
+	builder
 		.data(storage)
 		.limit_depth(limits.max_depth)
 		.limit_complexity(limits.max_complexity)

--- a/crates/reinhardt-graphql/tests/di_integration.rs
+++ b/crates/reinhardt-graphql/tests/di_integration.rs
@@ -1,7 +1,8 @@
 //! Integration tests for GraphQL dependency injection
 //!
 //! These tests verify that the `#[graphql_handler]` macro correctly integrates
-//! with the DI system.
+//! with the DI system. Shared mock factories are registered once so parallel
+//! fixtures can safely create independent request contexts.
 
 #![cfg(feature = "di")]
 
@@ -11,7 +12,7 @@ use reinhardt_di::{
 };
 use reinhardt_graphql::{SchemaBuilderExt, graphql_handler};
 use rstest::*;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
 /// Mock database connection for testing
 #[derive(Clone)]
@@ -129,17 +130,17 @@ impl User {
 
 /// Register mock types in the global registry for DI resolution.
 fn register_mock_types() {
-	let registry = global_registry();
-	if !registry.is_registered::<MockDatabase>() {
+	static REGISTER: Once = Once::new();
+	// Test fixtures run concurrently; checking and registering must be atomic.
+	REGISTER.call_once(|| {
+		let registry = global_registry();
 		registry.register_async::<MockDatabase, _, _>(DependencyScope::Request, |_ctx| async {
 			Ok(MockDatabase::new())
 		});
-	}
-	if !registry.is_registered::<MockCache>() {
 		registry.register_async::<MockCache, _, _>(DependencyScope::Request, |_ctx| async {
 			Ok(MockCache::new())
 		});
-	}
+	});
 }
 
 /// Fixture: Injection context with database and cache

--- a/crates/reinhardt-urls/README.md
+++ b/crates/reinhardt-urls/README.md
@@ -126,6 +126,44 @@ client routes, so `.server(...)` type-checks but is inert. Do not rely on an
 inactive closure for required side effects; test client route behavior by
 constructing `ClientRouter` directly inside a reactive scope on native.
 
+When server handlers live in cfg-gated modules, use the facade's
+`#[reinhardt::url_patterns]` attribute to remove their complete `.server(...)`
+arguments before name resolution on inactive targets:
+
+```rust
+use reinhardt::urls::prelude::UnifiedRouter;
+
+#[reinhardt::url_patterns]
+pub fn url_patterns() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.server(|server| server.endpoint(crate::native_handlers::health))
+		.with_namespace("demo")
+}
+```
+
+The attribute preserves server calls only when the **calling crate** enables
+`cfg(server)` and the target is not browser WASM
+(`all(target_family = "wasm", target_os = "unknown")`). For example, a caller
+can declare a `server = []` Cargo feature and use this `build.rs`:
+
+```rust
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(server)");
+	if std::env::var_os("CARGO_FEATURE_SERVER").is_some() {
+		println!("cargo::rustc-cfg=server");
+	}
+}
+```
+
+Keep native handler modules and native Cargo dependencies target-gated.
+The attribute supports one builder expression starting at
+`UnifiedRouter::new()` or `default()`, followed by `server`, `client`,
+`with_prefix`, `with_namespace`, `mount_unified`, or `merge`. Use separate
+annotated functions for nested server builders. It adds no inventory entry;
+retain a single root `#[routes]`, which can be stacked in either order with
+`#[url_patterns]`. Existing builder calls without the attribute retain their
+original type-checking behavior.
+
 ### Synchronous Server Routes
 
 Use `endpoint_sync` or `handler_sync` for routes that can build a response

--- a/crates/reinhardt-urls/src/routers/unified_router.rs
+++ b/crates/reinhardt-urls/src/routers/unified_router.rs
@@ -181,6 +181,11 @@ impl UnifiedRouter {
 	/// Native builds execute the closure and store the configured `ServerRouter`.
 	/// The WASM counterpart type-checks and drops the closure without invoking it.
 	///
+	/// For native-only handler references, annotate the enclosing builder function
+	/// with the facade's `#[reinhardt::url_patterns]`. It removes the complete
+	/// server argument before name resolution unless the caller enables
+	/// `cfg(server)` on a non-browser-WASM target.
+	///
 	/// # Example
 	///
 	/// ```rust,ignore
@@ -549,6 +554,10 @@ impl UnifiedRouter {
 	/// This arm only exists when `client-router` is disabled, and `routers.rs`
 	/// only re-exports it on native targets. WASM builds require the
 	/// `client-router` feature for the P1 no-op `server` closure shape.
+	///
+	/// The facade's `#[reinhardt::url_patterns]` can remove this call entirely
+	/// when the calling crate does not enable `cfg(server)`. Direct builder
+	/// calls retain their existing behavior.
 	pub fn server<F>(mut self, f: F) -> Self
 	where
 		F: FnOnce(ServerRouter) -> ServerRouter,
@@ -1010,6 +1019,10 @@ impl UnifiedRouter {
 	/// cross-target type-checking — its `ServerRouter` parameter type is unified
 	/// with the native arm — and then discarded without being invoked, so the
 	/// shared route definitions compile on both targets at zero WASM runtime cost.
+	/// Handler names must still be available on WASM for a direct builder call.
+	/// The facade's `#[reinhardt::url_patterns]` removes the complete server
+	/// argument before name resolution on browser WASM, even if the caller has
+	/// `cfg(server)` enabled.
 	pub fn server<F>(self, _f: F) -> Self
 	where
 		F: FnOnce(ServerRouter) -> ServerRouter,

--- a/instructions/API_PARITY.md
+++ b/instructions/API_PARITY.md
@@ -29,6 +29,7 @@ existing binding.
 |---|---|---|
 | `UnifiedRouter::server` | Invokes the closure and stores native server routes. | Type-checks and drops the closure without invoking it. |
 | `UnifiedRouter::client` | Type-checks and drops the closure without invoking it. | Invokes the closure and stores client routes. |
+| `#[url_patterns]` | Retains the complete `.server(...)` configuration and its native handler references. | Erases the complete `.server(...)` argument before browser-WASM name resolution while preserving the shared builder chain. |
 
 Inactive `UnifiedRouter` closures must not contain required side effects. Each
 active target must have an executable test proving its route configuration.

--- a/src/exports/macros.rs
+++ b/src/exports/macros.rs
@@ -27,9 +27,9 @@ pub use reinhardt_macros::websocket;
 
 #[cfg(native)]
 pub use reinhardt_macros::flatten_imports;
-pub use reinhardt_macros::routes;
 #[cfg(native)]
 pub use reinhardt_macros::viewset;
+pub use reinhardt_macros::{routes, url_patterns};
 
 #[cfg(all(feature = "admin", native))]
 pub use reinhardt_macros::admin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,17 @@
 //! - **Zero-Cost Abstractions**: High-level ergonomics without runtime overhead
 //! - **Async-First**: Built on tokio and async/await from the ground up
 //!
+//! ## Shared URL Declarations
+//!
+//! Apply [`macro@url_patterns`] to a synchronous function returning
+//! `UnifiedRouter` to share a builder chain containing native-only handlers.
+//! The attribute removes `.server(...)` calls unless the caller enables
+//! `cfg(server)` on a non-browser-WASM target. Client configuration, prefixes,
+//! namespaces, mounts, and merges retain their existing behavior. The macro
+//! is available on both targets; browser routing requires `client-router`.
+//! Keep [`macro@routes`] on the single project-level entry point for inventory
+//! registration. The attributes can be stacked in either order.
+//!
 //! ## Generated Model Form Facade
 //!
 //! Enable the `forms` feature to use generated model-backed forms through the

--- a/tests/bench/graphql_performance.rs
+++ b/tests/bench/graphql_performance.rs
@@ -92,7 +92,7 @@ fn bench_direct_graphql(c: &mut Criterion) {
 #[cfg(feature = "graphql-grpc")]
 fn bench_grpc_graphql(c: &mut Criterion) {
 	let runtime = tokio::runtime::Runtime::new().unwrap();
-	let schema = Schema::build(Query, Mutation, EmptySubscription).finish();
+	let schema = GraphQLGrpcService::schema_builder(Query, Mutation, EmptySubscription).finish();
 	let service = GraphQLGrpcService::new(schema);
 
 	let mut group = c.benchmark_group("grpc_graphql");

--- a/tests/integration/src/graphql/fixtures/schema.rs
+++ b/tests/integration/src/graphql/fixtures/schema.rs
@@ -83,12 +83,12 @@ async fn grpc_fixture(
 	#[future] postgres_container: (ContainerAsync<GenericImage>, Arc<PgPool>, u16, String),
 ) -> (
 	Schema<Query, Mutation, EmptySubscription>,
-	GraphQLGrpcService,
+	reinhardt_graphql::GraphQLGrpcService<Query, Mutation, EmptySubscription>,
 ) {
 	use reinhardt_graphql::grpc_service::GraphQLGrpcService;
 
 	let (_container, pool, _port, _url) = postgres_container.await;
-	let schema = create_schema();
+	let schema = reinhardt_graphql::create_schema(UserStorage::new());
 	let grpc_service = GraphQLGrpcService::new(schema.clone());
 
 	(schema, grpc_service)

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/README.md
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/README.md
@@ -1,0 +1,87 @@
+# Shared URL Pattern Consumer Fixture
+
+This fixture uses the real `reinhardt-web` facade and HTTP endpoint attributes.
+The host integration test creates isolated Cargo consumers under a temporary
+directory, substitutes either `reinhardt` or `framework` as the dependency
+name, and shares build artifacts within that test. The owning guards remove
+sources, build artifacts, logs, and child processes when the test exits.
+Consumer dev and test profiles omit debug information to limit repeated
+native linking and WASM binding-generation costs; debug assertions remain
+enabled.
+
+The calling crate declares `cfg(server)` in `build.rs` and enables it through
+its own `server` feature. Native handler modules, injected types, and captured
+values are absent on inactive targets. A native-only dependency deliberately
+fails to compile for browser WASM; both Cargo's build artifacts and target
+dependency tree must prove its absence there.
+
+## Compile and Native Runtime Matrix
+
+| Target | Caller `server` | `client-router` | Expected behavior |
+| --- | --- | --- | --- |
+| Native | Enabled | Disabled / enabled | Real HTTP handlers execute |
+| Native | Disabled | Disabled / enabled | Server arguments are erased |
+| `wasm32-unknown-unknown` | Disabled / enabled | Enabled | Client declarations compile; native references are erased |
+
+Each configuration runs with both facade dependency names. Native tests
+compare literal route paths, contract metadata, HTTP responses, middleware
+enforcement, injected values, evaluation order, and temporary destruction
+against handwritten builders. Both orders of `#[routes]` and
+`#[url_patterns]` are linked and executed on native, and compiled for WASM.
+Per-app attributes alone must contribute zero inventory registrations; each
+selected root contributes exactly one.
+
+The host matrix executes 64 Cargo commands, including 16 native test runs
+containing 124 tests in total. Its exact Nextest override
+reserves both worker slots and allows three 1200-second periods for nested
+compilation; other integration tests retain their existing limits.
+
+Negative controls require specific failures:
+
+- Removing the attribute exposes unavailable native handler paths (`E0433`).
+- Passing a non-handler to `.endpoint(...)` still fails in native server code
+  (`E0277`).
+- Unsupported bodies, methods, and nested server builders produce identical
+  primary diagnostics and source spans on every target and cfg variant.
+
+Install `wasm32-unknown-unknown` and populate Cargo's dependency cache before
+the offline nested checks:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo fetch --target wasm32-unknown-unknown
+cargo test -p reinhardt-integration-tests --test url_patterns_target_parity url_patterns_target_matrix -- --exact --nocapture
+```
+
+## Browser Runtime
+
+The browser test is explicitly ignored during ordinary integration runs and
+must be requested with `--ignored`. It requires Chrome, `chromedriver`, and
+`wasm-pack`:
+
+```sh
+cargo test -p reinhardt-integration-tests --test url_patterns_target_parity url_patterns_browser_runtime -- --exact --ignored --nocapture
+```
+
+It runs 12 sequential browser configurations: two facade names, two caller
+cfg states, and three root-registration states (none or either attribute
+order). Four tests per configuration verify client route counts,
+literal reverse URLs, missing native route names, unrelated `server` methods,
+erased native side effects, and materialized inventory factories. Compile
+success alone does not establish browser runtime behavior.
+
+The final fixture run completed all 12 configurations in 56.32 seconds with
+48 passing browser tests and a warm compiler cache, using Chrome
+152.0.7977.84 and ChromeDriver 152.0.7977.82. An earlier cold run took 602.79
+seconds, including 458.5 seconds for its initial build. Each run reused the
+same test-owned artifact directories across its configurations.
+
+## Public Example Coverage
+
+`src/lib.rs` exercises the macro's rustdoc example, including the identical
+function and macro name. `client_routes.rs` covers shared client composition;
+the registration modules cover a single root mounting multiple annotated
+apps. `build.rs` is the caller-cfg example used in the routing documentation.
+Qualified macro and type paths are compiled under both dependency names.
+Client page factories use the facade's existing `reinhardt_types::page::Page`
+bridge to keep this routing fixture independent of the `pages` feature.

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/build.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+	println!("cargo::rustc-check-cfg=cfg(server)");
+	if std::env::var_os("CARGO_FEATURE_SERVER").is_some() {
+		println!("cargo::rustc-cfg=server");
+	}
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/native-only/Cargo.toml
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/native-only/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "native-only-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/native-only/src/lib.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/native-only/src/lib.rs
@@ -1,0 +1,12 @@
+//! Native-only dependency used by real consumer endpoint code.
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+compile_error!("native-only fixture dependency reached the browser WASM graph");
+
+pub struct NativeMarker;
+
+impl NativeMarker {
+	pub fn body() -> &'static str {
+		"native-handler"
+	}
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/client_routes.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/client_routes.rs
@@ -1,0 +1,37 @@
+// The macro bridge exposes the shared type without enabling the Pages UI crate.
+use reinhardt::reinhardt_types::page::Page;
+use reinhardt::{ClientRouter, UnifiedRouter};
+
+#[reinhardt::url_patterns]
+fn login_urls() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.client(|client| client.route("login", "/login/", || Page::Empty))
+		.with_namespace("auth")
+}
+
+#[reinhardt::url_patterns]
+pub fn client_pages() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.server(|server| server.endpoint(crate::native_handlers::page_health))
+		.client({
+			#[cfg(test)]
+			crate::evaluation::record("client-argument");
+			|client| client.route("home", "/", || Page::Empty)
+		})
+		.mount_unified("/ignored-native-prefix/", login_urls())
+}
+
+struct Other;
+
+impl Other {
+	fn server(self, client: ClientRouter) -> ClientRouter {
+		client.route("extra", "/extra/", || Page::Empty)
+	}
+}
+
+#[reinhardt::url_patterns]
+pub fn unrelated_server_call() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.server(|server| server.endpoint(crate::native_handlers::page_health))
+		.client(|client| Other.server(client))
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/evaluation.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/evaluation.rs
@@ -1,0 +1,120 @@
+use reinhardt::urls::prelude::UnifiedRouter;
+use std::cell::RefCell;
+
+thread_local! {
+	static EVENTS: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn record(event: &'static str) {
+	EVENTS.with(|events| events.borrow_mut().push(event));
+}
+
+pub(crate) struct TraceGuard;
+
+impl TraceGuard {
+	pub(crate) fn new() -> Self {
+		EVENTS.with(|events| events.borrow_mut().clear());
+		Self
+	}
+
+	pub(crate) fn take(&self) -> Vec<&'static str> {
+		EVENTS.with(|events| std::mem::take(&mut *events.borrow_mut()))
+	}
+}
+
+impl Drop for TraceGuard {
+	fn drop(&mut self) {
+		EVENTS.with(|events| events.borrow_mut().clear());
+	}
+}
+
+#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+struct Captured(String);
+
+#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+impl Drop for Captured {
+	fn drop(&mut self) {
+		record("drop-capture");
+	}
+}
+
+struct TemporaryName(String);
+
+impl TemporaryName {
+	fn new() -> Self {
+		record("namespace");
+		Self(String::from("trace"))
+	}
+
+	fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl Drop for TemporaryName {
+	fn drop(&mut self) {
+		record("drop-borrow");
+	}
+}
+
+#[reinhardt::url_patterns]
+pub(crate) fn traced_urls() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.with_prefix({
+			record("prefix");
+			"/api/"
+		})
+		.server({
+			record("server-argument-1");
+			let captured = Captured(String::from("native"));
+			move |server| {
+				record("server-body-1");
+				assert_eq!(captured.0, "native");
+				drop(captured);
+				server
+			}
+		})
+		.with_namespace(TemporaryName::new().as_str())
+		.merge({
+			record("merge-argument");
+			UnifiedRouter::new()
+		})
+		.server({
+			record("server-argument-2");
+			|server| {
+				record("server-body-2");
+				server
+			}
+		})
+}
+
+#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+pub(crate) fn handwritten_traced_urls() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.with_prefix({
+			record("prefix");
+			"/api/"
+		})
+		.server({
+			record("server-argument-1");
+			let captured = Captured(String::from("native"));
+			move |server| {
+				record("server-body-1");
+				assert_eq!(captured.0, "native");
+				drop(captured);
+				server
+			}
+		})
+		.with_namespace(TemporaryName::new().as_str())
+		.merge({
+			record("merge-argument");
+			UnifiedRouter::new()
+		})
+		.server({
+			record("server-argument-2");
+			|server| {
+				record("server-body-2");
+				server
+			}
+		})
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/lib.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/lib.rs
@@ -1,0 +1,94 @@
+//! Consumer declarations with real native-only endpoint references.
+
+#![deny(warnings)]
+
+use reinhardt::url_patterns;
+use reinhardt::urls::prelude::UnifiedRouter;
+
+#[cfg(all(server, not(all(target_family = "wasm", target_os = "unknown"))))]
+mod native_handlers;
+
+#[cfg(test)]
+mod evaluation;
+
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
+mod native_tests;
+
+#[cfg(all(test, server, not(all(target_family = "wasm", target_os = "unknown"))))]
+mod native_support;
+
+#[cfg(feature = "client-router")]
+mod client_routes;
+
+#[cfg(feature = "client-router")]
+pub use client_routes::{client_pages, unrelated_server_call};
+
+#[cfg(all(
+	test,
+	feature = "client-router",
+	target_family = "wasm",
+	target_os = "unknown"
+))]
+mod wasm_tests;
+
+#[url_patterns]
+pub fn url_patterns() -> UnifiedRouter {
+	UnifiedRouter::new()
+		.server(|server| {
+			server
+				.endpoint(crate::native_handlers::health)
+				.endpoint(crate::native_handlers::protected)
+		})
+		.with_namespace("demo")
+}
+
+#[reinhardt::url_patterns]
+pub fn another_app() -> reinhardt::urls::prelude::UnifiedRouter {
+	reinhardt::urls::prelude::UnifiedRouter::default()
+		.server(|server| server.endpoint(crate::native_handlers::health))
+		.with_prefix("/other/")
+}
+
+#[cfg(feature = "routes-first")]
+mod registration_routes_first;
+
+#[cfg(feature = "url-patterns-first")]
+mod registration_url_patterns_first;
+
+#[cfg(all(test, not(all(target_family = "wasm", target_os = "unknown"))))]
+mod registration_tests {
+	use reinhardt::reinhardt_urls::routers::registration::iter_registered_url_patterns;
+	use rstest::rstest;
+
+	#[rstest]
+	fn only_the_root_attribute_registers_inventory() {
+		// Arrange
+		let expected = usize::from(cfg!(any(
+			feature = "routes-first",
+			feature = "url-patterns-first"
+		)));
+
+		// Act
+		let registrations: Vec<_> = iter_registered_url_patterns().collect();
+
+		// Assert
+		assert_eq!(registrations.len(), expected);
+		for registration in registrations {
+			let router = registration.server_router();
+			#[cfg(server)]
+			{
+				assert_eq!(router.get_all_routes().len(), 5);
+				assert_eq!(
+					router.reverse("demo:health", &[]).as_deref(),
+					Some("/app/health/")
+				);
+				assert_eq!(
+					router.reverse("native-page-health", &[]).as_deref(),
+					Some("/native-pages/health/")
+				);
+			}
+			#[cfg(not(server))]
+			assert_eq!(router.get_all_routes(), Vec::new());
+		}
+	}
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_handlers.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_handlers.rs
@@ -1,0 +1,22 @@
+use reinhardt::{Response, ViewResult};
+
+#[cfg(feature = "client-router")]
+#[reinhardt::get("/native-pages/health/", name = "native-page-health", auth = "public")]
+pub async fn page_health() -> ViewResult<Response> {
+	Ok(Response::ok().with_body(native_only_fixture::NativeMarker::body()))
+}
+
+#[reinhardt::get("/health/", name = "health", auth = "public")]
+pub async fn health() -> ViewResult<Response> {
+	Ok(Response::ok().with_body(native_only_fixture::NativeMarker::body()))
+}
+
+#[reinhardt::post(
+	"/protected/",
+	name = "protected",
+	auth = "protected",
+	guard = "fixture credential gate"
+)]
+pub async fn protected() -> ViewResult<Response> {
+	Ok(Response::ok().with_body("protected-handler"))
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_support.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_support.rs
@@ -1,0 +1,61 @@
+use crate::evaluation::record;
+use async_trait::async_trait;
+use reinhardt::reinhardt_di::{DiResult, Injectable, InjectionContext, SingletonScope};
+use reinhardt::{Handler, Middleware, Request, Response, ServerRouter, ViewResult};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct Config(&'static str);
+
+#[async_trait]
+impl Injectable for Config {
+	async fn inject(context: &InjectionContext) -> DiResult<Self> {
+		Ok(context
+			.singleton_scope()
+			.get::<Self>()
+			.expect("fixture singleton is registered")
+			.as_ref()
+			.clone())
+	}
+}
+
+struct CredentialGate;
+
+#[async_trait]
+impl Middleware for CredentialGate {
+	async fn process(
+		&self,
+		request: Request,
+		next: Arc<dyn Handler>,
+	) -> reinhardt::Result<Response> {
+		if request.get_header("x-fixture-credential").as_deref() != Some("accepted") {
+			record("denied");
+			return Ok(Response::forbidden().with_body("denied"));
+		}
+		record("middleware-before");
+		let response = next.handle(request).await?;
+		record("middleware-after");
+		Ok(response)
+	}
+}
+
+#[reinhardt::get(
+	"/secured/",
+	name = "secured",
+	auth = "protected",
+	guard = "fixture credential gate"
+)]
+pub(crate) async fn secured(#[inject] config: Config) -> ViewResult<Response> {
+	record("handler");
+	Ok(Response::ok().with_body(config.0))
+}
+
+pub(crate) fn configure(server: ServerRouter) -> ServerRouter {
+	let scope = Arc::new(SingletonScope::new());
+	scope.set(Config("injected-configuration"));
+	let context = Arc::new(InjectionContext::builder(scope).build());
+	server
+		.with_di_context(context)
+		.with_middleware(CredentialGate)
+		.endpoint(secured)
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_tests.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/native_tests.rs
@@ -1,0 +1,340 @@
+use crate::evaluation::{TraceGuard, traced_urls};
+use rstest::{fixture, rstest};
+use serial_test::serial;
+
+#[fixture]
+fn trace() -> TraceGuard {
+	TraceGuard::new()
+}
+
+#[rstest]
+#[serial(url_patterns_evaluation)]
+fn evaluation_and_temporary_lifetimes_are_preserved(trace: TraceGuard) {
+	// Arrange
+	#[cfg(server)]
+	let expected = vec![
+		"prefix",
+		"server-argument-1",
+		"server-body-1",
+		"drop-capture",
+		"namespace",
+		"merge-argument",
+		"server-argument-2",
+		"server-body-2",
+		"drop-borrow",
+	];
+	#[cfg(not(server))]
+	let expected = vec!["prefix", "namespace", "merge-argument", "drop-borrow"];
+
+	// Act
+	let generated = traced_urls().into_server();
+
+	// Assert
+	assert_eq!(generated.namespace(), Some("trace"));
+	assert_eq!(generated.prefix(), "/api/");
+	assert_eq!(trace.take(), expected);
+	#[cfg(server)]
+	{
+		let handwritten = crate::evaluation::handwritten_traced_urls().into_server();
+		assert_eq!(trace.take(), expected);
+		assert_eq!(generated.get_all_routes(), handwritten.get_all_routes());
+	}
+}
+
+#[cfg(not(server))]
+#[rstest]
+fn non_server_native_build_has_no_contributed_endpoints() {
+	// Arrange / Act
+	let router = crate::url_patterns().into_server();
+
+	// Assert
+	assert_eq!(router.get_all_routes(), Vec::new());
+	assert_eq!(router.reverse("demo:health", &[]), None);
+	assert_eq!(router.reverse("demo:protected", &[]), None);
+}
+
+#[cfg(feature = "client-router")]
+#[rstest]
+#[serial(url_patterns_evaluation)]
+fn client_configuration_arguments_are_evaluated_once(trace: TraceGuard) {
+	// Arrange / Act
+	let router = crate::client_pages().into_server();
+
+	// Assert
+	assert_eq!(trace.take(), vec!["client-argument"]);
+	assert_eq!(router.get_all_routes().len(), usize::from(cfg!(server)));
+}
+
+#[cfg(server)]
+mod server {
+	use super::trace;
+	use crate::evaluation::TraceGuard;
+	use reinhardt::reinhardt_core::endpoint::AuthProtection;
+	use reinhardt::urls::prelude::UnifiedRouter;
+	use reinhardt::{Handler, Method, Request, StatusCode};
+	use rstest::rstest;
+	use serial_test::serial;
+
+	fn handwritten() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.server(|server| {
+				server
+					.endpoint(crate::native_handlers::health)
+					.endpoint(crate::native_handlers::protected)
+			})
+			.with_namespace("demo")
+	}
+
+	#[reinhardt::url_patterns]
+	fn guarded() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.server(crate::native_support::configure)
+			.with_prefix("/api/")
+	}
+
+	fn handwritten_guarded() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.server(crate::native_support::configure)
+			.with_prefix("/api/")
+	}
+
+	#[reinhardt::url_patterns]
+	fn prefix_before() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.with_prefix("/api/")
+			.server(|server| server.endpoint(crate::native_handlers::health))
+	}
+
+	#[reinhardt::url_patterns]
+	fn prefix_after() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.server(|server| server.endpoint(crate::native_handlers::health))
+			.with_prefix("/api/")
+	}
+
+	#[reinhardt::url_patterns]
+	fn nested() -> UnifiedRouter {
+		UnifiedRouter::new()
+			.with_prefix("/api/")
+			.with_namespace("root")
+			.mount_unified("/app/", crate::url_patterns())
+			.merge(crate::another_app())
+	}
+
+	#[reinhardt::url_patterns]
+	fn duplicate() -> UnifiedRouter {
+		UnifiedRouter::new().server(|server| {
+			server
+				.endpoint(crate::native_handlers::health)
+				.endpoint(crate::native_handlers::health)
+		})
+	}
+
+	#[rstest]
+	fn endpoints_and_contract_metadata_match_the_handwritten_builder() {
+		// Arrange
+		let expected = vec![
+			(
+				String::from("/health/"),
+				Some(String::from("health")),
+				Some(String::from("demo")),
+				vec![Method::GET],
+			),
+			(
+				String::from("/protected/"),
+				Some(String::from("protected")),
+				Some(String::from("demo")),
+				vec![Method::POST],
+			),
+		];
+
+		// Act
+		let generated = crate::url_patterns().into_server();
+		let original = handwritten().into_server();
+		let contracts = generated.get_mounted_route_contracts().unwrap();
+
+		// Assert
+		assert_eq!(generated.get_all_routes(), expected);
+		assert_eq!(generated.get_all_routes(), original.get_all_routes());
+		assert_eq!(contracts, original.get_mounted_route_contracts().unwrap());
+		assert_eq!(contracts.len(), 2);
+		assert_eq!(contracts[0].metadata.authentication, AuthProtection::Public);
+		assert_eq!(
+			contracts[1].metadata.authentication,
+			AuthProtection::Protected
+		);
+		assert_eq!(
+			contracts[1].metadata.guard.as_deref(),
+			Some("fixture credential gate")
+		);
+		assert_eq!(
+			generated.reverse("demo:health", &[]).as_deref(),
+			Some("/health/")
+		);
+		assert_eq!(
+			generated.reverse("demo:protected", &[]).as_deref(),
+			Some("/protected/")
+		);
+	}
+
+	#[rstest]
+	#[case(Method::GET, "/health/", StatusCode::OK, "native-handler")]
+	#[case(Method::POST, "/protected/", StatusCode::OK, "protected-handler")]
+	#[tokio::test]
+	async fn actual_http_handlers_are_dispatched(
+		#[case] method: Method,
+		#[case] path: &str,
+		#[case] status: StatusCode,
+		#[case] body: &str,
+	) {
+		// Arrange
+		let router = crate::url_patterns().into_server();
+		let request = Request::builder().method(method).uri(path).build().unwrap();
+
+		// Act
+		let response = router.handle(request).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, status);
+		assert_eq!(response.body.as_ref(), body.as_bytes());
+	}
+
+	#[rstest]
+	#[case(
+		Method::POST,
+		"/health/",
+		405,
+		"Method not allowed: Method POST not allowed for /health/"
+	)]
+	#[case(Method::GET, "/missing/", 404, "Not found: No route for GET /missing/")]
+	#[tokio::test]
+	async fn failed_dispatch_matches_the_original_router(
+		#[case] method: Method,
+		#[case] path: &str,
+		#[case] status: u16,
+		#[case] message: &str,
+	) {
+		// Arrange
+		let request = || {
+			Request::builder()
+				.method(method.clone())
+				.uri(path)
+				.build()
+				.unwrap()
+		};
+		let generated = crate::url_patterns().into_server();
+		let original = handwritten().into_server();
+
+		// Act
+		let actual = generated.handle(request()).await.unwrap_err();
+		let expected = original.handle(request()).await.unwrap_err();
+
+		// Assert
+		assert_eq!(actual.status_code(), status);
+		assert_eq!(actual.to_string(), message);
+		assert_eq!(actual.kind(), expected.kind());
+		assert_eq!(actual.to_string(), expected.to_string());
+	}
+
+	#[rstest]
+	#[case(false, StatusCode::FORBIDDEN, "denied", vec!["denied"])]
+	#[case(true, StatusCode::OK, "injected-configuration", vec!["middleware-before", "handler", "middleware-after"])]
+	#[serial(url_patterns_evaluation)]
+	#[tokio::test]
+	async fn middleware_enforcement_and_injection_are_preserved(
+		trace: TraceGuard,
+		#[case] accepted: bool,
+		#[case] status: StatusCode,
+		#[case] body: &str,
+		#[case] events: Vec<&str>,
+	) {
+		// Arrange
+		let request = || {
+			Request::builder()
+				.method(Method::GET)
+				.uri("/api/secured/")
+				.header(
+					"x-fixture-credential",
+					if accepted { "accepted" } else { "rejected" },
+				)
+				.build()
+				.unwrap()
+		};
+
+		// Act
+		let generated = guarded().into_server();
+		let response = generated.handle(request()).await.unwrap();
+
+		// Assert
+		assert_eq!(response.status, status);
+		assert_eq!(response.body.as_ref(), body.as_bytes());
+		assert_eq!(trace.take(), events);
+		let original = handwritten_guarded().into_server();
+		let expected = original.handle(request()).await.unwrap();
+		assert_eq!(trace.take(), events);
+		assert_eq!(response.status, expected.status);
+		assert_eq!(response.body, expected.body);
+		assert_eq!(
+			generated.get_registered_middleware(),
+			original.get_registered_middleware()
+		);
+		assert_eq!(
+			generated.get_mounted_route_contracts().unwrap(),
+			original.get_mounted_route_contracts().unwrap()
+		);
+	}
+
+	#[rstest]
+	fn prefixes_mounts_namespaces_and_merge_keep_literal_reversal_paths() {
+		// Arrange / Act
+		let before = prefix_before().into_server();
+		let after = prefix_after().into_server();
+		let parent = nested().into_server();
+
+		// Assert
+		assert_eq!(
+			before.reverse("health", &[]).as_deref(),
+			Some("/api/health/")
+		);
+		assert_eq!(
+			after.reverse("health", &[]).as_deref(),
+			Some("/api/health/")
+		);
+		assert_eq!(before.get_all_routes(), after.get_all_routes());
+		assert_eq!(
+			parent.reverse("root:demo:health", &[]).as_deref(),
+			Some("/api/app/health/")
+		);
+		assert_eq!(
+			parent.reverse("root:demo:protected", &[]).as_deref(),
+			Some("/api/app/protected/")
+		);
+		assert_eq!(
+			parent.reverse("root:health", &[]).as_deref(),
+			Some("/api/other/health/")
+		);
+		assert_eq!(parent.get_all_routes().len(), 3);
+	}
+
+	#[rstest]
+	fn duplicate_endpoint_contracts_keep_the_original_error() {
+		// Arrange
+		let original = UnifiedRouter::new()
+			.server(|server| {
+				server
+					.endpoint(crate::native_handlers::health)
+					.endpoint(crate::native_handlers::health)
+			})
+			.into_server();
+
+		// Act
+		let actual = duplicate().into_server().get_mounted_route_contracts();
+
+		// Assert
+		assert_eq!(actual, original.get_mounted_route_contracts());
+		assert_eq!(
+			actual.unwrap_err(),
+			"route compilation failed: Failed to compile route '/health/' (GET): Insertion failed due to conflict with previously registered route: /health/"
+		);
+	}
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/registration_routes_first.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/registration_routes_first.rs
@@ -1,0 +1,9 @@
+#[reinhardt::routes]
+#[reinhardt::url_patterns]
+pub fn root_urls() -> reinhardt::urls::prelude::UnifiedRouter {
+	reinhardt::urls::prelude::UnifiedRouter::new()
+		.server(|server| server.endpoint(crate::native_handlers::health))
+		.mount_unified("/app/", crate::url_patterns())
+		.merge(crate::another_app())
+		.merge(crate::client_pages())
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/registration_url_patterns_first.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/registration_url_patterns_first.rs
@@ -1,0 +1,9 @@
+#[reinhardt::url_patterns]
+#[reinhardt::routes]
+pub fn root_urls() -> reinhardt::urls::prelude::UnifiedRouter {
+	reinhardt::urls::prelude::UnifiedRouter::new()
+		.server(|server| server.endpoint(crate::native_handlers::health))
+		.mount_unified("/app/", crate::url_patterns())
+		.merge(crate::another_app())
+		.merge(crate::client_pages())
+}

--- a/tests/integration/tests/fixtures/url_patterns_target_parity/src/wasm_tests.rs
+++ b/tests/integration/tests/fixtures/url_patterns_target_parity/src/wasm_tests.rs
@@ -1,0 +1,76 @@
+use crate::evaluation::{TraceGuard, traced_urls};
+use reinhardt::ClientRouter;
+use reinhardt::reinhardt_urls::routers::client_router::RouterError;
+use reinhardt::reinhardt_urls::routers::registration::iter_registered_client_routers;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn assert_client_routes(client: &ClientRouter) {
+	assert_eq!(client.route_count(), 2);
+	assert_eq!(client.reverse("home", &[]).unwrap(), "/");
+	assert_eq!(client.reverse("auth:login", &[]).unwrap(), "/login/");
+	for native_name in ["native-page-health", "demo:health", "demo:protected"] {
+		assert_eq!(
+			client.reverse(native_name, &[]),
+			Err(RouterError::InvalidRouteName(String::from(native_name)))
+		);
+	}
+}
+
+#[wasm_bindgen_test]
+fn client_routes_survive_server_erasure_and_mounting() {
+	// Arrange
+	let trace = TraceGuard::new();
+
+	// Act
+	let client = crate::client_pages().into_client();
+
+	// Assert
+	assert_client_routes(&client);
+	assert_eq!(trace.take(), vec!["client-argument"]);
+}
+
+#[wasm_bindgen_test]
+fn unrelated_server_method_is_preserved() {
+	// Arrange / Act
+	let client = crate::unrelated_server_call().into_client();
+
+	// Assert
+	assert_eq!(client.route_count(), 1);
+	assert_eq!(client.reverse("extra", &[]).unwrap(), "/extra/");
+}
+
+#[wasm_bindgen_test]
+fn native_arguments_captures_and_bodies_are_not_evaluated() {
+	// Arrange
+	let trace = TraceGuard::new();
+
+	// Act
+	let client = traced_urls().into_client();
+
+	// Assert
+	assert_eq!(client.route_count(), 0);
+	assert_eq!(
+		trace.take(),
+		vec!["prefix", "namespace", "merge-argument", "drop-borrow"]
+	);
+}
+
+#[wasm_bindgen_test]
+fn only_the_root_attribute_registers_the_client_factory() {
+	// Arrange
+	let expected = usize::from(cfg!(any(
+		feature = "routes-first",
+		feature = "url-patterns-first"
+	)));
+
+	// Act
+	let registrations: Vec<_> = iter_registered_client_routers().collect();
+
+	// Assert
+	assert_eq!(registrations.len(), expected);
+	for registration in registrations {
+		assert_client_routes(&registration.client_router());
+	}
+}

--- a/tests/integration/tests/url_patterns_target_parity.rs
+++ b/tests/integration/tests/url_patterns_target_parity.rs
@@ -266,7 +266,9 @@ wasm-bindgen-test = "0.3"
 			&& (output.stderr.contains("no matching package named")
 				|| output.stderr.contains("failed to download")
 				|| output.stderr.contains("attempting to make an HTTP request")
-				|| output.stderr.contains("candidate versions found which didn't match"));
+				|| output
+					.stderr
+					.contains("candidate versions found which didn't match"));
 		if resolution_failed {
 			self.run_once(command.env("CARGO_NET_OFFLINE", "false"))
 		} else {

--- a/tests/integration/tests/url_patterns_target_parity.rs
+++ b/tests/integration/tests/url_patterns_target_parity.rs
@@ -1,0 +1,516 @@
+//! Real consumer checks for shared native HTTP and browser URL declarations.
+//!
+//! Consumer manifests resolve independently of the workspace lockfile and patches.
+//! Refresh missing registry entries when their first offline resolution fails.
+
+use reinhardt_test::fixtures::temp_dir;
+use rstest::{fixture, rstest};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::{NamedTempFile, TempDir};
+
+const WASM: &str = "wasm32-unknown-unknown";
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(1200);
+
+struct ConsumerWorkspace {
+	root: TempDir,
+	repository: PathBuf,
+}
+
+#[fixture]
+fn consumer_workspace(temp_dir: TempDir) -> ConsumerWorkspace {
+	ConsumerWorkspace {
+		root: temp_dir,
+		repository: Path::new(env!("CARGO_MANIFEST_DIR"))
+			.ancestors()
+			.nth(2)
+			.expect("integration crate is inside tests/")
+			.to_path_buf(),
+	}
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Scenario {
+	target: Option<&'static str>,
+	server: bool,
+	client_router: bool,
+}
+
+impl Scenario {
+	fn features(self, registration: Option<&str>) -> String {
+		let mut features = Vec::new();
+		if self.server {
+			features.push("server");
+		}
+		if self.client_router {
+			features.push("client-router");
+		}
+		if let Some(registration) = registration {
+			features.push(registration);
+		}
+		features.join(",")
+	}
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+	fn drop(&mut self) {
+		// Reap even on timeout, panic, or an I/O error in the test harness.
+		let _ = self.0.kill();
+		let _ = self.0.wait();
+	}
+}
+
+struct RunOutput {
+	status: ExitStatus,
+	stdout: String,
+	stderr: String,
+}
+
+impl RunOutput {
+	fn messages(&self) -> impl Iterator<Item = Value> + '_ {
+		self.stdout
+			.lines()
+			.filter_map(|line| serde_json::from_str(line).ok())
+	}
+
+	fn diagnostic_text(&self) -> String {
+		self.messages()
+			.filter(|message| message["reason"] == "compiler-message")
+			.filter_map(|message| message["message"]["rendered"].as_str().map(String::from))
+			.collect::<Vec<_>>()
+			.join("\n")
+	}
+
+	fn assert_success(&self, label: &str) {
+		let output = self
+			.stdout
+			.lines()
+			.filter(|line| serde_json::from_str::<Value>(line).is_err())
+			.collect::<Vec<_>>()
+			.join("\n");
+		assert_eq!(
+			self.status.code(),
+			Some(0),
+			"{label}\n{}\n{}\n{output}",
+			self.diagnostic_text(),
+			self.stderr,
+		);
+	}
+
+	fn primary_errors(&self) -> Vec<(String, u64, u64)> {
+		self.messages()
+			.filter(|message| message["reason"] == "compiler-message")
+			.filter_map(|message| {
+				let diagnostic = &message["message"];
+				if diagnostic["level"] != "error" {
+					return None;
+				}
+				let span = diagnostic["spans"].as_array()?.iter().find(|span| {
+					span["is_primary"] == true
+						&& span["file_name"]
+							.as_str()
+							.is_some_and(|path| path.ends_with("src/lib.rs"))
+				})?;
+				Some((
+					diagnostic["message"].as_str()?.into(),
+					span["line_start"].as_u64()?,
+					span["column_start"].as_u64()?,
+				))
+			})
+			.collect()
+	}
+
+	fn assert_rust_error(&self, code: &str) {
+		assert_eq!(self.status.code(), Some(101), "{}", self.stderr);
+		let codes: Vec<_> = self
+			.messages()
+			.filter(|message| message["reason"] == "compiler-message")
+			.filter_map(|message| {
+				let diagnostic = &message["message"];
+				let in_consumer = diagnostic["spans"].as_array()?.iter().any(|span| {
+					span["is_primary"] == true
+						&& span["file_name"]
+							.as_str()
+							.is_some_and(|path| path.ends_with("src/lib.rs"))
+				});
+				in_consumer
+					.then(|| diagnostic["code"]["code"].as_str().map(String::from))
+					.flatten()
+			})
+			.collect();
+		assert!(
+			codes.iter().any(|actual| actual == code),
+			"expected {code}: {}\n{}",
+			self.diagnostic_text(),
+			self.stderr
+		);
+	}
+}
+
+impl ConsumerWorkspace {
+	fn source(&self) -> PathBuf {
+		self.repository
+			.join("tests/integration/tests/fixtures/url_patterns_target_parity")
+	}
+
+	fn create_consumer(&self, directory: &str, facade: &str, source: Option<&str>) -> PathBuf {
+		let root = self.root.path().join(directory);
+		fs::create_dir_all(root.join("src")).unwrap();
+		fs::create_dir_all(root.join("native-only/src")).unwrap();
+		for entry in fs::read_dir(self.source().join("src")).unwrap() {
+			let entry = entry.unwrap();
+			let text = fs::read_to_string(entry.path()).unwrap();
+			fs::write(
+				root.join("src").join(entry.file_name()),
+				text.replace("reinhardt::", &format!("{facade}::")),
+			)
+			.unwrap();
+		}
+		if let Some(source) = source {
+			fs::write(
+				root.join("src/lib.rs"),
+				source.replace("reinhardt::", &format!("{facade}::")),
+			)
+			.unwrap();
+		}
+		for relative in [
+			"build.rs",
+			"native-only/Cargo.toml",
+			"native-only/src/lib.rs",
+		] {
+			fs::copy(self.source().join(relative), root.join(relative)).unwrap();
+		}
+		// JSON string escaping is also valid for these TOML string paths.
+		let framework_path = serde_json::to_string(&self.repository).unwrap();
+		let manifest = format!(
+			r#"[package]
+name = "url-patterns-consumer"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[profile.dev]
+debug = 0
+
+[profile.test]
+debug = 0
+
+[features]
+server = []
+client-router = ["{facade}/client-router"]
+routes-first = ["client-router"]
+url-patterns-first = ["client-router"]
+
+[dependencies]
+{facade} = {{ package = "reinhardt-web", path = {framework_path}, default-features = false, features = ["core", "routing"] }}
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+{facade} = {{ package = "reinhardt-web", path = {framework_path}, default-features = false, features = ["di"] }}
+native-only-fixture = {{ path = "native-only" }}
+async-trait = "0.1"
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+rstest = "0.26.1"
+tokio = {{ version = "1", features = ["macros", "rt"] }}
+serial_test = "3"
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+"#
+		);
+		fs::write(root.join("Cargo.toml"), manifest).unwrap();
+		root
+	}
+
+	fn command(
+		&self,
+		root: &Path,
+		operation: &str,
+		scenario: Scenario,
+		registration: Option<&str>,
+	) -> Command {
+		let mut command = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+		command
+			.current_dir(root)
+			.arg(operation)
+			.arg("--manifest-path")
+			.arg(root.join("Cargo.toml"))
+			.env("CARGO_NET_OFFLINE", "true")
+			.env("CARGO_TARGET_DIR", self.root.path().join("target"))
+			.env("CARGO_BUILD_BUILD_DIR", self.root.path().join("build"))
+			.env("CARGO_INCREMENTAL", "0")
+			.env("CARGO_PROFILE_DEV_DEBUG", "0")
+			.env("CARGO_PROFILE_TEST_DEBUG", "0")
+			.env_remove("CARGO_ENCODED_RUSTFLAGS")
+			.env_remove("RUSTFLAGS");
+		if let Some(target) = scenario.target {
+			command.arg("--target").arg(target);
+		}
+		let features = scenario.features(registration);
+		if !features.is_empty() {
+			command.arg("--features").arg(features);
+		}
+		command
+	}
+
+	fn run(&self, command: &mut Command) -> RunOutput {
+		let output = self.run_once(command);
+		let resolution_failed = !output.status.success()
+			&& (output.stderr.contains("no matching package named")
+				|| output.stderr.contains("failed to download")
+				|| output.stderr.contains("attempting to make an HTTP request")
+				|| output.stderr.contains("candidate versions found which didn't match"));
+		if resolution_failed {
+			self.run_once(command.env("CARGO_NET_OFFLINE", "false"))
+		} else {
+			output
+		}
+	}
+
+	fn run_once(&self, command: &mut Command) -> RunOutput {
+		let stdout = NamedTempFile::new_in(self.root.path()).unwrap();
+		let stderr = NamedTempFile::new_in(self.root.path()).unwrap();
+		command
+			.stdin(Stdio::null())
+			.stdout(stdout.as_file().try_clone().unwrap())
+			.stderr(stderr.as_file().try_clone().unwrap());
+		let started = Instant::now();
+		eprintln!("Running {command:?}");
+		let mut child = ChildGuard(command.spawn().expect("spawn consumer command"));
+		let status = loop {
+			if let Some(status) = child.0.try_wait().expect("poll consumer command") {
+				break status;
+			}
+			assert!(
+				started.elapsed() < COMMAND_TIMEOUT,
+				"consumer command exceeded {COMMAND_TIMEOUT:?}:\n{}",
+				fs::read_to_string(stderr.path()).unwrap()
+			);
+			std::thread::sleep(Duration::from_millis(100));
+		};
+		eprintln!(
+			"Consumer command exited {status} after {:.1}s",
+			started.elapsed().as_secs_f32()
+		);
+		let output = RunOutput {
+			status,
+			stdout: fs::read_to_string(stdout.path()).unwrap(),
+			stderr: fs::read_to_string(stderr.path()).unwrap(),
+		};
+		for line in output
+			.stdout
+			.lines()
+			.filter(|line| line.starts_with("test result:"))
+		{
+			eprintln!("{line}");
+		}
+		output
+	}
+
+	fn check(&self, root: &Path, scenario: Scenario, registration: Option<&str>) -> RunOutput {
+		self.run(
+			self.command(root, "check", scenario, registration)
+				.args(["--lib", "--message-format=json"]),
+		)
+	}
+}
+
+#[rstest]
+fn url_patterns_target_matrix(consumer_workspace: ConsumerWorkspace) {
+	// Arrange
+	let workspace = consumer_workspace;
+	let scenarios = [
+		Scenario {
+			target: None,
+			server: true,
+			client_router: false,
+		},
+		Scenario {
+			target: None,
+			server: true,
+			client_router: true,
+		},
+		Scenario {
+			target: None,
+			server: false,
+			client_router: false,
+		},
+		Scenario {
+			target: None,
+			server: false,
+			client_router: true,
+		},
+		Scenario {
+			target: Some(WASM),
+			server: false,
+			client_router: true,
+		},
+		Scenario {
+			target: Some(WASM),
+			server: true,
+			client_router: true,
+		},
+	];
+	for facade in ["reinhardt", "framework"] {
+		let root = workspace.create_consumer(facade, facade, None);
+		for scenario in scenarios {
+			// Act
+			let output = workspace.check(&root, scenario, None);
+
+			// Assert
+			output.assert_success(&format!("{facade}: {scenario:?}"));
+			let native_artifact = output.messages().any(|message| {
+				message["reason"] == "compiler-artifact"
+					&& message["target"]["name"] == "native_only_fixture"
+			});
+			assert_eq!(
+				native_artifact,
+				scenario.target.is_none(),
+				"native dependency artifact: {facade} {scenario:?}"
+			);
+			let tree = workspace.run(
+				workspace
+					.command(&root, "tree", scenario, None)
+					.args(["--edges", "normal", "--prefix", "none"]),
+			);
+			tree.assert_success("consumer target dependency tree");
+			assert_eq!(
+				tree.stdout
+					.lines()
+					.any(|line| line.split_whitespace().next() == Some("native-only-fixture")),
+				scenario.target.is_none()
+			);
+			if scenario.target.is_none() {
+				workspace
+					.run(
+						workspace
+							.command(&root, "test", scenario, None)
+							.arg("--lib"),
+					)
+					.assert_success("native consumer tests");
+			}
+		}
+		for order in ["routes-first", "url-patterns-first"] {
+			for scenario in scenarios
+				.into_iter()
+				.filter(|scenario| scenario.client_router)
+			{
+				if scenario.target.is_some() {
+					workspace
+						.check(&root, scenario, Some(order))
+						.assert_success("browser registration attribute order");
+				} else {
+					workspace
+						.run(
+							workspace
+								.command(&root, "test", scenario, Some(order))
+								.arg("--lib"),
+						)
+						.assert_success("linked native registration attribute order");
+				}
+			}
+		}
+	}
+
+	// Negative controls distinguish name erasure from an inert runtime closure.
+	let original = fs::read_to_string(workspace.source().join("src/lib.rs")).unwrap();
+	let without_attribute = original
+		.replace("#[url_patterns]\n", "")
+		.replace("use reinhardt::url_patterns;\n", "");
+	let control =
+		workspace.create_consumer("without-attribute", "reinhardt", Some(&without_attribute));
+	workspace
+		.check(&control, scenarios[0], None)
+		.assert_success("unannotated native server control");
+	for scenario in [scenarios[2], scenarios[4]] {
+		workspace
+			.check(&control, scenario, None)
+			.assert_rust_error("E0433");
+	}
+	let invalid_handler = original.replace(
+		".endpoint(crate::native_handlers::health)",
+		".endpoint(0u8)",
+	);
+	let invalid = workspace.create_consumer("invalid-handler", "reinhardt", Some(&invalid_handler));
+	workspace
+		.check(&invalid, scenarios[0], None)
+		.assert_rust_error("E0277");
+
+	for invalid_case in [
+		"non_tail_body",
+		"unsupported_method",
+		"nested_server_builder",
+	] {
+		let path = workspace
+			.repository
+			.join("crates/reinhardt-core/macros/tests/ui/url_patterns/fail")
+			.join(format!("{invalid_case}.rs"));
+		let source = fs::read_to_string(path)
+			.unwrap()
+			.replace("reinhardt_macros::", "reinhardt::");
+		let root = workspace.create_consumer(invalid_case, "reinhardt", Some(&source));
+		let baseline = workspace.check(&root, scenarios[0], None);
+		assert_eq!(baseline.status.code(), Some(101));
+		let expected = baseline.primary_errors();
+		assert_ne!(
+			expected.len(),
+			0,
+			"macro must diagnose the malformed consumer"
+		);
+		for scenario in [scenarios[2], scenarios[4], scenarios[5]] {
+			let output = workspace.check(&root, scenario, None);
+			assert_eq!(output.status.code(), Some(101));
+			assert_eq!(
+				output.primary_errors(),
+				expected,
+				"target-independent diagnostic: {invalid_case} {scenario:?}"
+			);
+		}
+	}
+}
+
+#[rstest]
+#[ignore = "requires Chrome, chromedriver, and wasm-pack"]
+fn url_patterns_browser_runtime(consumer_workspace: ConsumerWorkspace) {
+	// Arrange
+	let workspace = consumer_workspace;
+	for facade in ["reinhardt", "framework"] {
+		let root = workspace.create_consumer(facade, facade, None);
+		for server in [false, true] {
+			for registration in [None, Some("routes-first"), Some("url-patterns-first")] {
+				let scenario = Scenario {
+					target: Some(WASM),
+					server,
+					client_router: true,
+				};
+				let mut command = Command::new("wasm-pack");
+				command
+					.current_dir(&root)
+					.args(["test", "--headless", "--chrome", "--features"])
+					.arg(scenario.features(registration))
+					.env("CARGO_TARGET_DIR", workspace.root.path().join("target"))
+					.env("CARGO_BUILD_BUILD_DIR", workspace.root.path().join("build"))
+					.env("CARGO_INCREMENTAL", "0")
+					.env("CARGO_PROFILE_DEV_DEBUG", "0")
+					.env("CARGO_PROFILE_TEST_DEBUG", "0")
+					.env_remove("CARGO_ENCODED_RUSTFLAGS")
+					.env_remove("RUSTFLAGS");
+
+				// Act
+				let output = workspace.run(&mut command);
+
+				// Assert
+				output.assert_success(&format!(
+					"browser runtime: {facade} {scenario:?} {registration:?}"
+				));
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The argumentless #[url_patterns] attribute lets one UnifiedRouter declaration refer to cfg-gated native handlers. Non-server and browser WASM builds erase entire server configuration arguments before name resolution, while native server builds retain the original builder expression.

- Preserve prefixes, namespaces, nested mounts, routing behavior, and registration attribute order.
- Reject unsupported declarations with target-independent source diagnostics.
- Verify native HTTP registration and browser erasure using real native-only handler modules and renamed facade consumers.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI/CD changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

The API is additive and existing form and router declarations retain their behavior.

## Motivation and Context

Shared URL modules previously referenced native endpoint names even in builds where those endpoints were intentionally unavailable. The attribute removes complete server arguments before name resolution while preserving native handler and router behavior.

Fixes #6284

## How Was This Tested?

- Passed all 47 URL-pattern macro unit tests and nine compile-fail UI fixtures.
- Passed the native/WASM consumer matrix with 64 commands, including expected diagnostic failures, native HTTP registration, both registration attribute orders, and renamed facade consumers.
- Passed all 48 Chrome/WASM tests across 12 consumer configurations.
- Passed `cargo check --workspace --all --all-features`.
- Passed strict Clippy for the macro library and changed integration test (`--no-deps -- -D warnings`) and strict all-feature documentation builds for the macro, URLs, and framework facade crates.
- Passed `cargo make placeholder-check`, workflow actionlint, nextest configuration parsing, and `git diff --check`.
- Passed the final full `cargo make fmt-check` (3,869 files unchanged).

Full workspace build/test/Clippy checks remain separate CI gates. Focused validation used `b9c91d59a0914633ac27bcc7e31d859f814e6d2b`. The subsequent base merge `af0fdcf0ba2e3d6dfc8f6b8938a94f013b0a7154` adds only upstream GraphQL and announcement changes; the feature diff against its new base is byte-for-byte identical.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New feature and related regression tests pass locally with my changes
- [ ] I have tested with all affected database backends (if applicable)
- [x] I have verified formatting with `cargo make fmt-check`
- [x] I have checked the affected macro library and integration test with strict Clippy
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- #6284
- kent8192/reinhardt-cloud#905

## Labels to Apply

- [x] `enhancement` - New feature or improvement
- [x] `routing` - URL routing, path matching
- [ ] `breaking-change` - Breaking change

---

🤖 Generated with [Codex](https://openai.com/codex/)
