### PR TITLE
fix(website): point Notes navigation to Reinhardt Press

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -92,7 +92,7 @@
 			<ul class="nav-links" id="nav-links" role="list">
 				<li><a href="/quickstart/">Quickstart</a></li>
 				<li><a href="/docs/">Docs</a></li>
-				<li><a href="/notes/">Notes</a></li>
+				<li><a href="https://press.reinhardt-web.dev/">Notes</a></li>
 				<li><a href="/changelog/">Changelog</a></li>
 				<li>
 					<a href="{{ config.extra.github_repo }}"


### PR DESCRIPTION
## Summary

This PR addresses:

- Pointing the global `Notes` navigation link to the Reinhardt Press publication site.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code quality improvements
- [ ] CI/CD changes
- [ ] Other (please describe):

## Breaking Change Assessment

- [x] **No** - This change is backward compatible
- [ ] **Yes** - This change breaks existing public API or behavior

## Motivation and Context

The global `Notes` navigation item previously pointed to the empty local `/notes/` section. Reinhardt Press hosts the technical articles, so the navigation should take readers directly to its published index.

No issue linked.

## How Was This Tested?

- Ran `zola check --skip-external-links` from `website/`.
- Ran `zola build` from `website/`.
- Verified the generated navigation contains `https://press.reinhardt-web.dev/`.

## Performance Impact

Not applicable.

## Breaking Changes

None.

**Migration Guide:**

Not applicable.

## Screenshots

### Before

The `Notes` navigation item linked to `/notes/`.

### After

The `Notes` navigation item links to `https://press.reinhardt-web.dev/`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] I have followed the [Commit Guidelines](../blob/main/instructions/COMMIT_GUIDELINE.md)
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: website navigation-only change)
- [x] New and existing website checks pass locally
- [ ] I have tested with all affected database backends (not applicable)
- [ ] I have formatted the code with `cargo make fmt-fix` (not applicable: no Rust changes)
- [ ] I have checked the code with `cargo make clippy-check` (not applicable: no Rust changes)
- [ ] I use self-hosted runner for CI (Repository owner only)

## Related Issues

- None.

## Labels to Apply

### Type Label (select one)

- [x] `bug` - Bug fix
- [ ] `enhancement` - New feature or improvement
- [ ] `documentation` - Documentation update
- [ ] `performance` - Performance improvement
- [ ] `refactoring` - Code refactoring
- [ ] `code-quality` - Code quality improvements

### Additional Labels (apply alongside type label when applicable)

- [ ] `breaking-change` - Breaking change

### Scope Label (select all that apply)

- None applicable.

### Priority Label (for maintainers)

- Maintainer triage.

---

**Additional Context:**

The change is limited to `website/templates/base.html` and preserves the existing `Notes` label and navigation styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
